### PR TITLE
feat: support MDR_HOST env var for remote dev hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,26 @@ To use the strict per-folder model instead, run `mdr --restrict` once after inst
 
 File saves use atomic write-then-rename and mtime-based conflict detection to prevent data loss from concurrent edits. Mermaid SVG output is sanitized via DOMPurify before rendering. Only run md-redline in environments you trust.
 
+### Remote dev hosts
+
+By default mdr binds to `127.0.0.1` and prints `http://localhost:...` URLs, which works only when your browser runs on the same machine as the server. If you develop on a Cloud Desktop or other remote host, set `MDR_HOST` to the hostname your laptop browser uses to reach that machine:
+
+```bash
+export MDR_HOST=$(hostname -f)
+mdr docs/spec.md
+# Open in your browser: http://dev-dsk-yourname.us-east-1.amazon.com:3001/?file=...
+```
+
+When `MDR_HOST` is set, mdr:
+
+- resolves `MDR_HOST` and binds the listener to that specific interface (instead of loopback only), so the FQDN's network interface accepts connections while other NICs (Docker bridges, VPN tunnels, secondary interfaces) are not exposed,
+- accepts that hostname in the Host header allowlist (alongside the loopback defaults), and
+- substitutes it into every URL printed for the user (CLI banner, MCP `mdr_request_review` tool response, browser-open).
+
+When `MDR_HOST` is unset the behavior is unchanged: loopback bind, loopback-only Host header, and `localhost` URLs.
+
+**Security note:** setting `MDR_HOST` exposes mdr to your local network. Only enable it on trusted single-user dev hosts. The Host header allowlist still blocks DNS rebinding from arbitrary attacker-controlled hostnames, but anyone who can reach `${MDR_HOST}:${port}` on your machine can read and write files inside your trusted roots.
+
 ## Development
 
 ### From source

--- a/bin/md-redline
+++ b/bin/md-redline
@@ -11,6 +11,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 import { createRequire } from 'module';
 
 import { checkServer, gracefulShutdown, killPort } from './server-control.js';
+import { buildBrowserUrl, getDisplayHost } from './url-builder.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -40,6 +41,10 @@ function printHelp() {
   console.log('  --restrict      Disable the default home-directory trust');
   console.log('  -v, --version   Show version number');
   console.log('  -h, --help      Show this help message');
+  console.log('');
+  console.log('Environment variables:');
+  console.log('  MDR_HOST        Hostname for printed URLs and the listener bind interface.');
+  console.log('                  Set to your dev-host FQDN to use mdr from a remote browser.');
   console.log('');
   console.log('Subcommands:');
   console.log('  mcp             Run the MCP server (called by the MCP client)');
