### PR TITLE
build(release): gate publish on the commit's CI matrix, drop local e2e rerun

### DIFF
--- a/scripts/ci-status.mjs
+++ b/scripts/ci-status.mjs
@@ -1,0 +1,65 @@
+// scripts/ci-status.mjs
+//
+// Pure decision logic for the release CI gate. Given the check runs GitHub
+// reports for a commit (the shape returned by
+// GET /repos/{owner}/{repo}/commits/{sha}/check-runs), decide whether the
+// commit is safe to release. Kept free of any network/gh calls so it can be
+// unit tested; release.mjs does the gh api call and hands the parsed
+// check_runs array to evaluateCiRuns().
+
+// GitHub check-run conclusions that do not block a release. failure,
+// cancelled, timed_out, action_required and stale all block; a null
+// conclusion only appears while a run is still in flight (caught as pending).
+const PASSING_CONCLUSIONS = new Set(['success', 'neutral', 'skipped']);
+
+/**
+ * @param {Array<{name?: string, status?: string, conclusion?: string|null, app?: {slug?: string}}>} checkRuns
+ * @param {{requiredApp?: string|null}} [options] - Only gate on check runs from
+ *   this GitHub App slug (default 'github-actions'), so unrelated third-party
+ *   checks never block a release. Pass null to consider every check run.
+ * @returns {{ok: boolean, reason: 'green'|'no-runs'|'pending'|'failed', message: string, names?: string[], count?: number}}
+ */
+export function evaluateCiRuns(checkRuns, { requiredApp = 'github-actions' } = {}) {
+  const runs = (checkRuns ?? []).filter(
+    (r) => !requiredApp || r?.app?.slug === requiredApp,
+  );
+
+  if (runs.length === 0) {
+    return {
+      ok: false,
+      reason: 'no-runs',
+      message: requiredApp
+        ? `No ${requiredApp} check runs found for this commit. Push it and let CI run first.`
+        : 'No check runs found for this commit. Push it and let CI run first.',
+    };
+  }
+
+  const pending = runs.filter((r) => r.status !== 'completed');
+  if (pending.length > 0) {
+    const names = pending.map((r) => r.name ?? '(unnamed)');
+    return {
+      ok: false,
+      reason: 'pending',
+      message: `CI is still running: ${names.join(', ')}. Wait for it to finish, then retry.`,
+      names,
+    };
+  }
+
+  const failed = runs.filter((r) => !PASSING_CONCLUSIONS.has(r.conclusion));
+  if (failed.length > 0) {
+    const names = failed.map((r) => `${r.name ?? '(unnamed)'} (${r.conclusion})`);
+    return {
+      ok: false,
+      reason: 'failed',
+      message: `CI is not green: ${names.join(', ')}. Fix it and let CI go green before releasing.`,
+      names,
+    };
+  }
+
+  return {
+    ok: true,
+    reason: 'green',
+    message: `CI is green (${runs.length} check${runs.length === 1 ? '' : 's'} passed).`,
+    count: runs.length,
+  };
+}

