### PR TITLE
Post-0.7.2 review fixes: wide-table scroll UX, a11y, test + doc coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -500,6 +500,27 @@ truncating each segment past 28 characters. Each segment is a button that
 jumps to that heading. Hidden in raw view and while the diff overlay is
 showing, and disappears again once scrolled back above the first heading.
 
+### Handoff button
+`src/components/HandOffButton.tsx` (in the panel toolbar) is md-redline's
+"submit review": it copies the agent prompt for the review comments so they
+can be handed back to the agent. Its scope follows the **active tab**, never
+the whole set of open tabs, because reviewers keep unrelated docs from
+different projects open at once and a comment in a background tab must not
+light up or rename the button while you read something else. Nothing is
+stranded: comments live in the file markers and every tab carries its own
+count badge (`tabCommentCounts`), so pending work is surfaced by the tab.
+
+States, driven by the active file's sendable-comment count:
+- **Active tab has no sendable comments**: quiet disabled icon with an
+  explanatory tooltip, even if other tabs do have comments.
+- **Active tab has comments, no other tab does**: labeled CTA; clicking hands
+  off the active file immediately.
+- **Active tab has comments AND other tabs do**: the CTA (count is always the
+  active file) gains a chevron segment that opens a picker. The picker
+  pre-selects the active file only and lists other commented tabs unchecked,
+  so cross-project tabs are opted in per file rather than assumed to belong to
+  this review. The active row is tagged "· this file".
+
 ### Diff overlay
 After a review handoff, a diff overlay shows what changed since the handoff,
 available in both rendered and raw views via the panel toolbar. The handoff