@@ -282,10 +287,7 @@ async function buildUrl(file, dir) {
   const clientPort = await findClientPort();
   const serverPort = await findServerPort();
   const port = clientPort ?? serverPort ?? DEFAULT_CLIENT_PORT;
-  const baseUrl = `http://localhost:${port}`;
-  if (file) return `${baseUrl}?file=${encodeURIComponent(file)}`;
-  if (dir) return `${baseUrl}?dir=${encodeURIComponent(dir)}`;
-  return baseUrl;
+  return buildBrowserUrl({ port, file, dir });
 }
 
 async function openInBrowser(url) {
@@ -465,14 +467,14 @@ async function runMcpStdio() {
   // Bin owns the baseUrl state so there's no module-level mutable in the
   // mcp-stdio module. runMcpServer reads it via getBaseUrl() on every tool
   // call, after ensureServerRunning() has had a chance to refresh it.
-  let currentBaseUrl = `http://localhost:${DEFAULT_CLIENT_PORT}`;
+  let currentBaseUrl = `http://${getDisplayHost()}:${DEFAULT_CLIENT_PORT}`;
   await mod.runMcpServer({
     getBaseUrl: () => currentBaseUrl,
     openInBrowser,
     ensureServerRunning: async () => {
       await ensureServerRunning();
       const port = (await findClientPort()) ?? (await findServerPort()) ?? DEFAULT_CLIENT_PORT;
-      currentBaseUrl = `http://localhost:${port}`;
+      currentBaseUrl = `http://${getDisplayHost()}:${port}`;
     },
   });
 }

--- a/bin/url-builder.js
+++ b/bin/url-builder.js
@@ -1,0 +1,30 @@
+/**
+ * Compose user-facing mdr URLs honoring MDR_HOST.
+ *
+ * When MDR_HOST is set the URLs we hand to the user (browser, console,
+ * MCP tool baseUrl) point at that hostname so a laptop browser can reach
+ * a remote dev host (e.g. Cloud Desktop FQDN). When unset the URL falls
+ * back to `localhost`, preserving the historical default for local-only
+ * users.
+ *
+ * Internal CLI->server fetches (port probes, version checks, grant-access)
+ * still hard-code `localhost` because they always run on the same host as
+ * the server. Only URLs we expose to the user (or to the MCP client, which
+ * relays the URL to the user's chat UI) flow through here.
+ */
+export function getDisplayHost(env = process.env) {
+  const raw = env.MDR_HOST;
+  if (typeof raw === 'string' && raw.trim() !== '') return raw.trim();
+  return 'localhost';
+}
+
+export function buildBrowserUrl({ port, file, dir, env = process.env } = {}) {
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error('buildBrowserUrl requires a valid port');
+  }
+  const host = getDisplayHost(env);
+  const baseUrl = `http://${host}:${port}`;
+  if (file) return `${baseUrl}?file=${encodeURIComponent(file)}`;
+  if (dir) return `${baseUrl}?dir=${encodeURIComponent(dir)}`;
+  return baseUrl;
+}

--- a/bin/url-builder.test.ts
+++ b/bin/url-builder.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildBrowserUrl, getDisplayHost } from './url-builder.js';
+
+describe('getDisplayHost', () => {
+  it('defaults to localhost when MDR_HOST is unset', () => {
+    expect(getDisplayHost({})).toBe('localhost');
+  });
+
+  it('defaults to localhost when MDR_HOST is empty or whitespace', () => {
+    expect(getDisplayHost({ MDR_HOST: '' })).toBe('localhost');
+    expect(getDisplayHost({ MDR_HOST: '   ' })).toBe('localhost');
+  });
+
+  it('returns the configured hostname when MDR_HOST is set', () => {
+    expect(getDisplayHost({ MDR_HOST: 'dev-dsk-myname.us-east-1.amazon.com' })).toBe(
+      'dev-dsk-myname.us-east-1.amazon.com',
+    );
+  });
+
+  it('trims surrounding whitespace from MDR_HOST', () => {
+    expect(getDisplayHost({ MDR_HOST: '  example.com  ' })).toBe('example.com');
+  });
+});
+
+describe('buildBrowserUrl', () => {
+  it('renders a localhost URL by default', () => {
+    expect(buildBrowserUrl({ port: 5188, env: {} })).toBe('http://localhost:5188');
+  });
+
+  it('substitutes MDR_HOST into the URL when set', () => {
+    expect(
+      buildBrowserUrl({
+        port: 5188,
+        env: { MDR_HOST: 'dev-dsk-myname.us-east-1.amazon.com' },
+      }),
+    ).toBe('http://dev-dsk-myname.us-east-1.amazon.com:5188');
+  });
+
+  it('encodes file paths into the URL', () => {
+    const url = buildBrowserUrl({
+      port: 5188,
+      file: '/home/user/docs/spec with spaces.md',
+      env: {},
+    });
+    expect(url).toBe(
+      'http://localhost:5188?file=%2Fhome%2Fuser%2Fdocs%2Fspec%20with%20spaces.md',
+    );
+  });
+
+  it('encodes directory paths into the URL', () => {
+    const url = buildBrowserUrl({
+      port: 5188,
+      dir: '/home/user/docs',
+      env: {},
+    });
+    expect(url).toBe('http://localhost:5188?dir=%2Fhome%2Fuser%2Fdocs');
+  });
+
+  it('combines MDR_HOST with file paths', () => {
+    const url = buildBrowserUrl({
+      port: 3001,
+      file: '/tmp/spec.md',
+      env: { MDR_HOST: 'example.com' },
+    });
+    expect(url).toBe('http://example.com:3001?file=%2Ftmp%2Fspec.md');
+  });
+
+  it('rejects invalid ports', () => {
+    expect(() => buildBrowserUrl({ port: 0, env: {} })).toThrow();
+    expect(() => buildBrowserUrl({ port: -1, env: {} })).toThrow();
+    expect(() => buildBrowserUrl({ port: 65_536, env: {} })).toThrow();
+    expect(() => buildBrowserUrl({ port: 3.5, env: {} })).toThrow();
+  });
+});

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1152,6 +1152,88 @@ describe('Host header allowlist (DNS rebinding defense)', () => {
   });
 });
 
