### PR TITLE
Rail comment cluster: prev/next nav and bulk actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -371,7 +371,23 @@ densities, switched via the segmented control (`RailDensityControl`,
 `[data-rail-header]`) that renders in the panel toolbar's right group while
 the rail is shown (a header inside the rail occluded the anchored cards), and
 persisted per-user (see below). Each density segment shows a crimson
-focus-visible ring on keyboard focus. Tab badges count ALL open comments including
+focus-visible ring on keyboard focus.
+
+`RailDensityControl` is the whole comment cluster, not just the toggle. Left to
+right: prev/next comment buttons (`[data-rail-prev]`, `[data-rail-next]`, wired
+to the same `handleJumpToPrev` / `handleJumpToNext` as the `P`/`N` shortcuts,
+which their tooltips name; disabled when the file has no comments), the density
+segmented control, the open count, and an overflow kebab
+(`[data-rail-actions]`). The kebab opens a `ContextMenu` with the bulk actions:
+**Resolve all open** (resolve workflow on, open comments exist), **Clear
+resolved** (resolve workflow on, resolved comments exist), and **Delete all
+comments...** (always, behind the same `ConfirmDialog` the list footer uses).
+The kebab is hidden entirely when the file has no comments. These duplicate
+`CommentListSurface`'s footer buttons on purpose: the footer only exists in List
+density and the drawer, so the kebab is the one route that works in Anchored
+density too.
+
+Tab badges count ALL open comments including
 agent-initiated ones (`tabCommentCounts` in App); the handoff button keeps
 the sendable-only map. Inline code in prose renders neutral (`--theme-text`
 on `--theme-bg-inset`), never the crimson accent:
@@ -735,10 +751,18 @@ share a 140ms fade/scale enter motion via the `.overlay-backdrop-enter` and
 tabs (prev/next), view toggles (comments rail, file explorer, outline, raw/rendered, diff,
 inline edit mode),
 file ops (reload, open, mark reviewed), settings, keyboard help, all themes,
-comment bulk ops (resolve all, delete all, hand off to agent), active comment ops
+comment bulk ops (resolve all, clear resolved, delete all, hand off to agent),
+active comment ops
 (resolve, reopen, delete), heading jump, diagram view (open diagram in fullscreen),
 agent asks (jump to next agent question, which shows the pending count and cycles
 through questions on repeat invocations).
+
+The bulk ops mirror the rail kebab's gating: resolve-all and clear-resolved need
+the resolve workflow on plus a non-zero open / resolved count, and delete-all is
+gated on the TOTAL comment count rather than the open count, so it still appears
+for a file whose comments are all resolved. Delete-all opens the same
+`ConfirmDialog` the rail kebab and list footer use (owned by `App`) instead of
+firing immediately.
 
 ### Update notice
 A quiet, persistent pill (`UpdateNotice.tsx`, `data-update-notice`) sits

--- a/e2e/commenting.spec.ts
+++ b/e2e/commenting.spec.ts
@@ -4,6 +4,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { TEST_DOC_BASELINE } from './helpers/fixture-baselines';
 import { resetTestAppState } from './helpers/test-state';
