### PR TITLE
fix(windows): stop cmd.exe mangling the browser-launch command line

### DIFF
--- a/bin/md-redline
+++ b/bin/md-redline
@@ -183,13 +183,19 @@ function spawnWindowsBrowser(command, url, { shellCommand = false } = {}) {
           '/d',
           '/s',
           '/c',
-          '"%MDR_INTERNAL_BROWSER_COMMAND%" "%MDR_INTERNAL_BROWSER_URL%"',
+          // Outer quote pair is required: with /s, cmd strips only the first and
+          // last quote of the /c string, leaving `"cmd" "url"` intact. Pair it
+          // with windowsVerbatimArguments so Node does not backslash-escape the
+          // inner quotes (\") — cmd reads those literally and the command name
+          // becomes unrecognized.
+          '""%MDR_INTERNAL_BROWSER_COMMAND%" "%MDR_INTERNAL_BROWSER_URL%""',
         ], {
           cwd: APP_DIR,
           detached: true,
           stdio: 'ignore',
           env,
           windowsHide: true,
+          windowsVerbatimArguments: true,
         })
       : spawn(command, [url], {
           cwd: APP_DIR,
@@ -211,17 +217,21 @@ function openWithWindowsShell(url) {
     // Keep the encoded URL out of cmd.exe's command string. cmd expands the
     // placeholder once and does not recursively expand percent signs in its
     // value, so URL escapes such as %3A and %5C reach the browser intact.
+    // The outer quote pair plus windowsVerbatimArguments keeps cmd's /s quote
+    // stripping and Node's argv escaping from mangling `start "" "url"` (without
+    // them Node emits \" and the browser receives a corrupted \"url\").
     const child = spawn(process.env.ComSpec ?? 'cmd.exe', [
       '/d',
       '/s',
       '/c',
-      'start "" "%MDR_INTERNAL_BROWSER_URL%"',
+      '"start "" "%MDR_INTERNAL_BROWSER_URL%""',
     ], {
       cwd: APP_DIR,
       detached: true,
       stdio: 'ignore',
       env: { ...process.env, MDR_INTERNAL_BROWSER_URL: url },
       windowsHide: true,
+      windowsVerbatimArguments: true,
     });
 
     child.once('error', rejectSpawn);

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -59,6 +59,35 @@ async function requestJson(appInstance: AppInstance, path: string, init?: Reques
   };
 }
 
+// Preference writes (addTrustedRoot, writePreferences) are fire-and-forget:
+// the request returns before the write lands on disk. Polling for the file to
+// exist and satisfy `predicate` replaces fixed sleeps that raced the write on
+// slow CI filesystems (Windows hit ENOENT at a 50ms wait). A concurrent read
+// during a non-atomic write can also surface a truncated file, so JSON.parse
+// failures are tolerated and retried. On timeout it does one final read so the
+// caller's own expect() reports a real diff (or a genuine ENOENT) rather than a
+// bare timeout.
+type PersistedPrefs = { trustedRoots?: string[]; recentFiles?: unknown[]; [key: string]: unknown };
+
+async function waitForPrefs(
+  realHome: string,
+  predicate: (parsed: PersistedPrefs) => unknown = () => true,
+  timeoutMs = 2000,
+): Promise<PersistedPrefs> {
+  const prefsPath = join(realHome, '.md-redline.json');
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const parsed = JSON.parse(await readFile(prefsPath, 'utf-8'));
+      if (predicate(parsed)) return parsed;
+    } catch {
+      /* file absent or mid-write; retry until the deadline */
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+  return JSON.parse(await readFile(prefsPath, 'utf-8'));
+}
+
 beforeAll(async () => {
   cwdRoot = await mkdtemp(join(tmpdir(), 'md-redline-server-cwd-'));
   fakeHome = await mkdtemp(join(tmpdir(), 'md-redline-server-home-'));
@@ -1007,10 +1036,7 @@ describe('/api/pick-file', () => {
     expect(body.path).toBe(externalFile);
 
     // Allow fire-and-forget addTrustedRoot to flush.
-    await new Promise((r) => setTimeout(r, 50));
-
-    const raw = await readFile(join(realHome, '.md-redline.json'), 'utf-8');
-    const parsed = JSON.parse(raw);
+    const parsed = await waitForPrefs(realHome, (p) => p.trustedRoots?.includes(externalDir));
     expect(parsed.trustedRoots).toContain(externalDir);
 
     await rm(realHome, { recursive: true, force: true });
@@ -1109,9 +1135,7 @@ describe('/api/pick-folder', () => {
     expect(response.status).toBe(200);
     expect(body.path).toBe(realPicked);
 
-    await new Promise((r) => setTimeout(r, 50));
-    const raw = await readFile(join(realHome, '.md-redline.json'), 'utf-8');
-    const parsed = JSON.parse(raw);
+    const parsed = await waitForPrefs(realHome, (p) => p.trustedRoots?.includes(realPicked));
     expect(parsed.trustedRoots).toContain(realPicked);
 
     await rm(realHome, { recursive: true, force: true });
@@ -1500,11 +1524,12 @@ describe('persisted trustedRoots hydration', () => {
       platformName: 'linux',
     });
 
-    // Allow fire-and-forget writePreferences to flush.
-    await new Promise((r) => setTimeout(r, 50));
-
-    const raw = await readFile(join(realHome, '.md-redline.json'), 'utf-8');
-    const parsed = JSON.parse(raw);
+    // Allow fire-and-forget writePreferences to flush (poll until the ghost
+    // root has been pruned, otherwise the read can see the pre-written pair).
+    const parsed = await waitForPrefs(
+      realHome,
+      (p) => p.trustedRoots?.length === 1 && p.trustedRoots[0] === externalDir,
+    );
     expect(parsed.trustedRoots).toEqual([externalDir]);
 
     await rm(realHome, { recursive: true, force: true });
@@ -1530,10 +1555,7 @@ describe('persisted trustedRoots hydration', () => {
       platformName: 'linux',
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    const raw = await readFile(join(realHome, '.md-redline.json'), 'utf-8');
-    const parsed = JSON.parse(raw);
+    const parsed = await waitForPrefs(realHome, (p) => p.trustedRoots?.includes(externalDir));
     expect(parsed.trustedRoots).toEqual([externalDir]);
 
     // Construct again with the same home dir — migration should NOT re-run.
@@ -1569,10 +1591,7 @@ describe('persisted trustedRoots hydration', () => {
       defaultTrustHome: true,
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    const raw = await readFile(join(realHome, '.md-redline.json'), 'utf-8');
-    const parsed = JSON.parse(raw);
+    const parsed = await waitForPrefs(realHome, (p) => p.trustedRoots?.includes(realHome));
     expect(parsed.trustedRoots).toEqual([realHome]);
 
     await rm(realHome, { recursive: true, force: true });
@@ -1647,10 +1666,10 @@ describe('persisted trustedRoots hydration', () => {
       defaultTrustHome: true,
     });
 
-    await new Promise((r) => setTimeout(r, 50));
-
-    const raw = await readFile(join(realHome, '.md-redline.json'), 'utf-8');
-    const parsed = JSON.parse(raw);
+    const parsed = await waitForPrefs(
+      realHome,
+      (p) => p.trustedRoots?.includes(realHome) && p.trustedRoots?.includes(externalDir),
+    );
     // Expect both the home dir AND the recent file's parent dir to be present
     expect(parsed.trustedRoots).toContain(realHome);
     expect(parsed.trustedRoots).toContain(externalDir);


### PR DESCRIPTION
## What

Fixes the Windows-only CI failure that surfaced right after 0.7.1 shipped: `bin/open-launch-cli.test.ts` failed on `windows-latest` with "browser stub never ran: the launcher did not survive CLI exit".

## Root cause

The Windows browser launcher spawns `cmd.exe` with `shell: false` and a pre-quoted composite `/c` payload (`"%CMD%" "%URL%"`). On Windows, Node then applies MSVCRT argv-escaping and rewrites the inner quotes as `\"`. cmd.exe reads `\"` literally, so the command name becomes unrecognized and nothing launches. Reproduced on a real Windows host, which prints:

```
'\"C:\Users\...\browser-stub.cmd\"' is not recognized as an internal or external command
```

**Blast radius is wider than the test.** The default path (`openWithWindowsShell`, used whenever there is no `MDR_BROWSER` override, i.e. every normal Windows user) hits the same bug more quietly: it does not crash, it hands the browser a corrupted `\"http://...\"` URL. So 0.7.1 cannot reliably open the browser on Windows at all.

## Fix

In both `spawnWindowsBrowser` and `openWithWindowsShell`:
- `windowsVerbatimArguments: true` so Node stops backslash-escaping the quotes.
- Wrap the `/c` payload in an outer quote pair so cmd's `/s` quote-stripping removes only the outer pair and leaves the inner `"cmd" "url"` intact.

## Verification

Run on an actual Windows host (not just macOS/Linux):
- The previously-failing regression test now passes (123ms vs the old 5s timeout).
- Full unit suite green: **Windows 1425 passed**, **macOS 1428 passed**.
- Lint and build clean.

## Known coverage gap

The default `openWithWindowsShell` path shares the same root fix but has no direct automated test, because `start` is a cmd builtin that cannot be shadowed on PATH and exercising it for real would launch a browser. The existing `MDR_BROWSER` stub test guards the override path (`spawnWindowsBrowser`); the default path was verified manually via a same-shape `.cmd` proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)