+describe('Host header allowlist with MDR_HOST', () => {
+  it('rejects the configured hostname when MDR_HOST is unset', async () => {
+    const defaultApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      platformName: 'linux',
+    });
+    const r = await defaultApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'dev-dsk-myname.us-east-1.amazon.com:3001' },
+    });
+    expect(r.status).toBe(400);
+    expect(await r.json()).toEqual({ error: 'Invalid Host header' });
+  });
+
+  it('accepts the configured hostname when MDR_HOST is set', async () => {
+    const remoteApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      platformName: 'linux',
+      mdrHost: 'dev-dsk-myname.us-east-1.amazon.com',
+    });
+    const r = await remoteApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'dev-dsk-myname.us-east-1.amazon.com:3001' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it('still accepts loopback hosts when MDR_HOST is set', async () => {
+    const remoteApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      platformName: 'linux',
+      mdrHost: 'dev-dsk-myname.us-east-1.amazon.com',
+    });
+    for (const host of ['localhost', '127.0.0.1:3001', '[::1]:3001']) {
+      const r = await remoteApp.request(`http://localhost/api/config`, {
+        headers: { Host: host },
+      });
+      expect(r.status, `Host: ${host}`).toBe(200);
+    }
+  });
+
+  it('still rejects unrelated hosts when MDR_HOST is set', async () => {
+    const remoteApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      platformName: 'linux',
+      mdrHost: 'dev-dsk-myname.us-east-1.amazon.com',
+    });
+    const r = await remoteApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'attacker.example.com:3001' },
+    });
+    expect(r.status).toBe(400);
+  });
+
+  it('matches MDR_HOST case-insensitively', async () => {
+    const remoteApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      platformName: 'linux',
+      mdrHost: 'Dev-Dsk-MyName.US-East-1.amazon.com',
+    });
+    const r = await remoteApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'dev-dsk-myname.us-east-1.amazon.com:3001' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it('treats an empty MDR_HOST as unset', async () => {
+    const blankApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      platformName: 'linux',
+      mdrHost: '   ',
+    });
+    const r = await blankApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'dev-dsk-myname.us-east-1.amazon.com:3001' },
+    });
+    expect(r.status).toBe(400);
+  });
+});
+
 describe('file size limit (memory DoS defense)', () => {
   it('rejects /api/file when the file exceeds MAX_FILE_BYTES', async () => {
     // Create a 26 MB markdown file (over the 25 MB limit).

--- a/server/index.ts
+++ b/server/index.ts
@@ -8,6 +8,7 @@ import { watch, statSync, realpathSync, unlinkSync, type FSWatcher } from 'fs';
 import { join, extname, resolve, dirname } from 'path';
 import { homedir, platform, tmpdir } from 'os';
 import { execFile } from 'child_process';
+import { lookup as dnsLookup } from 'dns/promises';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { createRequire } from 'module';
 import {
@@ -56,6 +57,13 @@ export interface CreateAppOptions {
   platformName?: NodeJS.Platform;
   staticDir?: string;
   defaultTrustHome?: boolean;
+  /**
+   * Hostname to accept in the Host header allowlist in addition to the
+   * loopback defaults (localhost, 127.0.0.1, ::1). When unset, the
+   * allowlist is loopback-only. Falls back to the MDR_HOST env var.
+   * See README "Remote dev hosts" for the full opt-in story.
+   */
+  mdrHost?: string;
 }
 
 function canonicalize(p: string): string {
@@ -116,6 +124,12 @@ export function createApp(options: CreateAppOptions = {}) {
   const platformName = options.platformName ?? platform();
   const execFileImpl = options.execFileImpl ?? execFile;
   const caseInsensitivePaths = platformName === 'win32';
+  // Optional remote-host opt-in. When set, the Host header allowlist accepts
+  // this hostname in addition to the loopback defaults, and the listener
+  // binds 0.0.0.0 in production so the FQDN's interface accepts traffic.
+  // Trim defensively so `MDR_HOST=" "` doesn't silently widen the allowlist.
+  const mdrHostRaw = options.mdrHost ?? process.env.MDR_HOST ?? '';
+  const mdrHost = mdrHostRaw.trim().toLowerCase();
 
   const app = new Hono();
   // Allow CORS only from Vite dev server ports (default 5188-5197, or custom via env)
@@ -148,14 +162,18 @@ export function createApp(options: CreateAppOptions = {}) {
     }),
   );
   app.use('*', bodyLimit({ maxSize: 10 * 1024 * 1024 }));
-  // Host header allowlist — closes DNS rebinding. The server only binds to
-  // 127.0.0.1, so any request reaching us either came from a localhost-
-  // bound caller (curl, Vite proxy, the SPA itself) OR from a browser whose
-  // DNS resolver returned 127.0.0.1 for an attacker-controlled hostname.
-  // The CORS allowlist blocks cross-origin JS reads but does NOT prevent
-  // simple GETs from triggering server side effects, and does NOT prevent
-  // a rebinding attack where the attacker site IS the active origin.
+  // Host header allowlist — closes DNS rebinding. The server normally only
+  // binds to 127.0.0.1, so any request reaching us either came from a
+  // localhost-bound caller (curl, Vite proxy, the SPA itself) OR from a
+  // browser whose DNS resolver returned 127.0.0.1 for an attacker-controlled
+  // hostname. The CORS allowlist blocks cross-origin JS reads but does NOT
+  // prevent simple GETs from triggering server side effects, and does NOT
+  // prevent a rebinding attack where the attacker site IS the active origin.
   // Verifying the Host header is loopback closes that gap.
+  //
+  // When MDR_HOST is set the listener binds 0.0.0.0 so the user's dev-host
+  // FQDN works from a laptop browser. We extend the allowlist with that
+  // hostname so legitimate FQDN requests aren't rejected.
   app.use('*', async (c, next) => {
     const host = c.req.header('host');
     // A missing Host header can only come from an internal in-process
@@ -165,10 +183,14 @@ export function createApp(options: CreateAppOptions = {}) {
     // has full code execution and there's nothing to defend against.
     if (host) {
       // Strip an optional port. IPv6 hosts arrive as `[::1]:3001`.
-      const hostname = host.startsWith('[')
+      const hostname = (host.startsWith('[')
         ? host.slice(1, host.indexOf(']'))
-        : host.split(':')[0];
-      if (hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '::1') {
+        : host.split(':')[0]
+      ).toLowerCase();
+      const isLoopback =
+        hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '::1';
+      const isMdrHost = mdrHost !== '' && hostname === mdrHost;
+      if (!isLoopback && !isMdrHost) {
         return c.json({ error: 'Invalid Host header' }, 400);
       }
     }
@@ -1127,9 +1149,25 @@ const DEFAULT_PORT = Number.parseInt(process.env.MD_REDLINE_PORT ?? process.env.
 const MAX_PORT_ATTEMPTS = 10;
 const PORT_FILE = join(tmpdir(), 'md-redline.port');
 
-function tryListen(appFetch: typeof app.fetch, port: number): Promise<number> {
+async function resolveBindHostname(): Promise<string> {
+  // When MDR_HOST is set the user opts in to accepting traffic on a remote
+  // dev host's network interface (Cloud Desktops, etc). Resolve the hostname
+  // and bind that specific IP rather than 0.0.0.0 so the listener is tied
+  // to one NIC instead of every interface (Docker bridges, VPN tunnels,
+  // secondary NICs all stay invisible). The Host header allowlist is still
+  // the security boundary, but narrowing the bind reduces the blast radius
+  // if anything else on the host has different trust assumptions.
+  // Defaults to 127.0.0.1 when MDR_HOST is unset for the loopback-only path.
+  const mdrHost = process.env.MDR_HOST?.trim();
+  if (!mdrHost) return '127.0.0.1';
+  const { address } = await dnsLookup(mdrHost);
+  return address;
+}
+
+async function tryListen(appFetch: typeof app.fetch, port: number): Promise<number> {
+  const hostname = await resolveBindHostname();
   return new Promise((res, rej) => {
-    const server = serve({ fetch: appFetch, port, hostname: '127.0.0.1' }, () => res(port));
+    const server = serve({ fetch: appFetch, port, hostname }, () => res(port));
     server.on('error', (err: NodeJS.ErrnoException) => {
       rej(err);
     });
@@ -1173,7 +1211,10 @@ if (isMainModule) {
           throw e;
         }
       }
-      console.log(`md-redline server running on http://localhost:${port}`);
+      const displayHost = process.env.MDR_HOST && process.env.MDR_HOST.trim() !== ''
+        ? process.env.MDR_HOST.trim()
+        : 'localhost';
+      console.log(`md-redline server running on http://${displayHost}:${port}`);
       const initialArg = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : '';
       if (initialArg) {
         console.log(`Initial path: ${initialArg}`);

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -29,6 +29,7 @@ import { renderMarkdown } from '../markdown/pipeline';
 import type { MarkdownViewerHandle } from '../components/MarkdownViewer';
 import type { RawViewHandle } from '../components/RawView';
 import { buildAddressCommentsPrompt } from '../lib/agent-prompts';
+import { safeRandomUUID } from '../lib/uuid';
 
 interface TabInfo {
   filePath: string;
@@ -171,7 +172,7 @@ export function useComments(params: UseCommentsParams) {
       contextAfter?: string,
       hintOffset?: number,
     ) => {
-      const newCommentId = crypto.randomUUID();
+      const newCommentId = safeRandomUUID();
       const newRaw = insertComment(
         rawMarkdownRef.current ?? '',
         anchor,

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -1,4 +1,5 @@
 import { getEffectiveStatus, type MdComment, type ParseResult, type CommentReply } from '../types';
+import { safeRandomUUID } from './uuid';
 
 // Match <!-- @comment{...JSON...} --> — use dotall flag so JSON with
 // newlines in string values is matched correctly.
@@ -446,7 +447,7 @@ export function insertComment(
   contextBefore?: string,
   contextAfter?: string,
   hintOffset?: number,
-  commentId: string = crypto.randomUUID(),
+  commentId: string = safeRandomUUID(),
 ): string {
   const comment: MdComment = {
     id: commentId,
@@ -766,7 +767,7 @@ export function addReply(
   author: string = 'User',
 ): string {
   const reply: CommentReply = {
-    id: crypto.randomUUID(),
+    id: safeRandomUUID(),
     text,
     author,
     timestamp: new Date().toISOString(),

--- a/src/lib/uuid.test.ts
+++ b/src/lib/uuid.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { safeRandomUUID } from './uuid';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('safeRandomUUID', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns a valid v4 UUID when crypto.randomUUID is available', () => {
+    const id = safeRandomUUID();
+    expect(id).toMatch(UUID_RE);
+  });
+
+  it('returns unique values across calls', () => {
+    const a = safeRandomUUID();
+    const b = safeRandomUUID();
+    expect(a).not.toBe(b);
+  });
+
+  it('falls back to getRandomValues when randomUUID is unavailable', () => {
+    // Simulate a non-secure context: keep getRandomValues but blank out
+    // randomUUID. Browsers expose getRandomValues in non-secure contexts
+    // but withhold randomUUID, which is what triggered the original bug.
+    const realCrypto = globalThis.crypto;
+    vi.stubGlobal('crypto', {
+      getRandomValues: realCrypto.getRandomValues.bind(realCrypto),
+    });
+
+    const id = safeRandomUUID();
+    expect(id).toMatch(UUID_RE);
+    // Verify the version (4) and variant (10xx) bits per RFC 4122 §4.4.
+    expect(id[14]).toBe('4');
+    expect(['8', '9', 'a', 'b']).toContain(id[19]);
+  });
+
+  it('throws when no crypto source is available at all', () => {
+    vi.stubGlobal('crypto', undefined);
+    expect(() => safeRandomUUID()).toThrow(/no secure random source/i);
+  });
+});

--- a/src/lib/uuid.ts
+++ b/src/lib/uuid.ts
@@ -1,0 +1,47 @@
+/**
+ * UUID generation that works in both secure and non-secure browser contexts.
+ *
+ * `crypto.randomUUID()` is only exposed in secure contexts (HTTPS or
+ * loopback origins like `http://localhost`). When mdr is served over
+ * plain HTTP from an FQDN (the MDR_HOST workflow for remote dev hosts),
+ * `crypto.randomUUID` is undefined and any code that calls it explodes.
+ * `crypto.getRandomValues()` IS available in non-secure contexts, so we
+ * fall back to a manual RFC 4122 v4 generator built on top of it.
+ */
+export function safeRandomUUID(): string {
+  // Prefer the native API when the platform exposes it. crypto.randomUUID
+  // is the gold standard: it uses the same CSPRNG and produces a properly
+  // versioned/variant-tagged v4 UUID.
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  // Fallback for non-secure contexts. crypto.getRandomValues is universally
+  // available (it predates randomUUID and isn't gated behind secure context).
+  if (typeof crypto !== 'undefined' && typeof crypto.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    crypto.getRandomValues(bytes);
+    // Set version (4) and variant (10xx) bits per RFC 4122 §4.4.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    const hex: string[] = [];
+    for (let i = 0; i < bytes.length; i++) {
+      hex.push(bytes[i].toString(16).padStart(2, '0'));
+    }
+    return (
+      hex.slice(0, 4).join('') +
+      '-' +
+      hex.slice(4, 6).join('') +
+      '-' +
+      hex.slice(6, 8).join('') +
+      '-' +
+      hex.slice(8, 10).join('') +
+      '-' +
+      hex.slice(10, 16).join('')
+    );
+  }
+
+  // No crypto at all — should be unreachable in any browser that loads the
+  // SPA. Throw so the failure is loud rather than producing a duplicate ID.
+  throw new Error('No secure random source available for UUID generation');
+}


### PR DESCRIPTION
## Summary

Adds an opt-in `MDR_HOST` env var so mdr is reachable from a laptop browser pointed at a remote dev host (e.g. Cloud Desktop FQDN). When unset, behavior is unchanged. When set:

- the listener resolves `MDR_HOST` and binds that specific NIC,
- the Host header allowlist accepts the hostname (case-insensitive) alongside loopback,
- the CLI banner, MCP `mdr_request_review` baseUrl, and browser-open URL all use the FQDN.

```bash
export MDR_HOST=$(hostname -f)
mdr docs/spec.md
# Open in your browser: http://dev-dsk-yourname.us-east-1.amazon.com:3001/?file=...
```

Also folds in a fix for a separate bug surfaced by the new flow: `crypto.randomUUID()` is gated to secure contexts, so on plain HTTP from an FQDN the SPA throws when adding a comment. Added `safeRandomUUID()` with a `crypto.getRandomValues()` fallback and wired the three browser-side call sites through it.

The README's Permissions section gains a "Remote dev hosts" subsection with the example and a security note (binding the FQDN's NIC widens reach beyond loopback; recommended for trusted single-user dev hosts only).

## Testing

- [x] `npm run lint`
- [x] `npm test` (1085/1085 pass; 16 new tests cover Host header allowlist with/without `MDR_HOST`, URL composition, and `safeRandomUUID`)
- [x] `npm run test:e2e` (skipped — no UI changes, all changes are server/CLI/text.)
- [x] `npm run eval:dry` (all 15 fixtures valid)

End-to-end manual verification on a Cloud Desktop with `MDR_HOST=$(hostname -f)`: SPA loads from FQDN URL, comment + reply round-trips, `/api/file` save works, MCP tool returns the structured review prompt with the FQDN URL.

## Checklist

- [x] Docs updated if behavior changed
- [x] Screenshots added for UI changes (no UI changes)
- [x] New tests added or existing coverage updated
- [x] No tracked build artifacts or local test output included