--- a/e2e/table-scroll.spec.ts
+++ b/e2e/table-scroll.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect, type Page } from '@playwright/test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { withMod } from './helpers/shortcuts';
+import { resetTestAppState } from './helpers/test-state';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMP_FIXTURE_DIR = resolve(__dirname, '..', 'node_modules', '.md-redline-e2e');
+let fixtureDir = '';
+let fixturePath = '';
+
+// A table wide enough to overflow the sheet, plus a short prose line so the
+// document isn't table-only (search opens against real content).
+const COLS = 16;
+const WIDE_TABLE_DOC = [
+  '# Wide Table Scroll',
+  '',
+  'This document has a paragraph of prose above a very wide table.',
+  '',
+  '| ' +
+    Array.from({ length: COLS }, (_, i) => `Column heading number ${i + 1}`).join(' | ') +
+    ' |',
+  '| ' + Array.from({ length: COLS }, () => '---').join(' | ') + ' |',
+  '| ' + Array.from({ length: COLS }, (_, i) => `data cell value ${i + 1}`).join(' | ') + ' |',
+  '',
+].join('\n');
+
+test.beforeEach(async ({ page }, testInfo) => {
+  mkdirSync(TEMP_FIXTURE_DIR, { recursive: true });
+  fixtureDir = resolve(
+    TEMP_FIXTURE_DIR,
+    `table-scroll-${process.pid}-${testInfo.retry}-${Date.now()}`,
+  );
+  mkdirSync(fixtureDir, { recursive: true });
+  fixturePath = resolve(fixtureDir, 'wide-table-doc.md');
+  writeFileSync(fixturePath, WIDE_TABLE_DOC);
+  await resetTestAppState(page);
+});
+
+test.afterEach(() => {
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+async function openFixture(page: Page) {
+  await page.goto(`/?file=${fixturePath}`);
+  await expect(page.getByRole('heading', { name: 'Wide Table Scroll' })).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+test.describe('wide-table horizontal scroll', () => {
+  test('an overflowing table viewport is keyboard-focusable and labeled', async ({ page }) => {
+    await openFixture(page);
+    const viewport = page.locator('.table-scroll__viewport').first();
+    // tabindex/aria-label are applied at runtime ONLY when the table overflows.
+    await expect(viewport).toHaveAttribute('tabindex', '0');
+    await expect(viewport).toHaveAttribute('aria-label', 'Scrollable table');
+    // At the left edge, only the end (right) fade cue shows.
+    await expect(page.locator('.table-scroll').first()).toHaveAttribute('data-overflow-end', '');
+  });
+
+  test('preserves horizontal scroll across an unrelated re-render', async ({ page }) => {
+    await openFixture(page);
+    const viewport = page.locator('.table-scroll__viewport').first();
+    // Confirms the table actually overflows before we rely on scrolling it.
+    await expect(viewport).toHaveAttribute('tabindex', '0');
+
+    // Scroll to a fixed mid offset — comfortably within range so a re-render's
+    // layout re-clamp of maxScroll can't move it. This isolates the exact
+    // regression (reset to the left edge) from harmless max re-clamping at the
+    // far right.
+    const target = await viewport.evaluate((el) => {
+      el.scrollLeft = 100;
+      return el.scrollLeft;
+    });
+    expect(target).toBe(100);
+
+    // Trigger a re-render that does NOT change table content or reflow the
+    // prose: open search and type a query with no matches. searchQuery is a
+    // dep of the viewer effect, so this rebuilds the rendered subtree from
+    // innerHTML — the exact path that used to snap the table back to the left.
+    // A no-match query avoids adding highlight <mark>s that would nudge prose
+    // metrics and re-clamp the table's max scroll.
+    await page.keyboard.press(withMod('f'));
+    const searchBar = page.locator('[data-testid="search-bar"]');
+    await expect(searchBar).toBeVisible();
+    await searchBar.getByPlaceholder('Find...').fill('nomatchxyzzy');
+    await expect(searchBar.locator('[data-testid="search-match-count"]')).toContainText(
+      'No results',
+    );
+
+    // The (rebuilt) viewport must still be scrolled to where we left it, not
+    // snapped back to the left edge.
+    await expect.poll(() => viewport.evaluate((el) => el.scrollLeft)).toBeGreaterThan(50);
+    const after = await viewport.evaluate((el) => el.scrollLeft);
+    expect(Math.abs(after - target)).toBeLessThanOrEqual(1);
+  });
+});

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -2,8 +2,49 @@
 
 import { render, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { MarkdownViewer, isInsideSvgTextContent } from './MarkdownViewer';
+import { MarkdownViewer, isInsideSvgTextContent, computeTableOverflow } from './MarkdownViewer';
 import { renderMarkdown } from '../markdown/pipeline';
+
+describe('computeTableOverflow', () => {
+  it('reports no overflow when content fits, with 1px slack for rounding', () => {
+    expect(computeTableOverflow(500, 500, 0)).toEqual({
+      overflowing: false,
+      overflowStart: false,
+      overflowEnd: false,
+    });
+    // max === 1 is within slack (not > 1), so still not overflowing.
+    expect(computeTableOverflow(501, 500, 0)).toEqual({
+      overflowing: false,
+      overflowStart: false,
+      overflowEnd: false,
+    });
+  });
+
+  it('fades only the end edge when scrolled to the far left', () => {
+    // scrollWidth 800, clientWidth 500 → max 300; scrollLeft 0.
+    expect(computeTableOverflow(800, 500, 0)).toEqual({
+      overflowing: true,
+      overflowStart: false,
+      overflowEnd: true,
+    });
+  });
+
+  it('fades only the start edge when scrolled to the far right', () => {
+    expect(computeTableOverflow(800, 500, 300)).toEqual({
+      overflowing: true,
+      overflowStart: true,
+      overflowEnd: false,
+    });
+  });
+
+  it('fades both edges when scrolled to the middle', () => {
+    expect(computeTableOverflow(800, 500, 150)).toEqual({
+      overflowing: true,
+      overflowStart: true,
+      overflowEnd: true,
+    });
+  });
+});
 
 describe('isInsideSvgTextContent', () => {
   const SVG_NS = 'http://www.w3.org/2000/svg';
@@ -134,7 +175,9 @@ describe('MarkdownViewer comment highlights — mermaid-node anchor fallback', (
     );
 
     await waitFor(() => {
-      const htmlMark = container.querySelector('mark.comment-highlight, mark.comment-highlight-sent');
+      const htmlMark = container.querySelector(
+        'mark.comment-highlight, mark.comment-highlight-sent',
+      );
       const svgMark = container.querySelector('.mermaid-comment-highlight');
       expect(htmlMark ?? svgMark).not.toBeNull();
     });
@@ -180,7 +223,9 @@ describe('MarkdownViewer comment highlights — mermaid-node anchor fallback', (
     await waitFor(() => {
       // The mark may land on either an HTML <mark> (foreignObject) or a mermaid SVG
       // text element. Either way, the rendered label text must appear highlighted.
-      const htmlMark = container.querySelector('mark.comment-highlight, mark.comment-highlight-sent');
+      const htmlMark = container.querySelector(
+        'mark.comment-highlight, mark.comment-highlight-sent',
+      );
       const svgMark = container.querySelector('.mermaid-comment-highlight');
       // At least one highlight form must be present.
       expect(htmlMark ?? svgMark).not.toBeNull();

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -2,8 +2,56 @@
 
 import { render, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
-import { MarkdownViewer, isInsideSvgTextContent, computeTableOverflow } from './MarkdownViewer';
+import {
+  MarkdownViewer,
+  isInsideSvgTextContent,
+  computeTableOverflow,
+  matchTableScroll,
+} from './MarkdownViewer';
 import { renderMarkdown } from '../markdown/pipeline';
+
+describe('matchTableScroll', () => {
+  it('restores offsets to the same tables when nothing changed', () => {
+    const prior = [
+      { key: 'a', scrollLeft: 100 },
+      { key: 'b', scrollLeft: 50 },
+    ];
+    expect(matchTableScroll(prior, ['a', 'b'])).toEqual([100, 50]);
+  });
+
+  it('keeps an unchanged table at its offset when a table is inserted before it', () => {
+    // The reviewer's desync scenario: a new table appears at index 0. Positional
+    // restore would misapply 100 to the new table and reset the real one to 0;
+    // identity keying keeps table "a" at 100 and starts the new "c" at 0.
+    const prior = [
+      { key: 'a', scrollLeft: 100 },
+      { key: 'b', scrollLeft: 50 },
+    ];
+    expect(matchTableScroll(prior, ['c', 'a', 'b'])).toEqual([undefined, 100, 50]);
+  });
+
+  it('restores correctly when a table is removed or the tables are reordered', () => {
+    const prior = [
+      { key: 'a', scrollLeft: 100 },
+      { key: 'b', scrollLeft: 50 },
+    ];
+    expect(matchTableScroll(prior, ['b'])).toEqual([50]); // "a" removed
+    expect(matchTableScroll(prior, ['b', 'a'])).toEqual([50, 100]); // reordered
+  });
+
+  it('gives two identical tables their own offsets, in order', () => {
+    const prior = [
+      { key: 'dup', scrollLeft: 10 },
+      { key: 'dup', scrollLeft: 20 },
+    ];
+    expect(matchTableScroll(prior, ['dup', 'dup'])).toEqual([10, 20]);
+    expect(matchTableScroll(prior, ['dup'])).toEqual([10]);
+  });
+
+  it('leaves new tables unrestored when there is no prior capture', () => {
+    expect(matchTableScroll([], ['a', 'b'])).toEqual([undefined, undefined]);
+  });
+});
 
 describe('computeTableOverflow', () => {
   it('reports no overflow when content fits, with 1px slack for rounding', () => {

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -44,6 +44,25 @@ describe('computeTableOverflow', () => {
       overflowEnd: true,
     });
   });
+
+  it('applies the 1px slack to the start/end edges, not just the overflow flag', () => {
+    // max = 800 - 500 = 300. Start fade needs scrollLeft > 1; end fade needs
+    // scrollLeft < max - 1 (299). At the exact 1px boundaries neither edge
+    // fades, so a sub-pixel rest position doesn't flicker a cue.
+    expect(computeTableOverflow(800, 500, 1)).toMatchObject({ overflowStart: false });
+    expect(computeTableOverflow(800, 500, 2)).toMatchObject({ overflowStart: true });
+    expect(computeTableOverflow(800, 500, 299)).toMatchObject({ overflowEnd: false });
+    expect(computeTableOverflow(800, 500, 298)).toMatchObject({ overflowEnd: true });
+  });
+
+  it('never reports overflow when the viewport is wider than its content', () => {
+    // Negative max (clientWidth > scrollWidth) must not spuriously fade.
+    expect(computeTableOverflow(400, 500, 0)).toEqual({
+      overflowing: false,
+      overflowStart: false,
+      overflowEnd: false,
+    });
+  });
 });
 
 describe('isInsideSvgTextContent', () => {

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -196,12 +196,12 @@ export const MarkdownViewer = memo(
       // changes that don't touch table content (search query, active comment,
       // text selection), so without this a reviewer scrolled into a hidden
       // column snaps back to the left the moment they type into search.
-      // Restored per table in the scroll-cue loop below, keyed by source-order
-      // index — stable because the same markdown re-renders the same tables in
-      // the same order.
+      // Captured with a content-identity key (not DOM position) so the restore
+      // below survives edits/agent rewrites that add or reorder tables.
       const priorTableScroll = Array.from(
         container.querySelectorAll<HTMLElement>('.table-scroll__viewport'),
-      ).map((vp) => vp.scrollLeft);
+        (vp) => ({ key: tableScrollKey(vp), scrollLeft: vp.scrollLeft }),
+      );
 
       // Set innerHTML from scratch — guarantees a clean starting state
       // Defense-in-depth: rehype-sanitize is the primary sanitizer, but
@@ -410,16 +410,22 @@ export const MarkdownViewer = memo(
       // Show an edge fade only when a table overflows, and only on the side(s)
       // with more content. This re-runs with the effect (innerHTML is rebuilt
       // each time), so listeners always target live nodes.
+      // Match the captured offsets to the rebuilt tables by identity, then
+      // restore each in the loop below. Runs inside useLayoutEffect (pre-paint),
+      // so there is no scroll-jump flash.
+      const restoredScroll = matchTableScroll(
+        priorTableScroll,
+        Array.from(
+          container.querySelectorAll<HTMLElement>('.table-scroll__viewport'),
+          tableScrollKey,
+        ),
+      );
       const tableCleanups: Array<() => void> = [];
       let tableIndex = 0;
       for (const host of container.querySelectorAll<HTMLElement>('.table-scroll')) {
         const viewport = host.querySelector<HTMLElement>('.table-scroll__viewport');
         if (!viewport) continue;
-        // Restore the horizontal scroll captured before the innerHTML rebuild
-        // (see priorTableScroll above), keyed by source-order index so a
-        // reviewer keeps their place across unrelated re-renders. Runs inside
-        // useLayoutEffect (pre-paint), so there is no scroll-jump flash.
-        const priorScroll = priorTableScroll[tableIndex];
+        const priorScroll = restoredScroll[tableIndex];
         if (priorScroll) viewport.scrollLeft = priorScroll;
         tableIndex += 1;
         const update = () => {
@@ -748,6 +754,41 @@ export function computeTableOverflow(
     overflowStart: overflowing && scrollLeft > 1,
     overflowEnd: overflowing && scrollLeft < max - 1,
   };
+}
+
+/** Stable-ish identity for a wrapped table, used to match its horizontal
+ *  scroll across an innerHTML rebuild by CONTENT rather than DOM position (see
+ *  matchTableScroll). The length prefix cheaply separates two tables that
+ *  share a 200-char prefix. */
+function tableScrollKey(viewport: HTMLElement): string {
+  const text = viewport.querySelector('table')?.textContent ?? '';
+  return `${text.length}:${text.slice(0, 200)}`;
+}
+
+/**
+ * Match the table horizontal-scroll offsets captured before an innerHTML
+ * rebuild to the tables present after it, by identity key rather than DOM
+ * position. `prior` is the pre-rebuild capture and `currentKeys` are the
+ * post-rebuild tables' identity keys, both in document order. Returns, per
+ * current table, the offset to restore (or undefined to leave it at 0).
+ *
+ * Keying by identity (not index) is what keeps a live content edit or agent
+ * rewrite that inserts/removes/reorders tables from applying a stale offset to
+ * the wrong table: an unchanged table keeps its place, a changed or new one
+ * starts at 0. Two identical tables consume offsets in order so each still
+ * restores. Pure and exported for unit tests.
+ */
+export function matchTableScroll(
+  prior: Array<{ key: string; scrollLeft: number }>,
+  currentKeys: string[],
+): Array<number | undefined> {
+  const buckets = new Map<string, number[]>();
+  for (const { key, scrollLeft } of prior) {
+    const bucket = buckets.get(key);
+    if (bucket) bucket.push(scrollLeft);
+    else buckets.set(key, [scrollLeft]);
+  }
+  return currentKeys.map((key) => buckets.get(key)?.shift());
 }
 
 /** Walk up from a text node; return the outermost SVG <text> ancestor, or null

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -191,6 +191,18 @@ export const MarkdownViewer = memo(
       const container = containerRef.current;
       if (!container) return;
 
+      // Capture each wide table's horizontal scroll BEFORE the innerHTML
+      // rebuild below tears the subtree down. This effect re-runs on dep
+      // changes that don't touch table content (search query, active comment,
+      // text selection), so without this a reviewer scrolled into a hidden
+      // column snaps back to the left the moment they type into search.
+      // Restored per table in the scroll-cue loop below, keyed by source-order
+      // index — stable because the same markdown re-renders the same tables in
+      // the same order.
+      const priorTableScroll = Array.from(
+        container.querySelectorAll<HTMLElement>('.table-scroll__viewport'),
+      ).map((vp) => vp.scrollLeft);
+
       // Set innerHTML from scratch — guarantees a clean starting state
       // Defense-in-depth: rehype-sanitize is the primary sanitizer, but
       // DOMPurify provides a second layer in case of a remark/rehype bypass.
@@ -399,9 +411,17 @@ export const MarkdownViewer = memo(
       // with more content. This re-runs with the effect (innerHTML is rebuilt
       // each time), so listeners always target live nodes.
       const tableCleanups: Array<() => void> = [];
+      let tableIndex = 0;
       for (const host of container.querySelectorAll<HTMLElement>('.table-scroll')) {
         const viewport = host.querySelector<HTMLElement>('.table-scroll__viewport');
         if (!viewport) continue;
+        // Restore the horizontal scroll captured before the innerHTML rebuild
+        // (see priorTableScroll above), keyed by source-order index so a
+        // reviewer keeps their place across unrelated re-renders. Runs inside
+        // useLayoutEffect (pre-paint), so there is no scroll-jump flash.
+        const priorScroll = priorTableScroll[tableIndex];
+        if (priorScroll) viewport.scrollLeft = priorScroll;
+        tableIndex += 1;
         const update = () => {
           const { overflowing, overflowStart, overflowEnd } = computeTableOverflow(
             viewport.scrollWidth,

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -1,4 +1,12 @@
-import { memo, useRef, useLayoutEffect, forwardRef, useImperativeHandle, useMemo, useEffect } from 'react';
+import {
+  memo,
+  useRef,
+  useLayoutEffect,
+  forwardRef,
+  useImperativeHandle,
+  useMemo,
+  useEffect,
+} from 'react';
 import type { MdComment } from '../types';
 import { getEffectiveStatus } from '../types';
 import { stripInlineFormatting } from '../lib/comment-parser';
@@ -278,7 +286,9 @@ export const MarkdownViewer = memo(
       } of highlightGroups.values()) {
         const isActive = ids.includes(activeCommentId || '');
         const allSent =
-          sentCommentIds && sentCommentIds.length > 0 && ids.every((id) => sentCommentIds.includes(id));
+          sentCommentIds &&
+          sentCommentIds.length > 0 &&
+          ids.every((id) => sentCommentIds.includes(id));
         wrapText(
           container,
           anchor,
@@ -306,9 +316,7 @@ export const MarkdownViewer = memo(
             // Append (not replace) so two highlight groups on the same
             // <text> element both register their ids — the click handler
             // reads this list to decide which thread to activate.
-            const existing = textEl.dataset.commentIds
-              ? textEl.dataset.commentIds.split(',')
-              : [];
+            const existing = textEl.dataset.commentIds ? textEl.dataset.commentIds.split(',') : [];
             for (const id of ids) {
               if (!existing.includes(id)) existing.push(id);
             }
@@ -339,7 +347,11 @@ export const MarkdownViewer = memo(
       )) {
         const el = mark as HTMLElement;
         const isActive = el.classList.contains('comment-highlight-active');
-        el.classList.remove('comment-highlight', 'comment-highlight-sent', 'comment-highlight-active');
+        el.classList.remove(
+          'comment-highlight',
+          'comment-highlight-sent',
+          'comment-highlight-active',
+        );
         el.classList.add('mermaid-comment-highlight');
         if (isActive) {
           el.classList.add('mermaid-comment-highlight-active');
@@ -391,11 +403,27 @@ export const MarkdownViewer = memo(
         const viewport = host.querySelector<HTMLElement>('.table-scroll__viewport');
         if (!viewport) continue;
         const update = () => {
-          const max = viewport.scrollWidth - viewport.clientWidth;
-          const x = viewport.scrollLeft;
-          const overflowing = max > 1;
-          host.toggleAttribute('data-overflow-start', overflowing && x > 1);
-          host.toggleAttribute('data-overflow-end', overflowing && x < max - 1);
+          const { overflowing, overflowStart, overflowEnd } = computeTableOverflow(
+            viewport.scrollWidth,
+            viewport.clientWidth,
+            viewport.scrollLeft,
+          );
+          host.toggleAttribute('data-overflow-start', overflowStart);
+          host.toggleAttribute('data-overflow-end', overflowEnd);
+          // A scrollable region must be keyboard-reachable (axe:
+          // scrollable-region-focusable) — Chromium/Firefox auto-focus
+          // overflow containers, but Safari doesn't, so a wide table's hidden
+          // content is otherwise unreachable without a mouse. Make the
+          // viewport a labeled tab stop, but ONLY while it actually overflows,
+          // so narrow tables don't become pointless tab stops. Re-runs on
+          // scroll/resize keep this in sync as the window changes.
+          if (overflowing) {
+            viewport.setAttribute('tabindex', '0');
+            viewport.setAttribute('aria-label', 'Scrollable table');
+          } else {
+            viewport.removeAttribute('tabindex');
+            viewport.removeAttribute('aria-label');
+          }
         };
         update();
         viewport.addEventListener('scroll', update, { passive: true });
@@ -677,6 +705,31 @@ function getBlockParent(node: Node): Element | null {
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 
+/**
+ * Pure overflow arithmetic for a horizontally-scrollable table viewport.
+ * Returns whether the content overflows and which edge fade to show. The 1px
+ * slack on every comparison absorbs sub-pixel layout rounding so a table that
+ * fits exactly doesn't flicker a fade cue. Extracted and exported because
+ * jsdom can't measure real layout (scrollWidth/clientWidth are 0), so the DOM
+ * wiring in the effect stays browser-only while this arithmetic stays unit-
+ * testable — see MarkdownViewer.test.tsx.
+ */
+export function computeTableOverflow(
+  scrollWidth: number,
+  clientWidth: number,
+  scrollLeft: number,
+): { overflowing: boolean; overflowStart: boolean; overflowEnd: boolean } {
+  const max = scrollWidth - clientWidth;
+  const overflowing = max > 1;
+  return {
+    overflowing,
+    // Content is hidden to the left (fade the start edge) once scrolled away
+    // from 0; hidden to the right (fade the end edge) until scrolled to max.
+    overflowStart: overflowing && scrollLeft > 1,
+    overflowEnd: overflowing && scrollLeft < max - 1,
+  };
+}
+
 /** Walk up from a text node; return the outermost SVG <text> ancestor, or null
  *  if not inside SVG text content (or if a <foreignObject> switches the context
  *  back to HTML before reaching an SVG text element). Used to redirect wraps
@@ -763,7 +816,10 @@ function pickLiteralOccurrence(
         }
       }
       if (contextAfter) {
-        const after = fullText.slice(occ + needle.length, occ + needle.length + contextAfter.length);
+        const after = fullText.slice(
+          occ + needle.length,
+          occ + needle.length + contextAfter.length,
+        );
         for (let j = 0; j < Math.min(after.length, contextAfter.length); j++) {
           if (after[j] === contextAfter[j]) score++;
           else break;
@@ -784,9 +840,7 @@ function pickLiteralOccurrence(
   const searchWindow = Math.max(20, needle.length);
   const windowed = fullText.indexOf(needle, Math.max(0, hintOffset - searchWindow));
   if (windowed !== -1 && windowed <= hintOffset + 20) return windowed;
-  return occs.reduce((b, idx) =>
-    Math.abs(idx - hintOffset) < Math.abs(b - hintOffset) ? idx : b,
-  );
+  return occs.reduce((b, idx) => (Math.abs(idx - hintOffset) < Math.abs(b - hintOffset) ? idx : b));
 }
 
 /**
@@ -796,9 +850,7 @@ function pickLiteralOccurrence(
 function pickClosestOccurrence(occs: number[], hintOffset?: number): number {
   if (occs.length === 1) return occs[0];
   if (hintOffset == null) return occs[0];
-  return occs.reduce((b, idx) =>
-    Math.abs(idx - hintOffset) < Math.abs(b - hintOffset) ? idx : b,
-  );
+  return occs.reduce((b, idx) => (Math.abs(idx - hintOffset) < Math.abs(b - hintOffset) ? idx : b));
 }
 
 // Mermaid node syntax: an identifier (capital-first is the Mermaid convention)
@@ -812,7 +864,8 @@ function pickClosestOccurrence(occs: number[], hintOffset?: number): number {
 // bracket classes is the textbook ReDoS shape — pathological inputs like
 // `A[xxxxxxxx...]` failing the final bracket would force catastrophic
 // backtracking on every iteration.
-const MERMAID_NODE_PATTERN = /^[A-Za-z][A-Za-z0-9_]*\s*[[{(>]+([^\]})]*[A-Za-z][^\]})]*)[\]})]+\s*$/s;
+const MERMAID_NODE_PATTERN =
+  /^[A-Za-z][A-Za-z0-9_]*\s*[[{(>]+([^\]})]*[A-Za-z][^\]})]*)[\]})]+\s*$/s;
 
 // Hard bound on input length before invoking MERMAID_NODE_PATTERN. Real
 // Mermaid node anchors are short ("E[Clicks Discover Pages]"); anything

--- a/src/components/PanelToolbar.tsx
+++ b/src/components/PanelToolbar.tsx
@@ -306,12 +306,12 @@ export function PanelToolbar({
         </Tooltip>
 
         {/* Handoff (primary CTA — anchors the far right). Always visible
-            when a file is open; disabled until at least one sendable comment
-            exists in ANY open tab (the button owns that logic), so the path
-            to "send this to an agent" is always discoverable and a pending
-            review never looks lost from a comment-free tab. A hairline
-            divider separates it from the utility icons so it reads as the
-            terminal action, not another utility. */}
+            when a file is open; disabled until the ACTIVE tab has a sendable
+            comment (the button owns that logic — scope follows the active tab,
+            not all open tabs), so the path to "send this to an agent" is
+            always discoverable. A hairline divider separates it from the
+            utility icons so it reads as the terminal action, not another
+            utility. */}
         {onCopyAgentPrompt && activeFilePath && (
           <>
             <div className="w-px h-4 bg-border" aria-hidden="true" />

--- a/src/components/Tooltip.test.tsx
+++ b/src/components/Tooltip.test.tsx
@@ -177,4 +177,106 @@ describe('Tooltip', () => {
     // (e.g. via portal) the title is restored.
     expect(btn.getAttribute('title') ?? null).toBe(null);
   });
+
+  // The useLayoutEffect pulls a viewport-edge tooltip's center back so the
+  // whole bubble stays within an 8px margin. jsdom reports 0 for offsetWidth
+  // and getBoundingClientRect, so we stub the trigger rect, the tooltip width,
+  // and window.innerWidth to exercise the clamp math directly.
+  describe('viewport clamping', () => {
+    const MARGIN = 8;
+    let restoreOffsetWidth: (() => void) | null = null;
+    let originalInnerWidth = 0;
+
+    function mockTooltipWidth(width: number) {
+      const proto = HTMLElement.prototype;
+      const original = Object.getOwnPropertyDescriptor(proto, 'offsetWidth');
+      Object.defineProperty(proto, 'offsetWidth', {
+        configurable: true,
+        get(this: HTMLElement) {
+          return this.getAttribute('role') === 'tooltip' ? width : 0;
+        },
+      });
+      restoreOffsetWidth = () => {
+        if (original) Object.defineProperty(proto, 'offsetWidth', original);
+        else delete (proto as unknown as Record<string, unknown>).offsetWidth;
+      };
+    }
+
+    function setInnerWidth(width: number) {
+      Object.defineProperty(window, 'innerWidth', { configurable: true, value: width });
+    }
+
+    beforeEach(() => {
+      originalInnerWidth = window.innerWidth;
+    });
+
+    afterEach(() => {
+      restoreOffsetWidth?.();
+      restoreOffsetWidth = null;
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: originalInnerWidth,
+      });
+    });
+
+    /** Render, stub the trigger rect, reveal the tooltip, return the bubble. */
+    function showTooltipAt(triggerLeft: number, triggerWidth: number): HTMLElement {
+      render(
+        <Tooltip text="a long tooltip label" delay={500}>
+          <button>trigger</button>
+        </Tooltip>,
+      );
+      const btn = screen.getByText('trigger');
+      btn.getBoundingClientRect = () =>
+        ({
+          left: triggerLeft,
+          right: triggerLeft + triggerWidth,
+          width: triggerWidth,
+          top: 100,
+          bottom: 120,
+          height: 20,
+          x: triggerLeft,
+          y: 100,
+          toJSON: () => ({}),
+        }) as DOMRect;
+      hover(btn);
+      act(() => {
+        vi.advanceTimersByTime(500);
+      });
+      return screen.getByRole('tooltip');
+    }
+
+    it('pulls a right-edge tooltip left so its right edge stays within the margin', () => {
+      setInnerWidth(1000);
+      mockTooltipWidth(200); // half = 100
+      // trigger center x = 960; max = 1000 - 8 - 100 = 892 → clamped to 892.
+      const left = parseFloat(showTooltipAt(940, 40).style.left);
+      expect(left).toBe(892);
+      expect(left).toBeLessThan(960); // actually moved
+      expect(left + 100).toBeLessThanOrEqual(1000 - MARGIN); // whole bubble fits
+    });
+
+    it('pushes a left-edge tooltip right so its left edge stays within the margin', () => {
+      setInnerWidth(1000);
+      mockTooltipWidth(200); // half = 100
+      // trigger center x = 0; min = 8 + 100 = 108 → clamped to 108.
+      const left = parseFloat(showTooltipAt(-20, 40).style.left);
+      expect(left).toBe(108);
+      expect(left).toBeGreaterThan(0); // actually moved
+      expect(left - 100).toBeGreaterThanOrEqual(MARGIN);
+    });
+
+    it('leaves a comfortably-centered tooltip unclamped', () => {
+      setInnerWidth(1000);
+      mockTooltipWidth(200);
+      // center x = 420, inside [108, 892] → unchanged.
+      expect(parseFloat(showTooltipAt(400, 40).style.left)).toBe(420);
+    });
+
+    it('leaves a tooltip wider than the viewport centered (clamping is impossible)', () => {
+      setInnerWidth(300);
+      mockTooltipWidth(400); // half = 200 → min 208 > max 92, so no clamp.
+      expect(parseFloat(showTooltipAt(250, 40).style.left)).toBe(270);
+    });
+  });
 });

--- a/src/markdown/pipeline.test.ts
+++ b/src/markdown/pipeline.test.ts
@@ -83,9 +83,7 @@ describe('renderMarkdown', () => {
   it('rewrites a relative image src when filePath is provided', () => {
     const md = '![diagram](./diagram.png)';
     const html = renderMarkdown(md, '/abs/dir/file.md');
-    expect(html).toContain(
-      `src="/api/asset?path=${encodeURIComponent('/abs/dir/diagram.png')}"`,
-    );
+    expect(html).toContain(`src="/api/asset?path=${encodeURIComponent('/abs/dir/diagram.png')}"`);
   });
 
   it('rewrites a relative .md link to a data attribute when filePath is provided', () => {
@@ -112,9 +110,7 @@ describe('renderMarkdown', () => {
   it('still rewrites absolute paths when filePath is omitted', () => {
     const md = '![x](/abs/img.png)';
     const html = renderMarkdown(md);
-    expect(html).toContain(
-      `src="/api/asset?path=${encodeURIComponent('/abs/img.png')}"`,
-    );
+    expect(html).toContain(`src="/api/asset?path=${encodeURIComponent('/abs/img.png')}"`);
   });
 
   it('preserves data: URI images through the sanitizer', () => {
@@ -130,5 +126,38 @@ describe('renderMarkdown', () => {
     expect(html).toContain('href="https://example.com"');
     expect(html).toContain('target="_blank"');
     expect(html).toContain('rel="noopener noreferrer"');
+  });
+});
+
+describe('renderMarkdown table scroll wrapping (rehypeWrapTables)', () => {
+  it('wraps a table in div.table-scroll > div.table-scroll__viewport > table', () => {
+    const md = '| A | B |\n| --- | --- |\n| 1 | 2 |';
+    const html = renderMarkdown(md);
+    expect(html).toContain('<div class="table-scroll"><div class="table-scroll__viewport"><table>');
+    expect(html).toContain('</table></div></div>');
+  });
+
+  it('wraps multiple sibling tables independently, dropping none and nesting none', () => {
+    const md = '| A |\n| --- |\n| 1 |\n\n| B |\n| --- |\n| 2 |';
+    const html = renderMarkdown(md);
+    // Every table is wrapped exactly once (2 viewports for 2 tables).
+    expect((html.match(/table-scroll__viewport/g) ?? []).length).toBe(2);
+    expect((html.match(/<table>/g) ?? []).length).toBe(2);
+    // The SKIP/index+1 visitor must not descend into a wrapper it just
+    // inserted: a nested wrap would splice a second .table-scroll straight
+    // inside a viewport.
+    expect(html).not.toContain('table-scroll__viewport"><div class="table-scroll"');
+  });
+
+  it('wraps a table nested inside a blockquote', () => {
+    const md = '> | A |\n> | --- |\n> | 1 |';
+    const html = renderMarkdown(md);
+    expect(html).toContain('<blockquote>');
+    expect(html).toContain('<div class="table-scroll"><div class="table-scroll__viewport"><table>');
+  });
+
+  it('leaves content without tables unwrapped', () => {
+    const html = renderMarkdown('Just a paragraph, no table.');
+    expect(html).not.toContain('table-scroll');
   });
 });


### PR DESCRIPTION
## Summary

Follow-up fixes from a review pass over everything merged since `0.7.2` (PR #13: base64 data-URI images, wide-table scroll, tooltip clamping, handoff active-tab scoping). Three commits, each a self-contained fix with tests.

**1. Test + a11y + docs coverage for the PR #13 fixes** (`7bde6bb`)
- Unit tests for the tooltip viewport-clamp branch (left/right edge, centered, wider-than-viewport) and the `rehypeWrapTables` transform (single, sibling, blockquote-nested, no-table).
- Extracted `computeTableOverflow` as a pure, unit-tested helper for the overflow-cue arithmetic.
- Made an overflowing table's scroll viewport keyboard-focusable (`tabindex` + `aria-label`), but only while it actually overflows, so Safari users can reach hidden columns (axe: `scrollable-region-focusable`).
- Documented the active-tab handoff button behavior in AGENTS.md.

**2. Preserve wide-table horizontal scroll across re-renders** (`832e543`)
- The viewer's `useLayoutEffect` rebuilds `innerHTML` on unrelated dep changes (search, active comment, text selection). Previously a reviewer scrolled into a hidden column snapped back to the left edge on the next keystroke. Now each table's `scrollLeft` is captured before the rebuild and restored after (pre-paint, no flash).
- New e2e (`e2e/table-scroll.spec.ts`) covers scroll-restore and the focusable/labeled viewport in a real browser. A negative-control run confirmed the test catches the reset-to-zero regression.
- Corrected a stale PanelToolbar comment (handoff gating is active-tab, not any-tab).

**3. Match scroll restore by content identity, not DOM index** (`c013738`)
- Index-based restore desynced when a live content edit or agent rewrite inserts/removes/reorders tables, applying a stale offset to the wrong table. Now keyed by content identity via the pure, tested `matchTableScroll` helper: unchanged tables keep their place, changed or new ones start at 0.

## Testing

- [x] `npm run lint`
- [x] `npm test` (unit: 1457 passed)
- [x] `npm run test:e2e` scoped to `table-scroll.spec.ts` (2 passed)
- [x] `tsc -b` clean, prettier clean on changed files
- [ ] full `npm run test:e2e` suite (relying on CI)

## Checklist

- [x] Docs updated (AGENTS.md handoff button section)
- [x] New tests added (unit + e2e)
- [x] No tracked build artifacts included

## Notes

Security: the base64/data-URI sanitizer change was re-examined each review round and confirmed safe (`protocols.src` only reaches `img[src]`; SVG scripts do not execute via `<img>`; DOMPurify second layer independently restricts `data:` to media tags).

Deferred as low priority: table `aria-label` uniqueness + focus-ring polish; nested raw-HTML table-in-table wrapping; HandOffButton unit tests (currently e2e-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)