+import { withMod } from './helpers/shortcuts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMP_FIXTURE_DIR = resolve(__dirname, '..', 'node_modules', '.md-redline-e2e');
@@ -261,6 +262,53 @@ test.describe('Comment lifecycle', () => {
     await page.keyboard.press('Escape');
     await expect(page.getByText('This will permanently delete all comments.')).not.toBeVisible();
     await expect(page.getByText('Escape test comment')).toBeVisible();
+  });
+});
+
+test.describe('Bulk actions outside List density', () => {
+  test('the rail kebab deletes every comment while Anchored density is active', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await addComment(page, 'valid credentials', 'Kebab comment A');
+    await addComment(page, 'brute force attacks', 'Kebab comment B');
+
+    // No density switch: the point is that this works from Anchored, where
+    // the List footer's Delete All button doesn't exist.
+    await expect(page.locator('[data-rail-header] button', { hasText: 'Anchored' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+    await page.locator('[data-rail-actions]').click();
+    await page.getByText('Delete all comments…').click();
+    await page.locator('.fixed.inset-0').getByRole('button', { name: 'Delete All' }).click();
+
+    await expect(page.getByText('Kebab comment A')).not.toBeVisible();
+    await expect(page.getByText('Kebab comment B')).not.toBeVisible();
+  });
+
+  test('the rail kebab disappears once there are no comments left', async ({ page }) => {
+    await openFixture(page);
+    await expect(page.locator('[data-rail-actions]')).toHaveCount(0);
+
+    await addComment(page, 'valid credentials', 'Only comment');
+    await expect(page.locator('[data-rail-actions]')).toBeVisible();
+  });
+
+  test('the palette delete-all confirms first, and cancelling keeps the comments', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await addComment(page, 'valid credentials', 'Palette comment');
+
+    await page.keyboard.press(withMod('k'));
+    await page.getByPlaceholder('Type a command...').fill('Delete all');
+    await page.getByText('Delete all comments').click();
+
+    const dialog = page.locator('.fixed.inset-0');
+    await expect(dialog.getByRole('heading', { name: 'Delete all comments' })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByText('Palette comment')).toBeVisible();
   });
 });
 

--- a/e2e/handoff.spec.ts
+++ b/e2e/handoff.spec.ts
@@ -58,10 +58,11 @@ test.describe('Hand-off button', () => {
     const btn = page.getByTestId('handoff-button');
     await expect(btn).toBeEnabled({ timeout: 10_000 });
 
-    // Delete all comments via command palette
+    // Delete all comments via command palette (which confirms first)
     await page.keyboard.press(withMod('k'));
     await page.getByPlaceholder('Type a command...').fill('Delete all');
     await page.getByText('Delete all comments').click();
+    await page.getByRole('button', { name: 'Delete All' }).click();
 
     await expect(btn).toBeVisible();
     await expect(btn).toBeDisabled();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -590,6 +590,15 @@ export default function App() {
     requestCommentFocus,
   });
 
+  // `commentCount` is the OPEN count while the resolve workflow is on, so the
+  // resolved tail is whatever the total has beyond it. With resolve off there
+  // is no resolved state at all.
+  const resolvedCommentCount = settings.enableResolve ? comments.length - commentCount : 0;
+
+  // Bulk delete is unrecoverable, so every entry point (rail kebab, list
+  // footer, command palette) confirms first. This backs the palette's.
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+
   // Review frontier: when the active file's open comments cross to zero, advance
   // the diff reference to the current content so the diff resets for the next
   // round. Gated on the resolve feature so the "resolved" story is always true.
@@ -2077,13 +2086,27 @@ export default function App() {
         onExecute: handleBulkResolve,
       });
     }