--- a/scripts/ci-status.test.ts
+++ b/scripts/ci-status.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - plain .mjs helper without type declarations
+import { evaluateCiRuns } from './ci-status.mjs';
+
+const ga = { slug: 'github-actions' };
+
+function ciRun(name: string, status: string, conclusion: string | null, app = ga) {
+  return { name, status, conclusion, app };
+}
+
+// Mirrors the four jobs md-redline's CI reports per commit.
+const greenMatrix = [
+  ciRun('checks', 'completed', 'success'),
+  ciRun('unit (macos-latest)', 'completed', 'success'),
+  ciRun('unit (ubuntu-latest)', 'completed', 'success'),
+  ciRun('unit (windows-latest)', 'completed', 'success'),
+];
+
+describe('evaluateCiRuns', () => {
+  it('passes when every github-actions check succeeded', () => {
+    const result = evaluateCiRuns(greenMatrix);
+    expect(result.ok).toBe(true);
+    expect(result.reason).toBe('green');
+    expect(result.count).toBe(4);
+  });
+
+  it('blocks when a job failed (the 0.7.1 Windows regression)', () => {
+    const runs = [
+      ciRun('checks', 'completed', 'success'),
+      ciRun('unit (macos-latest)', 'completed', 'success'),
+      ciRun('unit (windows-latest)', 'completed', 'failure'),
+    ];
+    const result = evaluateCiRuns(runs);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('failed');
+    expect(result.message).toContain('unit (windows-latest)');
+  });
+
+  it('blocks while any job is still running (e2e in the checks job)', () => {
+    const runs = [
+      ciRun('checks', 'in_progress', null),
+      ciRun('unit (macos-latest)', 'completed', 'success'),
+      ciRun('unit (windows-latest)', 'completed', 'success'),
+    ];
+    const result = evaluateCiRuns(runs);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('pending');
+    expect(result.message).toContain('checks');
+  });
+
+  it('treats queued/waiting jobs as pending, not green', () => {
+    const runs = [ciRun('unit (windows-latest)', 'queued', null)];
+    const result = evaluateCiRuns(runs);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('pending');
+  });
+
+  it('blocks when the commit has no check runs at all', () => {
+    expect(evaluateCiRuns([]).reason).toBe('no-runs');
+    expect(evaluateCiRuns(undefined).reason).toBe('no-runs');
+  });
+
+  it('blocks when only non-actions checks exist (no CI ran)', () => {
+    const runs = [ciRun('some-bot', 'completed', 'success', { slug: 'third-party-bot' })];
+    const result = evaluateCiRuns(runs);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('no-runs');
+  });
+
+  it('ignores unrelated third-party checks and gates only on github-actions', () => {
+    const runs = [
+      ...greenMatrix,
+      ciRun('coverage-bot', 'completed', 'failure', { slug: 'third-party-bot' }),
+    ];
+    const result = evaluateCiRuns(runs);
+    expect(result.ok).toBe(true);
+  });
+
+  it('accepts neutral and skipped conclusions as passing', () => {
+    const runs = [
+      ciRun('unit (macos-latest)', 'completed', 'skipped'),
+      ciRun('unit (windows-latest)', 'completed', 'neutral'),
+    ];
+    expect(evaluateCiRuns(runs).ok).toBe(true);
+  });
+
+  it('blocks on cancelled and timed_out conclusions', () => {
+    expect(evaluateCiRuns([ciRun('checks', 'completed', 'cancelled')]).reason).toBe('failed');
+    expect(evaluateCiRuns([ciRun('checks', 'completed', 'timed_out')]).reason).toBe('failed');
+  });
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -2,13 +2,18 @@
 // scripts/release.mjs
 //
 // Orchestrates the md-redline release flow:
-// preflight → tests → compute version → generate notes → confirm/edit
-// → bump → publish → push → create release.
+// preflight → local unit tests → verify CI green → compute version
+// → generate notes → confirm/edit → bump → push → publish → create release.
+//
+// The slow end-to-end suite is NOT re-run here. CI already runs unit (on
+// Windows, macOS and Linux) plus e2e on the exact commit being released, so the
+// gate is "is HEAD's CI matrix green?" rather than a slower, mac-only rerun
+// that would still miss the other platforms.
 //
 // Spec: docs/superpowers/specs/2026-04-07-release-notes-review-design.md
 //
-// Dev escape hatch: set RELEASE_SKIP_E2E=1 to skip the slow Playwright
-// suite during local iteration. Real releases never set this.
+// Dev escape hatch: set RELEASE_SKIP_CI_CHECK=1 to bypass the CI gate during
+// local iteration or an offline emergency. Real releases never set this.
 
 import { spawnSync } from 'node:child_process';
 import { readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
@@ -16,6 +21,8 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
+
+import { evaluateCiRuns } from './ci-status.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -114,15 +121,66 @@ function preflight() {
   console.log('  ✓ working tree clean');
 }
 
-function runTests() {
-  console.log('\n→ Running unit tests');
+function runLocalUnitTests() {
+  // Fast local sanity only (build + unit, a few seconds). The full matrix,
+  // including e2e and the Windows/macOS/Linux unit jobs, is enforced against
+  // this exact commit by verifyCiGreen().
+  console.log('\n→ Running unit tests locally (build + unit)');
   run('npm', ['test']);
-  if (process.env.RELEASE_SKIP_E2E === '1') {
-    console.log('  (skipping e2e: RELEASE_SKIP_E2E=1)');
+}
+
+/**
+ * Gate the release on the real CI matrix. Reads the check runs GitHub recorded
+ * for HEAD and refuses to publish unless every GitHub Actions check completed
+ * successfully. This is what catches platform-specific breakage (e.g. a
+ * Windows-only failure) that a local, mac-only test run never would.
+ *
+ * HEAD here is the pre-bump commit CI actually ran on; `npm version` later adds
+ * a commit that only changes the version string, so the tested code is
+ * unchanged.
+ */
+function verifyCiGreen() {
+  if (process.env.RELEASE_SKIP_CI_CHECK === '1') {
+    console.log('\n→ Skipping CI gate (RELEASE_SKIP_CI_CHECK=1)');
+    console.warn(
+      '  ! Publishing without confirming CI passed on this commit. Real releases should not do this.',
+    );
     return;
   }
-  console.log('\n→ Running e2e tests');
-  run('npm', ['run', 'test:e2e']);
+
+  console.log('\n→ Verifying CI is green for HEAD');
+  const sha = run('git', ['rev-parse', 'HEAD'], { capture: true }).trim();
+  const shortSha = sha.slice(0, 7);
+
+  let raw;
+  try {
+    raw = run(
+      'gh',
+      ['api', `repos/{owner}/{repo}/commits/${sha}/check-runs?per_page=100`],
+      { capture: true },
+    );
+  } catch (e) {
+    throw new Error(
+      `Could not query CI status for ${shortSha} via gh: ${e.message}\n` +
+      `If you are genuinely offline, set RELEASE_SKIP_CI_CHECK=1 to bypass (not recommended).`,
+    );
+  }
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch (e) {
+    throw new Error(`Could not parse gh check-runs response for ${shortSha}: ${e.message}`);
+  }
+
+  const result = evaluateCiRuns(data.check_runs);
+  if (!result.ok) {
+    throw new Error(
+      `CI gate failed for ${shortSha}: ${result.message}\n` +
+      `Release only from a commit whose CI matrix is fully green (check the Actions tab or \`gh pr checks\`).`,
+    );
+  }
+  console.log(`  ✓ ${result.message} (${shortSha})`);
 }
 
 function readPackageVersion() {
@@ -343,7 +401,8 @@ async function main() {
   console.log(`md-redline release: ${type}\n`);
 
   preflight();
-  runTests();
+  runLocalUnitTests();
+  verifyCiGreen();
 
   const currentVersion = readPackageVersion();
   const nextVersion = computeNextVersion(type);


### PR DESCRIPTION
## What

`npm run release` re-ran the full Playwright e2e suite locally before publishing. This PR replaces that with a gate on the real CI matrix: the release refuses to publish unless HEAD's GitHub Actions checks all passed (Windows, macOS, Linux).

## Why

The local e2e rerun was redundant with CI *and* pointed the wrong way. It only ran on macOS, so it could never catch a platform-specific break. That's exactly how the Windows browser-launch bug shipped in 0.7.1: local mac tests were green, the release published, and the Windows CI job went red afterward. Gating on the actual multi-OS CI conclusion closes that gap and is faster when releasing from an already-green `main`.

## How

- **`scripts/ci-status.mjs`** — pure `evaluateCiRuns()` decision logic, no network, so it's unit tested. Gates only on `github-actions` check runs (ignores unrelated third-party checks); treats `success`/`neutral`/`skipped` as passing; anything else, or any still-running job, blocks.
- **`scripts/ci-status.test.ts`** — green / failed / pending / no-runs / third-party / neutral-skipped / cancelled-timed_out cases (9 tests).
- **`scripts/release.mjs`** — adds `verifyCiGreen()` (reads `GET /commits/{sha}/check-runs` via `gh`), drops the local e2e step, keeps the fast local unit build as a pre-flight, and swaps the `RELEASE_SKIP_E2E` hatch for `RELEASE_SKIP_CI_CHECK` (offline/emergency only).

New flow: `preflight → local unit → verify CI green → notes → confirm → bump → push → publish → release`.

## Verification

Unit tests + lint + `tsc -b` clean; full suite 1437 passing. Exercised the gate against live GitHub data:

| Commit | Gate result |
|---|---|
| `609833b` (0.7.1 release) | **blocked** — `unit (windows-latest) (failure)` |
| main merge (e2e still running) | **blocked** — pending: `checks` |
| a fully green commit | **allowed** — 4 checks passed |

So this gate would have stopped the exact bad 0.7.1 publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)