-    if (commentCount > 0) {
+    if (settings.enableResolve && resolvedCommentCount > 0) {
+      cmds.push({
+        id: 'delete-resolved',
+        label: 'Clear resolved comments',
+        section: 'Comments',
+        onExecute: handleBulkDeleteResolved,
+      });
+    }
+    // Gated on the total, not the open count: with the resolve workflow on, a
+    // file whose comments are all resolved still has comments to delete.
+    if (comments.length > 0) {
       cmds.push({
         id: 'delete-all',
         label: 'Delete all comments',
         section: 'Comments',
-        onExecute: handleBulkDelete,
+        // Destructive and unrecoverable, so it routes through the same confirm
+        // step as the rail kebab and the list footer rather than firing bare.
+        onExecute: () => setConfirmDeleteAll(true),
       });
+    }
+    if (commentCount > 0) {
       cmds.push({
         id: 'copy-agent-prompt',
         label: 'Hand off to agent (copy instructions)',
@@ -2127,9 +2150,10 @@ export default function App() {
     return cmds;
   }, [
     commentCount,
+    resolvedCommentCount,
     settings.enableResolve,
-    handleBulkDelete,
     handleBulkResolve,
+    handleBulkDeleteResolved,
     handleHandoff,
     activeFilePath,
     activeCommentId,
@@ -2581,6 +2605,14 @@ export default function App() {
                       density={railDensity}
                       onDensityChange={setRailDensity}
                       openCount={commentCount}
+                      resolvedCount={resolvedCommentCount}
+                      totalCount={comments.length}
+                      resolveEnabled={settings.enableResolve}
+                      onJumpPrev={handleJumpToPrev}
+                      onJumpNext={handleJumpToNext}
+                      onBulkResolve={handleBulkResolve}
+                      onBulkDeleteResolved={handleBulkDeleteResolved}
+                      onBulkDelete={handleBulkDelete}
                     />
                   ) : undefined
                 }
@@ -2931,6 +2963,20 @@ export default function App() {
         cancelLabel="Cancel"
         onConfirm={executePendingClose}
         onCancel={() => setPendingClose(null)}
+      />
+
+      {/* Backs the command palette's "Delete all comments". The rail kebab and
+          the list footer own their own copies of this dialog. */}
+      <ConfirmDialog
+        open={confirmDeleteAll}
+        title="Delete all comments"
+        message="This will permanently delete all comments. This cannot be undone."
+        confirmLabel="Delete All"
+        onConfirm={() => {
+          setConfirmDeleteAll(false);
+          handleBulkDelete();
+        }}
+        onCancel={() => setConfirmDeleteAll(false)}
       />
 
       {/* Keyboard shortcuts hint */}

--- a/src/components/CommentsRail.test.tsx
+++ b/src/components/CommentsRail.test.tsx
@@ -104,11 +104,27 @@ afterEach(() => {
 });
 
 describe('RailDensityControl', () => {
+  const renderControl = (overrides: Partial<Parameters<typeof RailDensityControl>[0]> = {}) =>
+    render(
+      <RailDensityControl
+        density="anchored"
+        onDensityChange={vi.fn()}
+        openCount={3}
+        resolvedCount={0}
+        totalCount={3}
+        resolveEnabled
+        onJumpPrev={vi.fn()}
+        onJumpNext={vi.fn()}
+        onBulkResolve={vi.fn()}
+        onBulkDeleteResolved={vi.fn()}
+        onBulkDelete={vi.fn()}
+        {...overrides}
+      />,
+    );
+
   it('renders both density options, the open count, and switches on click', () => {
     const onDensityChange = vi.fn();
-    render(
-      <RailDensityControl density="anchored" onDensityChange={onDensityChange} openCount={3} />,
-    );
+    renderControl({ onDensityChange });
     expect(screen.getByRole('button', { name: 'Anchored' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'List' })).toBeTruthy();
     expect(screen.getByText('3 open')).toBeTruthy();
@@ -117,10 +133,95 @@ describe('RailDensityControl', () => {
   });
 
   it('density buttons carry a visible keyboard focus ring', () => {
-    render(<RailDensityControl density="anchored" onDensityChange={vi.fn()} openCount={2} />);
+    renderControl({ openCount: 2 });
     const anchored = screen.getByRole('button', { name: 'Anchored' });
     expect(anchored.className).toContain('focus-visible:ring-2');
     expect(anchored.className).toContain('focus-visible:ring-inset');
+  });
+
+  it('prev/next buttons jump between comments and disable when there are none', () => {
+    const onJumpPrev = vi.fn();
+    const onJumpNext = vi.fn();
+    const { rerender } = renderControl({ onJumpPrev, onJumpNext });
+    fireEvent.click(screen.getByRole('button', { name: 'Previous comment' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Next comment' }));
+    expect(onJumpPrev).toHaveBeenCalledTimes(1);
+    expect(onJumpNext).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <RailDensityControl
+        density="anchored"
+        onDensityChange={vi.fn()}
+        openCount={0}
+        resolvedCount={0}
+        totalCount={0}
+        resolveEnabled
+        onJumpPrev={onJumpPrev}
+        onJumpNext={onJumpNext}
+        onBulkDelete={vi.fn()}
+      />,
+    );
+    expect(
+      (screen.getByRole('button', { name: 'Next comment' }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it('offers the bulk actions in an overflow menu, gated on the counts', () => {
+    const onBulkResolve = vi.fn();
+    renderControl({ onBulkResolve, resolvedCount: 0 });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment actions' }));
+    expect(screen.getByText('Resolve all open')).toBeTruthy();
+    // No resolved comments yet, so nothing to clear.
+    expect(screen.queryByText('Clear resolved')).toBeNull();
+    fireEvent.click(screen.getByText('Resolve all open'));
+    expect(onBulkResolve).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides resolve-only bulk actions when the resolve workflow is off', () => {
+    renderControl({ resolveEnabled: false, resolvedCount: 0 });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment actions' }));
+    expect(screen.queryByText('Resolve all open')).toBeNull();
+    expect(screen.getByText('Delete all comments…')).toBeTruthy();
+  });
+
+  it('confirms before deleting all comments', () => {
+    const onBulkDelete = vi.fn();
+    renderControl({ onBulkDelete });
+    fireEvent.click(screen.getByRole('button', { name: 'Comment actions' }));
+    fireEvent.click(screen.getByText('Delete all comments…'));
+    expect(onBulkDelete).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete All' }));
+    expect(onBulkDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the overflow menu entirely when there are no comments', () => {
+    renderControl({ openCount: 0, totalCount: 0, resolvedCount: 0 });
+    expect(screen.queryByRole('button', { name: 'Comment actions' })).toBeNull();
+  });
+
+  it('drops an open menu and dialog when the comments disappear underneath them', () => {
+    // A file-watcher reload or an agent rewrite can empty the document with no
+    // click involved, so neither surface gets ContextMenu's outside-mousedown.
+    const { rerender } = renderControl();
+    fireEvent.click(screen.getByRole('button', { name: 'Comment actions' }));
+    fireEvent.click(screen.getByText('Delete all comments…'));
+    expect(screen.getByRole('button', { name: 'Delete All' })).toBeTruthy();
+
+    rerender(
+      <RailDensityControl
+        density="anchored"
+        onDensityChange={vi.fn()}
+        openCount={0}
+        resolvedCount={0}
+        totalCount={0}
+        resolveEnabled
+        onJumpPrev={vi.fn()}
+        onJumpNext={vi.fn()}
+        onBulkDelete={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('Resolve all open')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Delete All' })).toBeNull();
   });
 });
 

--- a/src/components/CommentsRail.tsx
+++ b/src/components/CommentsRail.tsx
@@ -5,6 +5,9 @@ import type { RailDensity } from '../hooks/usePaneLayout';
 import type { SidebarCommentEditorState } from '../lib/comment-editor-state';
 import { GAP, RAIL, PAD_R } from '../lib/page-geometry';
 import { ThreadCard } from './ThreadCard';
+import { ConfirmDialog } from './ConfirmDialog';
+import { ContextMenu, type ContextMenuEntry } from './ContextMenu';
+import { Tooltip } from './Tooltip';
 import {
   CommentListSurface,
   type SidebarContextMenuInfo,
@@ -116,22 +119,108 @@ export function CommentsRail(props: CommentsRailProps) {
   );
 }
 
+const navButtonClass =
+  'p-1 rounded transition-colors text-content-muted enabled:hover:text-content-secondary ' +
+  'enabled:hover:bg-tint disabled:opacity-40 disabled:cursor-default ' +
+  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring';
+
 /**
- * Density toggle + open count for the rail, rendered in the panel toolbar's
- * right group (not inside the rail: a header floating over the anchored
- * cards occluded them).
+ * Comment cluster for the rail, rendered in the panel toolbar's right group
+ * (not inside the rail: a header floating over the anchored cards occluded
+ * them). Holds prev/next navigation, the density toggle, the open count, and
+ * an overflow menu with the bulk actions.
+ *
+ * The bulk actions also live in CommentListSurface's footer, but that footer
+ * only exists in List density and the drawer. Putting them here too is the
+ * one place they are reachable regardless of density.
  */
 export function RailDensityControl({
   density,
   onDensityChange,
   openCount,
+  resolvedCount,
+  totalCount,
+  resolveEnabled,
+  onJumpPrev,
+  onJumpNext,
+  onBulkResolve,
+  onBulkDeleteResolved,
+  onBulkDelete,
 }: {
   density: RailDensity;
   onDensityChange: (d: RailDensity) => void;
   openCount: number;
+  resolvedCount: number;
+  totalCount: number;
+  resolveEnabled: boolean;
+  onJumpPrev: () => void;
+  onJumpNext: () => void;
+  onBulkResolve?: () => void;
+  onBulkDeleteResolved?: () => void;
+  onBulkDelete: () => void;
 }) {
+  const [menuPos, setMenuPos] = useState<{ x: number; y: number } | null>(null);
+  const [confirmDeleteAll, setConfirmDeleteAll] = useState(false);
+
+  // The comments can go away without any click of ours: a file-watcher reload
+  // or an agent rewriting the document both drop the count to zero. The kebab
+  // unmounts with them, but the menu and dialog are fixed-position siblings
+  // that would otherwise keep floating with nothing left to act on (and
+  // ContextMenu only self-closes on an outside mousedown or window blur).
+  useEffect(() => {
+    if (totalCount === 0) {
+      setMenuPos(null);
+      setConfirmDeleteAll(false);
+    }
+  }, [totalCount]);
+
+  const menuItems: ContextMenuEntry[] = [];
+  if (resolveEnabled && openCount > 0 && onBulkResolve) {
+    menuItems.push({ label: 'Resolve all open', onClick: onBulkResolve });
+  }
+  if (resolveEnabled && resolvedCount > 0 && onBulkDeleteResolved) {
+    menuItems.push({ label: 'Clear resolved', onClick: onBulkDeleteResolved });
+  }
+  if (menuItems.length > 0) menuItems.push({ type: 'divider' });
+  menuItems.push({
+    label: 'Delete all comments…',
+    danger: true,
+    onClick: () => setConfirmDeleteAll(true),
+  });
+
   return (
     <div data-rail-header className="flex items-center gap-2 mr-1">
+      <div className="flex items-center">
+        <Tooltip text="Previous comment (P)">
+          <button
+            type="button"
+            data-rail-prev
+            className={navButtonClass}
+            onClick={onJumpPrev}
+            disabled={totalCount === 0}
+            aria-label="Previous comment"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+            </svg>
+          </button>
+        </Tooltip>
+        <Tooltip text="Next comment (N)">
+          <button
+            type="button"
+            data-rail-next
+            className={navButtonClass}
+            onClick={onJumpNext}
+            disabled={totalCount === 0}
+            aria-label="Next comment"
+          >
+            <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
+            </svg>
+          </button>
+        </Tooltip>
+      </div>
+
       <div role="group" aria-label="Comment layout density" className="flex rounded-md border border-border-subtle overflow-hidden">
         {(['anchored', 'list'] as const).map((d) => (
           <button
@@ -151,6 +240,53 @@ export function RailDensityControl({
       <span className="text-[10px] text-content-muted tabular-nums whitespace-nowrap">
         {openCount} open
       </span>
+
+      {/* Overflow menu: hidden with no comments, since every item needs one.
+          The tooltip is suppressed while the menu is open — the pointer is
+          still over the trigger, so it would sit behind the menu it just
+          spawned. */}
+      {totalCount > 0 && (
+        <Tooltip text={menuPos ? null : 'Comment actions'}>
+          <button
+            type="button"
+            data-rail-actions
+            className={navButtonClass}
+            aria-label="Comment actions"
+            aria-haspopup="menu"
+            aria-expanded={menuPos !== null}
+            onClick={(e) => {
+              if (menuPos) {
+                setMenuPos(null);
+                return;
+              }
+              const rect = e.currentTarget.getBoundingClientRect();
+              setMenuPos({ x: rect.right - 180, y: rect.bottom + 4 });
+            }}
+          >
+            <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+              <circle cx="5" cy="12" r="1.75" />
+              <circle cx="12" cy="12" r="1.75" />
+              <circle cx="19" cy="12" r="1.75" />
+            </svg>
+          </button>
+        </Tooltip>
+      )}
+
+      {menuPos && (
+        <ContextMenu items={menuItems} position={menuPos} onClose={() => setMenuPos(null)} />
+      )}
+
+      <ConfirmDialog
+        open={confirmDeleteAll}
+        title="Delete all comments"
+        message="This will permanently delete all comments. This cannot be undone."
+        confirmLabel="Delete All"
+        onConfirm={() => {
+          setConfirmDeleteAll(false);
+          onBulkDelete();
+        }}
+        onCancel={() => setConfirmDeleteAll(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Why

Two gaps in Anchored density, the rail's default:

- **Bulk actions were unreachable.** Resolve all / Clear resolved / Delete all live in `CommentListSurface`'s footer, which only renders in List density and the drawer. From Anchored, the only route was the command palette.
- **Prev/next comment had no button.** `N`/`J` and `P`/`K` worked, but nothing on screen said so.

## What changed

`RailDensityControl` is now the full comment cluster in the toolbar's right group:

```
[˄] [˅]   [Anchored | List]   2 open   [⋯]
```

- **Prev/next buttons** (`[data-rail-prev]`, `[data-rail-next]`) call the same `handleJumpToPrev` / `handleJumpToNext` as the shortcuts, which their tooltips name. Disabled when the file has no comments.
- **Overflow kebab** (`[data-rail-actions]`) opens a `ContextMenu` with **Resolve all open**, **Clear resolved**, and **Delete all comments...**, gated on the same counts as the list footer and behind the same `ConfirmDialog`. Hidden entirely at zero comments.

The list footer stays as-is. The duplication is deliberate: consistent placement beats chrome that appears and disappears with density.

Two palette fixes came out of the same wiring:

- Added a **Clear resolved comments** command, which had no palette entry.
- **Delete all comments** now opens the confirm dialog instead of firing bare, matching the other two entry points.
- It was also gated on `commentCount`, the *open* count when the resolve workflow is on, so it disappeared for a file whose comments were all resolved. Now gated on the total.

## Verification

- `tsc -b` clean, eslint clean over `src` and `e2e`
- 1462 unit tests pass, including 6 new `RailDensityControl` cases
- 64 e2e tests pass across commenting / handoff / command-palette / comment-navigation / margin-notes, including 3 new cases for the kebab and the palette confirm
- Driven manually at 1440px: cluster fits alongside search/copy/handoff, menu positions correctly, next chevron activates and expands the first anchored card

`e2e/handoff.spec.ts` needed a confirm click added, since it drove delete-all through the palette.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CdE4Y5jEmgMviUR6F4Vods