### PR TITLE
Fix explorer reveal, selection copy, and multi-block anchoring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,60 @@ While a template prefill sits untouched in the full comment form, Escape
 clears the prefill and keeps the form open; a second Escape (or an Escape
 after typing) closes the form as usual.
 
+### Copying a document selection
+The rendered view paints the pending selection as `mark.selection-highlight`
+(`MarkdownViewer.tsx`), which replaces the selected text nodes and collapses the
+browser's own range, so a plain Cmd/Ctrl+C would copy nothing. The document-level
+`copy` handler in `App.tsx` restores it:
+
+- `getCopySelectionFallbackText` (`src/lib/copy-selection.ts`) decides whether to
+  override. It stands down outside the rendered view, when a real native selection
+  still exists, and inside editable elements. The one exception is the comment
+  composer: with quick comment on, the textarea takes focus the instant a selection
+  is made, so a collapsed caret there still copies the document selection. Text
+  selected inside the composer keeps the native copy.
+- `buildRangeHtml` (`src/lib/copy-selection-html.ts`) supplies the `text/html`
+  flavor. `resolveSelection` calls it at selection time and stores the result on
+  `SelectionInfo.html`, before the repaint destroys the range, so the rich flavor
+  does not depend on the highlight painting (or painting correctly). It clones the
+  range after widening each boundary through ancestors the selection sits flush
+  against, so a tight `<a>` or heading wrapper is not flattened; the walk only
+  climbs content elements (`CONTENT_WRAPPERS`), never layout wrappers like the doc
+  sheet, whose classes have no business on the clipboard. It then unwraps the app's
+  own highlight marks, strips viewer chrome, and re-wraps the leading run of loose
+  `<li>`s in their list (only the leading run, so a selection that runs out of a
+  list keeps the blocks after it).
+
+  Numbering is per level, not per list-pair. `collectListLevels` walks every
+  list the range's start sits inside, outermost first, pairing each with the
+  item at that list's own level, and each level gets its own `start` via
+  `restoreOrderedStart` (whose offset comes structurally from that item, not
+  from matching item text). Modelling this as a fixed outer/inner pair looks
+  sufficient and is not: nesting is arbitrarily deep, and any list between the
+  two ends up silently renumbered from 1. Separately, `owningList` picks the
+  list whose items are the fragment's *top-level* nodes, which is the one
+  `wrapLooseListItems` may have to rebuild because the list element itself was
+  never inside the range.
+
+  Tables get the mirror-image treatment: `rebuildTableWrapper` restores the
+  `<table>` around rows or cells left at the fragment's top level by a partial
+  selection, since the HTML fragment parser drops stray `<tr>`/`<td>` and
+  foster-parents their text. `unwrapSingleCell` then undoes it for a selection
+  that lives inside one cell, which is a text selection rather than a table
+  one: copying a value out of a config table should paste the value, not a 1x1
+  table.
+
+  Locating a source list's counterpart inside the clone is not derivable by
+  search (nesting, partial ancestors and dropped leading siblings all move it),
+  so `buildRangeHtml` tags the source elements with `CLONE_MARK` for the
+  duration of `cloneContents` and strips the attribute from both the live
+  document (in a `finally`) and the clone before serializing. This is the one
+  place the helper touches the live DOM; it is synchronous, and a test asserts
+  the source document is byte-identical afterwards.
+
+Both flavors go on the clipboard, so pasting into a rich-text editor keeps
+headings, bold, links, tables, and list structure.
+
 ### Comments rail
 The single comment surface for the rendered view: a fixed-width column at the
 right edge of the document page, inside the same width-managed page unit as
@@ -482,6 +536,38 @@ button. To re-anchor: select replacement text in the viewer, then click the
 button. This calls `moveComment` under the hood and restores the comment at the
 new position. When comments first become orphaned, a debounced toast fires after
 500 ms: `"N comment(s) lost their anchor. See "Needs re-anchoring" in Comments."`
+
+Orphan detection is a separate matcher from the viewer's: `detectMissingAnchors`
+(`comment-parser.ts`) searches the markdown **source**, where an anchor captured
+from rendered text meets syntax the reader never sees. `partsAppearContiguously`
+therefore allows structural markdown between anchor words (cell pipes and the
+`|:---|` delimiter row, list bullets, blockquote arrows, heading hashes). It
+tries a whitespace-only gap first, so an anchor whose own words are punctuation
+(a literal `-` between words) is not swallowed by the scaffolding skip. A
+selection crossing a table would otherwise be flagged as an orphan the instant
+it was saved, even though the viewer highlighted it correctly.
+
+#### Anchor matching tiers
+`findMatchRange` (`MarkdownViewer.tsx`) locates an anchor in the concatenated
+visible text nodes, in order:
+
+1. Literal match (hint and context aware).
+2. Flexible-whitespace match on the original text, hint aware via
+   `findFlexibleMatch`. A cross-block anchor carries newlines that the
+   concatenated text nodes do not, so this is tier 1 with the whitespace
+   loosened. The walk stops at the first match past the offset hint (matches
+   come out left to right, so nothing later can be closer) and is capped at
+   `MAX_FLEXIBLE_PROBES`, since this tier now runs for every anchor that misses
+   a literal match rather than once as a last resort.
+3. Stripped-formatting match (`**bold**` → `bold`), literal then flexible.
+4. Mermaid node syntax (`E[label]` → `label`), with its own inner fallbacks.
+
+The whole-text tiers must stay ahead of the stripped one. `stripInlineFormatting`
+reads markdown source syntax, and an anchor captured from rendered text can carry
+something that only looks like syntax: `1. ` opening a heading such as
+`## 1. Current Strategy` parses as an ordered-list marker. Matching the stripped
+variant first either anchors to "Current Strategy" and silently drops the number
+from the highlight, or fails outright and reports the anchor as lost.
 
 #### Agent questions
 When the agent calls `mdr_ask`, the questions render as standard comment cards
@@ -635,7 +721,37 @@ There is no explorer toggle in the toolbar anymore; `Cmd+B` still toggles
 The app logo and the settings gear live only in the sidebar.
 
 ### File explorer
-Sidebar view (`Cmd+B`) for browsing and opening markdown files.
+Sidebar view (`Cmd+B`) for browsing and opening markdown files. The panel sizes
+itself `flex-1 min-h-0` so a long listing scrolls inside the panel instead of
+pushing the settings button out of the sidebar's bottom corner.
+
+**Reveal in explorer.** `revealDirInExplorer(dir, filePath?)` in `App.tsx` backs
+both the tab context menu's "Reveal in Explorer Sidebar" and the explorer's
+"Open in Explorer" on a directory. It sets the directory, switches the left
+panel to Explorer, opens it, and bumps `explorerRevealNonce`. The nonce is what
+makes a reveal work when the explorer is already pointed at that directory:
+`FileExplorer` re-browses on nonce change, since the panel tracks its own
+navigation and the stored directory alone would not have changed.
+
+A reveal applies exactly once. The consumed nonce is recorded the moment the
+reveal lands, because `revealPath` stays set afterwards and would otherwise keep
+winning every later scroll-into-view and re-flashing its row whenever the active
+file changed. Consumption is owned by `App` (`explorerRevealConsumedRef`, seeded
+into the panel as `revealConsumedNonce` and reported back via
+`onRevealConsumed`) rather than by the panel: `FileExplorer` unmounts on every
+sidebar toggle, Outline switch and focus-mode entry, so panel-local state would
+resurrect a spent reveal on the next remount. It is a ref, not state, because
+recording a consumption must not re-render — that would scroll the panel a
+second time, away from the row just revealed. A reveal whose target never appears is retired
+when the listing for that file's own directory arrives without it, scoped that
+way so a still-in-flight browse of some other directory cannot retire it early.
+
+The revealed row scrolls into view and, when it is not the active file, flashes
+briefly. The flash timer lives in its own effect keyed on `flashPath` rather
+than in the reveal effect, so an interruption (opening another file mid-flash)
+re-arms the timer instead of tearing it down and leaving the row highlighted for
+good. A row that is both the reveal target and the active file claims both refs,
+so the active-file scroll keeps working after the reveal is spent.
 
 ### Document outline
 Sidebar view (`Cmd+Shift+O`) showing heading structure for quick navigation.
@@ -704,7 +820,13 @@ The Prose typeface, Document width, and Prose size controls are each an accessib
 segmented control (`role="group"` with a label) whose segments show a crimson
 focus-visible ring on keyboard focus.
 
-Note on templates: the default template texts contain no em-dashes; `parseSettings` upgrades persisted copies of the pre-2026-07-10 default texts in place (exact-match only, customized templates untouched).
+Note on templates: the shipped set is `DEFAULT_TEMPLATES` in `src/lib/settings.ts`, ordered so the
+two most-used verdicts (`Agreed`, `Rewrite this`) land in the selection pill's one-tap slots.
+`parseSettings` runs two migrations, both exact-match only so customized templates are never
+touched: pre-2026-07-10 default texts are rewritten in place to drop em-dashes, and a stored list
+that still matches the pre-2026-07-28 default set in full is replaced with the current defaults
+(that revision added `Agreed` and `Why this?`, dropped `Fix formatting`, and folded `Too vague`
+into `Rewrite this`).
 
 ### Themes
 

--- a/e2e/copy-selection.spec.ts
+++ b/e2e/copy-selection.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect, type Page } from '@playwright/test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FORMATTED_DOC_BASELINE } from './helpers/fixture-baselines';
+import { resetTestAppState } from './helpers/test-state';
+
+// The app's document-level `copy` listener (App.tsx handleCopy) writes both
+// clipboard flavors on setData, so a listener registered after it fires can
+// read back exactly what it wrote. Declared globally so TS knows about the
+// bag the page-side listener stashes results in; see armCopyListener below.
+declare global {
+  interface Window {
+    __copied: { plain: string; html: string } | null;
+  }
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMP_FIXTURE_DIR = resolve(__dirname, '..', 'node_modules', '.md-redline-e2e');
+let fixtureDir = '';
+let fixturePath = '';
+
+test.beforeEach(async ({ page }, testInfo) => {
+  mkdirSync(TEMP_FIXTURE_DIR, { recursive: true });
+  fixtureDir = resolve(
+    TEMP_FIXTURE_DIR,
+    `copy-selection-${process.pid}-${testInfo.retry}-${Date.now()}`,
+  );
+  mkdirSync(fixtureDir, { recursive: true });
+  fixturePath = resolve(fixtureDir, 'formatted-doc.md');
+  writeFileSync(fixturePath, FORMATTED_DOC_BASELINE);
+  await resetTestAppState(page);
+});
+
+test.afterEach(async ({ page }) => {
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+  // Quick comment persists to the shared e2e prefs file, and several specs
+  // (review-session, update-notice, the agent-* suites) never reset app state
+  // before running. Leaving it on would silently put them in a mode where any
+  // selection auto-focuses the composer.
+  await page.request.put('/api/preferences', { data: { settings: { quickComment: false } } });
+});
+
+async function openFixture(page: Page) {
+  await page.goto(`/?file=${fixturePath}`);
+  await page.locator('.prose').waitFor({ timeout: 10_000 });
+}
+
+/**
+ * Registers a `copy` listener after the app's own (App.tsx handleCopy) has
+ * had a chance to register. document.addEventListener fires listeners in
+ * registration order, so ours runs second and can read back whatever the app
+ * called clipboardData.setData with. We don't read the OS clipboard here —
+ * that permission is unreliable in CI — we intercept the event itself.
+ */
+async function armCopyListener(page: Page) {
+  await page.evaluate(() => {
+    window.__copied = null;
+    document.addEventListener('copy', (e) => {
+      window.__copied = {
+        plain: e.clipboardData?.getData('text/plain') ?? '',
+        html: e.clipboardData?.getData('text/html') ?? '',
+      };
+    });
+  });
+}
+
+async function readCopied(page: Page) {
+  return page.evaluate(() => window.__copied);
+}
+
+/**
+ * Selects from the top-level heading through the first bold run in the
+ * formatted-doc fixture, spanning a heading and a `<strong>` in one
+ * selection. Built with two element lookups + createRange (not the
+ * single-text-node selectText helper other specs use) because this
+ * selection needs to cross block boundaries. Dispatches a bubbling mouseup
+ * on document, same as useSelection listens for.
+ */
+async function selectHeadingThroughBold(page: Page) {
+  await page.evaluate(() => {
+    const prose = document.querySelector('.prose');
+    if (!prose) throw new Error('.prose container not found');
+    const heading = prose.querySelector('h1');
+    const strong = Array.from(prose.querySelectorAll('strong')).find((el) =>
+      el.textContent?.includes('bold text here'),
+    );
+    if (!heading?.firstChild || !strong?.firstChild) {
+      throw new Error('expected heading/strong text nodes not found');
+    }
+    const range = document.createRange();
+    range.setStart(heading.firstChild, 0);
+    range.setEnd(strong.firstChild, strong.firstChild.textContent?.length ?? 0);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+}
+
+/** PUT the Quick comment setting directly, bypassing the settings UI. */
+async function enableQuickComment(page: Page) {
+  await page.request.put('/api/preferences', {
+    data: { settings: { quickComment: true } },
+  });
+}
+
+test.describe('Copy selection', () => {
+  test('copying a rendered selection writes both text/plain and text/html', async ({ page }) => {
+    await openFixture(page);
+    await armCopyListener(page);
+    await selectHeadingThroughBold(page);
+
+    await page.keyboard.press('ControlOrMeta+c');
+
+    await expect.poll(() => readCopied(page)).not.toBeNull();
+    const copied = (await readCopied(page))!;
+    expect(copied.plain).toContain('Formatted Document');
+    expect(copied.plain).toContain('bold text here');
+    expect(copied.html).toMatch(/<h1[\s>]/);
+    expect(copied.html).toContain('<strong>');
+  });
+
+  test('Quick comment focusing the composer with a collapsed caret still copies the document selection', async ({
+    page,
+  }) => {
+    await enableQuickComment(page);
+    await openFixture(page);
+    await armCopyListener(page);
+    await selectHeadingThroughBold(page);
+
+    // Quick comment locks the selection and moves focus into the composer
+    // textarea the moment a selection is made (CommentForm.tsx). The caret
+    // there is collapsed (no textarea-local selection), which is the
+    // regression case: a naive check of "is focus in an editable element"
+    // would wrongly let native copy win and paste nothing useful.
+    const textarea = page.getByPlaceholder('Add your comment...');
+    await expect(textarea).toBeFocused({ timeout: 5000 });
+
+    await page.keyboard.press('ControlOrMeta+c');
+
+    await expect.poll(() => readCopied(page)).not.toBeNull();
+    const copied = (await readCopied(page))!;
+    expect(copied.plain).toContain('Formatted Document');
+    expect(copied.plain).toContain('bold text here');
+    expect(copied.html).toMatch(/<h1[\s>]/);
+    expect(copied.html).toContain('<strong>');
+  });
+
+  test('selecting text inside the composer textarea leaves native copy alone', async ({ page }) => {
+    await enableQuickComment(page);
+    await openFixture(page);
+    await armCopyListener(page);
+    await selectHeadingThroughBold(page);
+
+    const textarea = page.getByPlaceholder('Add your comment...');
+    await expect(textarea).toBeFocused({ timeout: 5000 });
+    await textarea.fill('a comment worth selecting');
+
+    // Select the composer's own text (not a collapsed caret). The handler
+    // must stand down and let the browser's native copy run.
+    await page.evaluate(() => {
+      const el = document.activeElement as HTMLTextAreaElement;
+      el.setSelectionRange(0, el.value.length);
+    });
+
+    await page.keyboard.press('ControlOrMeta+c');
+
+    await expect.poll(() => readCopied(page)).not.toBeNull();
+    const copied = (await readCopied(page))!;
+    // Both flavors come back empty: our handler never called
+    // clipboardData.setData, so nothing was written by the app for this
+    // listener to read back. An empty string here means "native copy
+    // proceeded", not "copy failed".
+    expect(copied.plain).toBe('');
+    expect(copied.html).toBe('');
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1840,18 +1840,30 @@ export default function App() {
 
   useEffect(() => {
     const handleCopy = (e: ClipboardEvent) => {
+      const active = document.activeElement as HTMLElement | null;
+      const composer =
+        active instanceof HTMLTextAreaElement && active.closest('[data-comment-form]') !== null
+          ? active
+          : null;
       const fallbackText = getCopySelectionFallbackText({
         nativeSelectionText: window.getSelection()?.toString() ?? '',
         viewerSelectionText: selectionRef.current?.text ?? null,
-        activeElement: document.activeElement as HTMLElement | null,
+        activeElement: active,
         viewMode,
+        inCommentComposer: composer !== null,
+        composerCaretCollapsed:
+          composer !== null && composer.selectionStart === composer.selectionEnd,
       });
       if (!fallbackText || !e.clipboardData) return;
 
       // The viewer paints its own selection highlight, which clears the native
-      // browser selection range. Restore expected copy behavior from app state.
+      // browser selection range. Restore expected copy behavior from app state,
+      // including the rich-text flavor snapshotted at selection time so
+      // formatting survives a paste into a rich-text editor.
       e.preventDefault();
       e.clipboardData.setData('text/plain', fallbackText);
+      const html = selectionRef.current?.html;
+      if (html) e.clipboardData.setData('text/html', html);
     };
 
     document.addEventListener('copy', handleCopy);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -77,6 +77,7 @@ import { useComments } from './hooks/useComments';
 import { useHeadingTracking } from './hooks/useHeadingTracking';
 import { useContextMenuItems } from './hooks/useContextMenuItems';
 import { getCopySelectionFallbackText } from './lib/copy-selection';
+import { getParentDir } from './lib/path-utils';
 import { useReviewSession, findActiveSessionForFile } from './hooks/useReviewSession';
 import { ReviewBanner } from './components/ReviewBanner';
 import { stripReviewParamFromUrl } from './lib/review-url';
@@ -224,8 +225,7 @@ export default function App() {
         if (overrideDir) {
           hint = overrideDir;
         } else if (activeFilePath) {
-          const lastSlash = activeFilePath.lastIndexOf('/');
-          hint = lastSlash > 0 ? activeFilePath.slice(0, lastSlash) : null;
+          hint = getParentDir(activeFilePath) || null;
         }
         const url = hint
           ? `/api/pick-folder?defaultPath=${encodeURIComponent(hint)}`
@@ -248,6 +248,16 @@ export default function App() {
   );
 
   const [explorerDir, setExplorerDir] = useState<string | undefined>(undefined);
+  // Bumped on every explicit reveal so the explorer re-browses even when the
+  // requested directory equals the last one we asked for (the user may have
+  // navigated elsewhere inside the panel since).
+  const [explorerRevealNonce, setExplorerRevealNonce] = useState(0);
+  const [explorerRevealPath, setExplorerRevealPath] = useState<string | undefined>(undefined);
+  // Which reveal the explorer has already applied. A ref rather than state: the
+  // panel unmounts on every sidebar toggle, Outline switch and focus-mode
+  // entry, so this has to outlive it, and recording a consumption must not
+  // re-render (that would scroll the panel a second time).
+  const explorerRevealConsumedRef = useRef<number | null>(null);
   const [homeDir, setHomeDir] = useState<string>('');
   const { recentFiles, addRecentFile, clearRecentFiles } = useRecentFiles();
   const { author, setAuthor } = useAuthor();
@@ -300,6 +310,22 @@ export default function App() {
       setExplorerVisible(visible);
     },
     [focusMode, exitFocusMode, setExplorerVisible],
+  );
+
+  const handleExplorerRevealConsumed = useCallback((nonce: number) => {
+    explorerRevealConsumedRef.current = nonce;
+  }, []);
+
+  /** Show a directory in the explorer panel, opening and switching to it. */
+  const revealDirInExplorer = useCallback(
+    (dir: string, filePath?: string) => {
+      setExplorerDir(dir);
+      setExplorerRevealPath(filePath);
+      setExplorerRevealNonce((n) => n + 1);
+      setLeftPanelView('explorer');
+      setExplorerVisibleGuarded(true);
+    },
+    [setLeftPanelView, setExplorerVisibleGuarded],
   );
 
   const setSidebarVisibleGuarded = useCallback(
@@ -1447,10 +1473,8 @@ export default function App() {
         }
         const firstFile = session.filePaths[0];
         if (firstFile) {
-          const lastSlash = firstFile.lastIndexOf('/');
-          if (lastSlash > 0) {
-            setExplorerDir(firstFile.slice(0, lastSlash));
-          }
+          const parent = getParentDir(firstFile);
+          if (parent) setExplorerDir(parent);
         }
       } catch {
         /* ignore */
@@ -1475,10 +1499,8 @@ export default function App() {
       addRecentFile(urlFile);
       // Also point the explorer at the file's parent dir so the user can
       // browse siblings, rather than falling back to the server's cwd.
-      const lastSlash = urlFile.lastIndexOf('/');
-      if (lastSlash > 0) {
-        setExplorerDir(urlFile.slice(0, lastSlash));
-      }
+      const parent = getParentDir(urlFile);
+      if (parent) setExplorerDir(parent);
       window.history.replaceState({}, '', window.location.pathname);
       return;
     }
@@ -1500,10 +1522,8 @@ export default function App() {
           openTab(data.initialFile);
           // Same as the urlFile path: point the explorer at the file's
           // parent dir so siblings are browsable.
-          const lastSlash = data.initialFile.lastIndexOf('/');
-          if (lastSlash > 0) {
-            setExplorerDir(data.initialFile.slice(0, lastSlash));
-          }
+          const parent = getParentDir(data.initialFile);
+          if (parent) setExplorerDir(parent);
         }
         if (data.initialDir) {
           setExplorerDir(data.initialDir);
@@ -1592,8 +1612,7 @@ export default function App() {
     addRecentFile,
     revealInFinder,
     revealLabel,
-    setExplorerDir,
-    setExplorerVisible: setExplorerVisibleGuarded,
+    revealDirInExplorer,
     tabs,
     closeTab,
     closeOtherTabs,
@@ -2223,10 +2242,7 @@ export default function App() {
   // file. Computed here so the Toolbar can render the path in its prompt.
   const accessDeniedDir =
     errorKind === 'access-denied' && activeFilePath
-      ? (() => {
-          const lastSlash = activeFilePath.lastIndexOf('/');
-          return lastSlash > 0 ? activeFilePath.slice(0, lastSlash) : null;
-        })()
+      ? getParentDir(activeFilePath) || null
       : null;
 
   // Optimistic sent IDs: updated immediately when a batch is sent, before
@@ -2370,6 +2386,10 @@ export default function App() {
               {leftPanelView === 'explorer' ? (
                 <FileExplorer
                   initialDir={explorerDir}
+                  revealNonce={explorerRevealNonce}
+                  revealPath={explorerRevealPath}
+                  revealConsumedNonce={explorerRevealConsumedRef.current}
+                  onRevealConsumed={handleExplorerRevealConsumed}
                   activeFilePath={activeFilePath}
                   homeDir={homeDir}
                   onOpenFile={handleExplorerOpenFile}

--- a/src/components/FileExplorer.test.tsx
+++ b/src/components/FileExplorer.test.tsx
@@ -1,0 +1,410 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, act, waitFor } from '@testing-library/react';
+import { FileExplorer } from './FileExplorer';
+
+interface BrowseResult {
+  dir: string;
+  parent: string | null;
+  directories: { name: string; path: string }[];
+  files: { name: string; path: string }[];
+}
+
+function browseResult(overrides: Partial<BrowseResult> = {}): BrowseResult {
+  return {
+    dir: '/docs',
+    parent: '/',
+    directories: [],
+    files: [
+      { name: 'a.md', path: '/docs/a.md' },
+      { name: 'b.md', path: '/docs/b.md' },
+      { name: 'c.md', path: '/docs/c.md' },
+    ],
+    ...overrides,
+  };
+}
+
+function mockFetchResolving(result: BrowseResult) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    text: () => Promise.resolve(JSON.stringify(result)),
+  });
+}
+
+// RTL's findBy*/waitFor poll via setTimeout, which fake timers freeze. Under
+// fake timers, flush the microtask queue by hand instead so the component's
+// fetch -> readJsonResponse -> setData chain settles before we assert.
+async function flushMicrotasks() {
+  await act(async () => {
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+// The inactive rows carry `hover:bg-tint`, so a plain substring check for
+// "bg-tint" would false-positive on every non-flashed row. Check for the
+// bare class token the flash applies instead.
+function hasClass(el: Element, cls: string): boolean {
+  return el.className.split(/\s+/).includes(cls);
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', mockFetchResolving(browseResult()));
+  // jsdom does not implement scrollIntoView; the component calls it
+  // unconditionally on every reveal/active-file effect run.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  // @ts-expect-error - test-only cleanup of the jsdom stub
+  delete Element.prototype.scrollIntoView;
+});
+
+describe('FileExplorer: revealNonce forces a re-browse', () => {
+  it('re-browses the same initialDir when revealNonce changes', async () => {
+    const { rerender } = render(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={0}
+        activeFilePath={null}
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await screen.findByText('a.md');
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        activeFilePath={null}
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledTimes(2));
+    const lastCall = (globalThis.fetch as unknown as ReturnType<typeof vi.fn>).mock.calls.at(-1);
+    expect(String(lastCall?.[0])).toContain(encodeURIComponent('/docs'));
+  });
+});
+
+describe('FileExplorer: reveal flash', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('flashes a revealed file that is not the active file, then clears the flash', async () => {
+    render(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/b.md"
+        activeFilePath="/docs/a.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await flushMicrotasks();
+
+    const bButton = screen.getByTitle('/docs/b.md');
+    expect(hasClass(bButton, 'bg-tint')).toBe(true);
+    expect(hasClass(bButton, 'font-medium')).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+
+    expect(hasClass(bButton, 'bg-tint')).toBe(false);
+  });
+});
+
+describe('FileExplorer: reveal edge cases', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('scrolls without flashing when the revealed file is already the active one', async () => {
+    render(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/b.md"
+        activeFilePath="/docs/b.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+    expect(hasClass(screen.getByTitle('/docs/b.md'), 'bg-tint')).toBe(false);
+  });
+
+  it('keeps scrolling to the active file after revealing that same file', async () => {
+    // The revealed row is also the active row here. If it claimed only the
+    // reveal ref, the active ref would stay null and later listings would
+    // scroll to nothing at all.
+    const scrollIntoView = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>;
+    const { rerender } = render(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/b.md"
+        activeFilePath="/docs/b.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+    scrollIntoView.mockClear();
+
+    // Navigate away and back: a fresh listing with the reveal already spent.
+    rerender(
+      <FileExplorer
+        initialDir="/other"
+        revealNonce={1}
+        revealPath="/docs/b.md"
+        activeFilePath="/docs/b.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+
+    expect(scrollIntoView).toHaveBeenCalled();
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(screen.getByTitle('/docs/b.md'));
+  });
+
+  it('does not re-fire a spent reveal when the panel remounts', async () => {
+    // The panel unmounts on a sidebar toggle, an Outline switch, or entering
+    // focus mode. Consumption is owned by the caller so it survives that.
+    let consumed: number | null = null;
+    const props = {
+      initialDir: '/docs',
+      revealNonce: 1,
+      revealPath: '/docs/b.md',
+      activeFilePath: '/docs/a.md',
+      onOpenFile: vi.fn(),
+      onClose: vi.fn(),
+      onRevealConsumed: (nonce: number) => {
+        consumed = nonce;
+      },
+    };
+
+    const first = render(<FileExplorer {...props} revealConsumedNonce={consumed} />);
+    await flushMicrotasks();
+    expect(hasClass(screen.getByTitle('/docs/b.md'), 'bg-tint')).toBe(true);
+    expect(consumed).toBe(1);
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+    first.unmount();
+
+    render(<FileExplorer {...props} revealConsumedNonce={consumed} />);
+    await flushMicrotasks();
+    expect(hasClass(screen.getByTitle('/docs/b.md'), 'bg-tint')).toBe(false);
+  });
+
+  it('reveals a file that only exists in the refreshed listing', async () => {
+    // Revealing into the directory already on screen runs the effect against
+    // the stale listing first. Retiring there would drop the reveal of a file
+    // the forced refresh is about to add.
+    let call = 0;
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockImplementation(() => {
+        call += 1;
+        const body =
+          call === 1
+            ? browseResult({ files: [{ name: 'a.md', path: '/docs/a.md' }] })
+            : browseResult({
+                files: [
+                  { name: 'a.md', path: '/docs/a.md' },
+                  { name: 'new.md', path: '/docs/new.md' },
+                ],
+              });
+        return Promise.resolve({ ok: true, text: () => Promise.resolve(JSON.stringify(body)) });
+      }),
+    );
+
+    const props = {
+      initialDir: '/docs',
+      activeFilePath: '/docs/a.md',
+      onOpenFile: vi.fn(),
+      onClose: vi.fn(),
+    };
+    const { rerender } = render(<FileExplorer {...props} revealNonce={0} />);
+    await flushMicrotasks();
+    expect(screen.queryByTitle('/docs/new.md')).toBeNull();
+
+    rerender(<FileExplorer {...props} revealNonce={1} revealPath="/docs/new.md" />);
+    await flushMicrotasks();
+
+    const row = screen.getByTitle('/docs/new.md');
+    expect(hasClass(row, 'bg-tint')).toBe(true);
+  });
+
+  it('retires a reveal whose target is missing from its own directory listing', async () => {
+    const { rerender } = render(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/gone.md"
+        activeFilePath="/docs/a.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+    expect(screen.queryByTitle('/docs/gone.md')).toBeNull();
+
+    // The file reappears in a later listing under the SAME nonce. The reveal
+    // was already spent, so it must not scroll to or flash the row now.
+    vi.stubGlobal(
+      'fetch',
+      mockFetchResolving(
+        browseResult({
+          files: [
+            { name: 'a.md', path: '/docs/a.md' },
+            { name: 'gone.md', path: '/docs/gone.md' },
+          ],
+        }),
+      ),
+    );
+    rerender(
+      <FileExplorer
+        initialDir="/docs2"
+        revealNonce={1}
+        revealPath="/docs/gone.md"
+        activeFilePath="/docs/a.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+
+    const revived = screen.queryByTitle('/docs/gone.md');
+    expect(revived).not.toBeNull();
+    expect(hasClass(revived!, 'bg-tint')).toBe(false);
+  });
+});
+
+describe('FileExplorer: stale reveal does not hijack later activity (regression)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears the flash when another file opens before the timer expires', async () => {
+    // The flash timer used to live in the reveal effect, whose cleanup ran on
+    // any dep change while the effect body then short-circuited on the already
+    // consumed nonce — leaving the row highlighted for good.
+    const { rerender } = render(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/a.md"
+        activeFilePath="/docs/b.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+    expect(hasClass(screen.getByTitle('/docs/a.md'), 'bg-tint')).toBe(true);
+
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+    });
+    rerender(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/a.md"
+        activeFilePath="/docs/c.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+
+    await act(async () => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(hasClass(screen.getByTitle('/docs/a.md'), 'bg-tint')).toBe(false);
+  });
+
+  it('does not re-flash the previously revealed file when only activeFilePath changes', async () => {
+    const scrollIntoView = Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>;
+
+    const { rerender } = render(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/a.md"
+        activeFilePath="/docs/b.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await flushMicrotasks();
+
+    const aButton = screen.getByTitle('/docs/a.md');
+    expect(hasClass(aButton, 'bg-tint')).toBe(true);
+    expect(scrollIntoView).toHaveBeenCalled();
+    scrollIntoView.mockClear();
+
+    // Let the reveal's own flash timer expire, as it would in real usage
+    // before the user goes on to open another file.
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+    expect(hasClass(aButton, 'bg-tint')).toBe(false);
+
+    rerender(
+      <FileExplorer
+        initialDir="/docs"
+        revealNonce={1}
+        revealPath="/docs/a.md"
+        activeFilePath="/docs/c.md"
+        onOpenFile={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    await flushMicrotasks();
+
+    const cButton = screen.getByTitle('/docs/c.md');
+    expect(hasClass(cButton, 'bg-primary-bg')).toBe(true);
+
+    const aButtonAgain = screen.getByTitle('/docs/a.md');
+    expect(hasClass(aButtonAgain, 'bg-tint')).toBe(false);
+
+    // Give any (incorrectly) re-armed flash timer a chance to fire, then
+    // re-check: the stale reveal must not have re-triggered a flash at all.
+    await act(async () => {
+      vi.advanceTimersByTime(1600);
+    });
+    expect(hasClass(screen.getByTitle('/docs/a.md'), 'bg-tint')).toBe(false);
+
+    expect(scrollIntoView).toHaveBeenCalled();
+    // scrollIntoView is a method call on the element itself (`this`), not an arg.
+    expect(scrollIntoView.mock.instances.at(-1)).toBe(cButton);
+  });
+});

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -91,7 +91,7 @@ export function FileExplorer({
   const dirName = getPathBasename(data?.dir || '') || data?.dir || 'Files';
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex-1 min-h-0 flex flex-col">
       {/* Header */}
       {!hideHeader && (
         <div className="h-10 border-b border-border flex items-center justify-between pl-1 pr-2 shrink-0">

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getApiErrorMessage, readJsonResponse, type ApiErrorPayload } from '../lib/http';
-import { getPathBasename, tildeShortenPath } from '../lib/path-utils';
+import { getParentDir, getPathBasename, tildeShortenPath } from '../lib/path-utils';
 
 interface BrowseResult {
   dir: string;
@@ -21,6 +21,23 @@ export interface ExplorerContextMenuInfo {
 
 interface Props {
   initialDir?: string;
+  /**
+   * Bumped by the app on an explicit reveal. Forces a re-browse of `initialDir`
+   * even when it did not change, since the user may have navigated the panel
+   * somewhere else in the meantime.
+   */
+  revealNonce?: number;
+  /** File to scroll to on a reveal; falls back to the active file. */
+  revealPath?: string;
+  /**
+   * Nonce already consumed by an earlier mount. The panel unmounts whenever the
+   * sidebar is toggled, the Outline tab is selected, or focus mode is entered,
+   * so consumption has to be owned above this component or a spent reveal
+   * re-fires on every remount.
+   */
+  revealConsumedNonce?: number | null;
+  /** Reports the nonce this panel just consumed, so it survives the unmount. */
+  onRevealConsumed?: (nonce: number) => void;
   activeFilePath: string | null;
   /** User's home directory; used to tilde-shorten the path in the trust prompt. */
   homeDir?: string;
@@ -33,6 +50,10 @@ interface Props {
 
 export function FileExplorer({
   initialDir,
+  revealNonce = 0,
+  revealPath,
+  revealConsumedNonce = null,
+  onRevealConsumed,
   activeFilePath,
   homeDir = '',
   onOpenFile,
@@ -46,10 +67,23 @@ export function FileExplorer({
   const [error, setError] = useState<string | null>(null);
   const [errorKind, setErrorKind] = useState<'access-denied' | 'generic' | null>(null);
   const [accessDeniedDir, setAccessDeniedDir] = useState<string | null>(null);
+  const [flashPath, setFlashPath] = useState<string | null>(null);
 
   const abortRef = useRef<AbortController | null>(null);
+  const activeFileRef = useRef<HTMLButtonElement | null>(null);
+  const revealFileRef = useRef<HTMLButtonElement | null>(null);
+  // A reveal applies once. The app keeps `revealPath` set after the reveal
+  // lands, so without this the revealed row would keep winning every later
+  // scroll-into-view and re-flash whenever the active file changed. Seeded from
+  // the caller so a remount does not resurrect a spent reveal.
+  const consumedRevealRef = useRef<number | null>(revealConsumedNonce);
+  // Which reveal the listing in `data` was fetched for. A reveal into the
+  // directory already on screen runs the effect below against the stale
+  // listing first, and retiring on that would drop a reveal of a file the
+  // refresh is about to add.
+  const dataRevealNonceRef = useRef<number | null>(null);
 
-  const browse = useCallback(async (dir?: string) => {
+  const browse = useCallback(async (dir?: string, forRevealNonce?: number) => {
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
@@ -66,6 +100,7 @@ export function FileExplorer({
         throw new Error(getApiErrorMessage(res, result, 'Failed to browse'));
       }
       setData(result);
+      dataRevealNonceRef.current = forRevealNonce ?? null;
     } catch (err) {
       if (controller.signal.aborted) return;
       const msg = err instanceof Error ? err.message : 'Failed to browse';
@@ -82,11 +117,56 @@ export function FileExplorer({
   }, []);
 
   useEffect(() => {
-    browse(initialDir);
+    browse(initialDir, revealNonce);
     return () => {
       abortRef.current?.abort();
     };
-  }, [browse, initialDir]);
+  }, [browse, initialDir, revealNonce]);
+
+  // Keep the open file visible when the listing changes or a reveal lands, so
+  // it is not stranded below the fold in a long directory. A revealed file that
+  // is not the active one gets a brief flash so the eye can find it.
+  useEffect(() => {
+    if (!data) return;
+    const revealPending = revealNonce !== consumedRevealRef.current;
+    const revealed = revealPending ? revealFileRef.current : null;
+    const target = revealed ?? activeFileRef.current;
+    target?.scrollIntoView({ block: 'nearest' });
+    if (!revealed) {
+      // The listing for the revealed file's own directory has arrived without
+      // it (deleted, filtered out), so the request is spent. Retiring it here
+      // stops a long-dead reveal from firing if that row ever appears later.
+      // A listing for some other directory means the browse is still in
+      // flight, so the reveal stays pending.
+      // Only retire against the listing this reveal actually fetched: the
+      // effect also runs against whatever was already on screen, which for a
+      // newly created file does not contain it yet.
+      const listingIsForThisReveal = dataRevealNonceRef.current === revealNonce;
+      if (
+        revealPending &&
+        revealPath &&
+        listingIsForThisReveal &&
+        data.dir === getParentDir(revealPath)
+      ) {
+        consumedRevealRef.current = revealNonce;
+        onRevealConsumed?.(revealNonce);
+      }
+      return;
+    }
+    consumedRevealRef.current = revealNonce;
+    onRevealConsumed?.(revealNonce);
+    setFlashPath(revealPath === activeFilePath ? null : (revealPath ?? null));
+  }, [data, activeFilePath, revealPath, revealNonce, onRevealConsumed]);
+
+  // The flash expires on its own clock. Owning the timer here rather than in
+  // the reveal effect above means an interruption (the user opening another
+  // file mid-flash) re-arms the timer instead of tearing it down and leaving
+  // the row highlighted for good.
+  useEffect(() => {
+    if (!flashPath) return;
+    const timer = window.setTimeout(() => setFlashPath(null), 1600);
+    return () => window.clearTimeout(timer);
+  }, [flashPath]);
 
   const dirName = getPathBasename(data?.dir || '') || data?.dir || 'Files';
 
@@ -235,6 +315,14 @@ export function FileExplorer({
             return (
               <button
                 key={file.path}
+                ref={(el) => {
+                  // A row can be both the reveal target and the active file, so
+                  // claim each ref independently. An either/or ternary left
+                  // activeFileRef null for that row, and the effect above then
+                  // had nothing to scroll to for the rest of the session.
+                  if (file.path === revealPath) revealFileRef.current = el;
+                  if (isActive) activeFileRef.current = el;
+                }}
                 onClick={() => onOpenFile(file.path)}
                 onContextMenu={(e) => {
                   if (!onCtxMenu) return;
@@ -250,7 +338,9 @@ export function FileExplorer({
                 className={`w-full text-left px-3 py-1.5 text-xs flex items-center gap-2 transition-colors ${
                   isActive
                     ? 'bg-primary-bg text-primary-text font-medium'
-                    : 'text-content hover:bg-tint'
+                    : file.path === flashPath
+                      ? 'bg-tint text-content font-medium'
+                      : 'text-content hover:bg-tint'
                 }`}
                 title={file.path}
               >

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -203,6 +203,48 @@ describe('MarkdownViewer comment highlights — markdown-formatted anchor fallba
   });
 });
 
+describe('MarkdownViewer comment highlights — numbered heading anchors', () => {
+  it('highlights a multi-block anchor whose heading opens with a list-like number', async () => {
+    // stripInlineFormatting reads "1. " at a line start as an ordered-list
+    // marker, so the stripped variant of this anchor loses it and matches
+    // nothing. findMatchRange must fall through to the flexible search on the
+    // original text rather than giving up, or the anchor is reported lost.
+    const markdown = '## 1. Current Strategy\n\n### 1.1 The thesis\n\nOwn the lead journey.\n';
+    // Block tags butt against each other, as they do once the viewer has
+    // re-rendered: the concatenated text nodes carry no separator, so the
+    // anchor's newlines cannot match literally and the tiered search runs.
+    const html =
+      '<h2>1. Current Strategy</h2><h3>1.1 The thesis</h3><p>Own the lead journey.</p>';
+
+    const comment = {
+      id: 'cmt_numbered',
+      anchor: '1. Current Strategy\n1.1 The thesis\nOwn the lead journey.',
+      text: 'Section note',
+      author: 'Dennis',
+      timestamp: new Date().toISOString(),
+      cleanOffset: 0,
+    };
+
+    const { container } = render(
+      <MarkdownViewer
+        html={html}
+        cleanMarkdown={markdown}
+        comments={[comment]}
+        activeCommentId={null}
+        selectionText={null}
+        selectionOffset={null}
+        onHighlightClick={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      const marks = container.querySelectorAll('mark.comment-highlight');
+      expect(marks.length).toBeGreaterThan(0);
+      expect(marks[0].textContent).toContain('1. Current Strategy');
+    });
+  });
+});
+
 describe('MarkdownViewer comment highlights — mermaid-node anchor fallback', () => {
   it('highlights a Mermaid label even when the anchor includes markdown formatting inside the brackets', async () => {
     // Covers the deepest fallback branch in findMatchRange: Mermaid node

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -940,14 +940,28 @@ const MERMAID_NODE_MAX_LEN = 1024;
 /**
  * Find a matching range for `text` in `fullText`. Tiers:
  *   1. Literal exact match (hint/context aware).
- *   2. Stripped-formatting fallback (e.g. **bold** → bold).
- *   3. Mermaid node syntax fallback (e.g. "E[label]" → "label"), with its
+ *   2. Flexible whitespace match on the original text (hint aware). A
+ *      cross-block anchor carries newlines the concatenated text nodes do not,
+ *      so this is really tier 1 with the whitespace loosened.
+ *   3. Stripped-formatting fallback (e.g. **bold** → bold).
+ *   4. Mermaid node syntax fallback (e.g. "E[label]" → "label"), with its
  *      own stripped-formatting and flexible-search inner fallbacks.
- *   4. Flexible whitespace search on the original text.
  *
- * Returns null when no tier finds a match. Tier 2 (stripped) shortcircuits
- * to flexibleSearch on the stripped text — it does NOT fall through to the
- * Mermaid path, preserving the original wrapText behavior.
+ * Returns null when no tier finds a match.
+ *
+ * The whole-text tiers run before the stripped one because the stripper reads
+ * markdown source syntax, and an anchor captured from rendered text can carry
+ * something that only looks like syntax: `1. ` opening a heading such as
+ * "## 1. Current Strategy" parses as an ordered-list marker. Matching the
+ * stripped variant first would quietly anchor to "Current Strategy" and drop
+ * the number from the highlight, or fail outright and report a lost anchor.
+ *
+ * Tier 3 also falls through to tier 4 on failure, where it used to stop. An
+ * anchor can be both markdown-formatted and Mermaid node syntax
+ * ("E[**bold** label]"), and stopping at tier 3 meant such an anchor never
+ * reached the label extraction that was written for it. Falling through only
+ * ever adds candidates, and each later tier is itself anchored to the same
+ * text, so it cannot turn a correct match into a wrong one.
  */
 function findMatchRange(
   fullText: string,
@@ -970,7 +984,11 @@ function findMatchRange(
     return { start, end: start + text.length };
   }
 
-  // Tier 2: stripped formatting
+  // Tier 2: flexible whitespace on the original text
+  const flexible = findFlexibleMatch(fullText, text, hintOffset);
+  if (flexible) return flexible;
+
+  // Tier 3: stripped formatting
   const strippedText = stripInlineFormatting(text).plain;
   if (strippedText !== text && strippedText.length > 0) {
     const occs = findAllOccurrences(fullText, strippedText);
@@ -978,10 +996,11 @@ function findMatchRange(
       const start = pickClosestOccurrence(occs, hintOffset);
       return { start, end: start + strippedText.length };
     }
-    return flexibleSearch(fullText, strippedText) ?? null;
+    const flexible = flexibleSearch(fullText, strippedText);
+    if (flexible) return flexible;
   }
 
-  // Tier 3: Mermaid node syntax
+  // Tier 4: Mermaid node syntax
   const mermaidMatch =
     text.length <= MERMAID_NODE_MAX_LEN ? text.match(MERMAID_NODE_PATTERN) : null;
   if (mermaidMatch) {
@@ -1002,8 +1021,42 @@ function findMatchRange(
     }
   }
 
-  // Tier 4: flexible whitespace on the original
-  return flexibleSearch(fullText, text) ?? null;
+  return null;
+}
+
+/**
+ * Backstop on the flexible-match walk below. A pathological anchor whose first
+ * word is very common would otherwise rescan the document once per occurrence,
+ * for every comment, on every repaint.
+ */
+const MAX_FLEXIBLE_PROBES = 64;
+
+/**
+ * The flexible-whitespace match of `needle` closest to `hintOffset`.
+ *
+ * Without a hint this is the first match and costs a single scan. With one,
+ * the walk stops as soon as a match starts at or past the hint, since matches
+ * are enumerated left to right and everything after that point is farther
+ * away than the candidate already in hand.
+ */
+function findFlexibleMatch(
+  haystack: string,
+  needle: string,
+  hintOffset?: number,
+): { start: number; end: number } | null {
+  let best: { start: number; end: number } | null = null;
+  let from = 0;
+  for (let probe = 0; probe < MAX_FLEXIBLE_PROBES; probe++) {
+    const match = flexibleSearch(haystack, needle, from);
+    if (!match) break;
+    if (hintOffset === undefined) return match;
+    if (best === null || Math.abs(match.start - hintOffset) < Math.abs(best.start - hintOffset)) {
+      best = match;
+    }
+    if (match.start >= hintOffset) break;
+    from = match.start + 1;
+  }
+  return best;
 }
 
 /**

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -334,7 +334,8 @@ export function SettingsPanel({ open, onClose, author, onAuthorChange }: Props) 
                   </button>
                 </div>
                 <p className="text-xs text-content-muted mb-3">
-                  Drag to reorder. The order here matches the template picker.
+                  Drag to reorder. The order here matches the template picker, and the first two
+                  become the one-tap buttons on the selection pill.
                 </p>
 
                 {/* Template list */}

--- a/src/hooks/useContextMenuItems.ts
+++ b/src/hooks/useContextMenuItems.ts
@@ -66,6 +66,29 @@ export interface UseContextMenuItemsParams {
   sidebarCtxMenu: ContextMenuInstance;
 }
 
+/**
+ * Put a viewer selection on the clipboard with the same two flavors the
+ * Cmd/Ctrl+C path writes, so right-click Copy does not silently flatten a
+ * table or a nested list that the keyboard copy would have preserved.
+ * Falls back to plain text when the richer API is unavailable or rejects.
+ */
+function copySelectionToClipboard(sel: SelectionInfo): void {
+  const writePlain = () => void navigator.clipboard.writeText(sel.text).catch(() => {});
+  if (!sel.html || typeof ClipboardItem === 'undefined' || !navigator.clipboard.write) {
+    writePlain();
+    return;
+  }
+  try {
+    const item = new ClipboardItem({
+      'text/plain': new Blob([sel.text], { type: 'text/plain' }),
+      'text/html': new Blob([sel.html], { type: 'text/html' }),
+    });
+    navigator.clipboard.write([item]).catch(writePlain);
+  } catch {
+    writePlain();
+  }
+}
+
 export function useContextMenuItems(params: UseContextMenuItemsParams) {
   const {
     comments,
@@ -196,7 +219,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
           {
             label: 'Copy',
             onClick: () => {
-              navigator.clipboard.writeText(sel.text);
+              copySelectionToClipboard(sel);
             },
           },
         ];

--- a/src/hooks/useContextMenuItems.ts
+++ b/src/hooks/useContextMenuItems.ts
@@ -6,7 +6,7 @@ import type { TabContextMenuInfo } from '../components/TabBar';
 import type { SidebarContextMenuInfo } from '../components/CommentListSurface';
 import type { MdComment, SelectionInfo } from '../types';
 import { getEffectiveStatus } from '../types';
-import { getPathBasename } from '../lib/path-utils';
+import { getParentDir, getPathBasename } from '../lib/path-utils';
 
 type ContextMenuInstance = {
   open: (x: number, y: number) => void;
@@ -53,8 +53,8 @@ export interface UseContextMenuItemsParams {
   addRecentFile: (path: string) => void;
   revealInFinder: (path: string) => void;
   revealLabel: string;
-  setExplorerDir: Dispatch<SetStateAction<string | undefined>>;
-  setExplorerVisible: (v: boolean | ((prev: boolean) => boolean)) => void;
+  /** Open the explorer panel on a directory (re-browses even if unchanged). */
+  revealDirInExplorer: (dir: string, filePath?: string) => void;
   tabs: Array<{ filePath: string }>;
   closeTab: (path: string) => void;
   closeOtherTabs: (path: string) => void;
@@ -88,8 +88,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
     addRecentFile,
     revealInFinder,
     revealLabel,
-    setExplorerDir,
-    setExplorerVisible,
+    revealDirInExplorer,
     tabs,
     closeTab,
     closeOtherTabs,
@@ -255,10 +254,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
         const items: ContextMenuEntry[] = [
           {
             label: 'Open in Explorer',
-            onClick: () => {
-              setExplorerDir(info.path);
-              setExplorerVisible(true);
-            },
+            onClick: () => revealDirInExplorer(info.path),
           },
           { type: 'divider' as const },
           { label: revealLabel, onClick: () => revealInFinder(info.path) },
@@ -281,8 +277,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
       addRecentFile,
       revealInFinder,
       revealLabel,
-      setExplorerVisible,
-      setExplorerDir,
+      revealDirInExplorer,
       viewerCtxMenu,
       explorerCtxMenu,
       tabCtxMenu,
@@ -300,8 +295,9 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
       const hasTabsToRight = tabIndex >= 0 && tabIndex < tabs.length - 1;
       const hasOtherTabs = tabs.length > 1;
       const fileName = getPathBasename(info.filePath) || info.filePath;
-      const lastSlash = info.filePath.lastIndexOf('/');
-      const parentDir = lastSlash > 0 ? info.filePath.slice(0, lastSlash) : null;
+      // Separator-agnostic: a Windows path has no forward slashes, and a file
+      // at the POSIX root still has a parent to reveal.
+      const parentDir = getParentDir(info.filePath) || null;
 
       const items: ContextMenuEntry[] = [
         { label: 'Close', onClick: () => closeTab(info.filePath) },
@@ -322,8 +318,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
           disabled: parentDir === null,
           onClick: () => {
             if (parentDir === null) return;
-            setExplorerDir(parentDir);
-            setExplorerVisible(true);
+            revealDirInExplorer(parentDir, info.filePath);
           },
         },
         { label: revealLabel, onClick: () => revealInFinder(info.filePath) },
@@ -341,8 +336,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
       closeTabsToRight,
       revealInFinder,
       revealLabel,
-      setExplorerDir,
-      setExplorerVisible,
+      revealDirInExplorer,
       viewerCtxMenu,
       explorerCtxMenu,
       tabCtxMenu,

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -348,7 +348,12 @@ describe('addReply', () => {
 describe('appendReply', () => {
   it('appends a reply to an existing comment with no existing replies', () => {
     const raw = `${marker({ id: 'c1', anchor: 'hello', text: 'top comment' })}hello world`;
-    const reply = { id: 'r1', text: 'a reply', author: 'Agent', timestamp: '2026-01-01T00:00:00.000Z' };
+    const reply = {
+      id: 'r1',
+      text: 'a reply',
+      author: 'Agent',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    };
     const result = appendReply(raw, 'c1', reply);
     const parsed = parseComments(result);
     expect(parsed.comments[0].replies).toHaveLength(1);
@@ -362,7 +367,12 @@ describe('appendReply', () => {
 
   it('appends to an existing reply array', () => {
     const raw = `${marker({ id: 'c1', replies: [{ id: 'r0', text: 'first', author: 'User', timestamp: '2026-01-01T00:00:00.000Z' }] })}hello`;
-    const reply = { id: 'r1', text: 'second', author: 'Agent', timestamp: '2026-01-02T00:00:00.000Z' };
+    const reply = {
+      id: 'r1',
+      text: 'second',
+      author: 'Agent',
+      timestamp: '2026-01-02T00:00:00.000Z',
+    };
     const result = appendReply(raw, 'c1', reply);
     const parsed = parseComments(result);
     expect(parsed.comments[0].replies).toHaveLength(2);
@@ -372,14 +382,24 @@ describe('appendReply', () => {
 
   it('returns unchanged content when commentId is not found', () => {
     const raw = `${marker({ id: 'c1' })}hello`;
-    const reply = { id: 'r1', text: 'orphan', author: 'Agent', timestamp: '2026-01-01T00:00:00.000Z' };
+    const reply = {
+      id: 'r1',
+      text: 'orphan',
+      author: 'Agent',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    };
     const result = appendReply(raw, 'c_does_not_exist', reply);
     expect(result).toBe(raw);
   });
 
   it('preserves contextBefore, contextAfter, and other fields', () => {
     const raw = `${marker({ id: 'c1', anchor: 'foo', contextBefore: 'pre', contextAfter: 'post' })}foo`;
-    const reply = { id: 'r1', text: 'reply', author: 'Agent', timestamp: '2026-01-01T00:00:00.000Z' };
+    const reply = {
+      id: 'r1',
+      text: 'reply',
+      author: 'Agent',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    };
     const result = appendReply(raw, 'c1', reply);
     const parsed = parseComments(result);
     expect(parsed.comments[0].contextBefore).toBe('pre');
@@ -400,7 +420,12 @@ describe('appendReply', () => {
       expectsReply: true,
       sessionId: 'rev_xyz',
     })}foo`;
-    const reply = { id: 'r1', text: 'my answer', author: 'User', timestamp: '2026-01-01T00:00:00.000Z' };
+    const reply = {
+      id: 'r1',
+      text: 'my answer',
+      author: 'User',
+      timestamp: '2026-01-01T00:00:00.000Z',
+    };
     const result = appendReply(raw, 'c1', reply);
     const parsed = parseComments(result);
     expect(parsed.comments[0].agentInitiated).toBe(true);
@@ -466,10 +491,7 @@ describe('removeReply', () => {
 });
 
 describe('findNewReplyIds', () => {
-  function makeComment(
-    id: string,
-    replies: { id: string; text: string }[] = [],
-  ): MdComment {
+  function makeComment(id: string, replies: { id: string; text: string }[] = []): MdComment {
     return {
       id,
       anchor: 'a',
@@ -579,9 +601,7 @@ describe('backfillReplyTimestamps', () => {
   it('returns the original string when forceIds is empty', () => {
     const raw = `${marker({
       id: 'c1',
-      replies: [
-        { id: 'r1', text: 'reply', author: 'A', timestamp: '2024-01-01T00:00:00.000Z' },
-      ],
+      replies: [{ id: 'r1', text: 'reply', author: 'A', timestamp: '2024-01-01T00:00:00.000Z' }],
     })}hello`;
     const result = backfillReplyTimestamps(raw, new Set(), FALLBACK);
     expect(result).toBe(raw);
@@ -590,9 +610,7 @@ describe('backfillReplyTimestamps', () => {
   it('returns the original string when no matching reply is found', () => {
     const raw = `${marker({
       id: 'c1',
-      replies: [
-        { id: 'r1', text: 'reply', author: 'A', timestamp: '2024-01-01T00:00:00.000Z' },
-      ],
+      replies: [{ id: 'r1', text: 'reply', author: 'A', timestamp: '2024-01-01T00:00:00.000Z' }],
     })}hello`;
     const result = backfillReplyTimestamps(raw, new Set(['nonexistent']), FALLBACK);
     expect(result).toBe(raw);
@@ -778,6 +796,91 @@ describe('detectMissingAnchors', () => {
     expect(missing.has('a')).toBe(false);
   });
 
+  it('does not flag an anchor that crosses table cells', () => {
+    // The anchor comes from rendered text, where the cell pipes are invisible.
+    const clean = [
+      '| | Single-point tool | Full lead journey |',
+      '|---|---|---|',
+      '| **Autonomous** | Chatbase (chat) | **EasyMate (target)** |',
+    ].join('\n');
+    const comments = [
+      { id: 'a', anchor: 'Single-point tool\nFull lead journey\nAutonomous\nChatbase (chat)' },
+    ] as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(false);
+  });
+
+  it('does not flag an anchor that runs from a heading into a table', () => {
+    const clean = [
+      '### 1.1 The thesis',
+      '',
+      'Own the **complete lead journey** for SMBs.',
+      '',
+      '| | Single-point tool |',
+      '|---|---|',
+      '| **Autonomous** | Chatbase (chat) |',
+    ].join('\n');
+    const comments = [
+      {
+        id: 'a',
+        anchor:
+          '1.1 The thesis\nOwn the complete lead journey for SMBs.\nSingle-point tool\nAutonomous\nChatbase (chat)',
+      },
+    ] as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(false);
+  });
+
+  it('still flags an anchor whose words were changed inside a table', () => {
+    const clean = '| **Autonomous** | Chatbase (chat) |';
+    const comments = [{ id: 'a', anchor: 'Autonomous Smith.ai (voice)' }] as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(true);
+  });
+
+  it('does not flag an anchor whose word opens with a dash inside a blockquote', () => {
+    // The scaffolding skip must not swallow the "-" that starts the next word.
+    const clean = '> revenue\n> -20% YoY';
+    const comments = [{ id: 'a', anchor: 'revenue -20% YoY' }] as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(false);
+  });
+
+  it('does not flag an anchor whose word opens with a dash inside a list', () => {
+    const clean = '- revenue\n- -20% drop';
+    const comments = [{ id: 'a', anchor: 'revenue -20% drop' }] as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(false);
+  });
+
+  it('does not flag an anchor whose table cell opens with a dash', () => {
+    const clean = '| Cost | -20% |';
+    const comments = [{ id: 'a', anchor: 'Cost -20%' }] as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(false);
+  });
+
+  it('flags an anchor whose words were separated by new punctuation', () => {
+    // ": " between the words is visible content, not markdown scaffolding. The
+    // viewer's matcher would not follow it either, so the comment must be
+    // reported for re-anchoring rather than silently losing its highlight.
+    expect(
+      detectMissingAnchors('alpha: beta', [{ id: 'a', anchor: 'alpha beta' }] as MdComment[]).has(
+        'a',
+      ),
+    ).toBe(true);
+    expect(
+      detectMissingAnchors('alpha -> beta', [{ id: 'a', anchor: 'alpha beta' }] as MdComment[]).has(
+        'a',
+      ),
+    ).toBe(true);
+    expect(
+      detectMissingAnchors('alpha = beta', [{ id: 'a', anchor: 'alpha beta' }] as MdComment[]).has(
+        'a',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not flag an anchor containing a literal dash between words', () => {
+    const clean = 'Trade-offs: speed - cost - quality';
+    const comments = [{ id: 'a', anchor: 'speed - cost - quality' }] as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(false);
+  });
+
   it('detects partially modified anchor', () => {
     const clean = 'Hello universe';
     const comments = [{ id: 'a', anchor: 'Hello world' }] as MdComment[];
@@ -860,36 +963,28 @@ describe('detectMissingAnchors', () => {
 
   it('does not flag anchor spanning a task list', () => {
     const clean = '- [ ] First task\n- [x] Done task';
-    const comments = [
-      { id: 'a', anchor: 'First task\nDone task' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'First task\nDone task' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('does not flag anchor spanning a nested (indented) list', () => {
     const clean = '- Outer item\n  - Inner item\n  - Another inner';
-    const comments = [
-      { id: 'a', anchor: 'Outer item\nInner item\nAnother inner' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Outer item\nInner item\nAnother inner' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('does not flag anchor spanning inline HTML tags', () => {
     const clean = 'Footnote<sup>1</sup> here.\nLine one<br>Line two.';
-    const comments = [
-      { id: 'a', anchor: 'Footnote1 here.\nLine oneLine two.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Footnote1 here.\nLine oneLine two.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('does not flag anchor spanning an autolink', () => {
     const clean = 'Visit <https://example.com> today.';
-    const comments = [
-      { id: 'a', anchor: 'Visit https://example.com today.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Visit https://example.com today.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -897,9 +992,7 @@ describe('detectMissingAnchors', () => {
   it('does not flag anchor spanning reference-style links and ref definitions', () => {
     const clean =
       'See [the docs][docs-ref] and [an example][ex] for info.\n\n[docs-ref]: https://example.com/docs\n[ex]: https://example.com/ex';
-    const comments = [
-      { id: 'a', anchor: 'See the docs and an example for info.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'See the docs and an example for info.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -915,18 +1008,14 @@ describe('detectMissingAnchors', () => {
 
   it('does not flag anchor spanning footnote refs and definitions', () => {
     const clean = 'See the docs[^1] for more details.\n\n[^1]: footnote text here.';
-    const comments = [
-      { id: 'a', anchor: 'See the docs for more details.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'See the docs for more details.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('does not flag anchor spanning a backslash hard break', () => {
     const clean = 'Line one\\\nLine two';
-    const comments = [
-      { id: 'a', anchor: 'Line one\nLine two' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Line one\nLine two' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -936,9 +1025,7 @@ describe('detectMissingAnchors', () => {
     // non-empty. The handler must leave it in place so a comment whose
     // anchor includes the literal text still matches.
     const clean = 'Aside [^] continues here.';
-    const comments = [
-      { id: 'a', anchor: 'Aside [^] continues here.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Aside [^] continues here.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -955,9 +1042,7 @@ describe('detectMissingAnchors', () => {
       '    - npm test\n' +
       '\n' +
       'Then continue.';
-    const comments = [
-      { id: 'a', anchor: '- npm install\n- npm test' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: '- npm install\n- npm test' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -967,11 +1052,8 @@ describe('detectMissingAnchors', () => {
     // `[the docs]: url` definition elsewhere, is a shortcut reference link.
     // remark-gfm renders just `the docs` (no brackets) — the parser must
     // drop the brackets to match.
-    const clean =
-      'See [the docs] for full details.\n\n[the docs]: https://example.com';
-    const comments = [
-      { id: 'a', anchor: 'See the docs for full details.' },
-    ] as MdComment[];
+    const clean = 'See [the docs] for full details.\n\n[the docs]: https://example.com';
+    const comments = [{ id: 'a', anchor: 'See the docs for full details.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -981,9 +1063,7 @@ describe('detectMissingAnchors', () => {
     // verbatim — the parser must NOT drop the brackets, otherwise an anchor
     // that includes them would fail to match.
     const clean = 'See [Note] for the warning. No reference defined.';
-    const comments = [
-      { id: 'a', anchor: 'See [Note] for the warning.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'See [Note] for the warning.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -994,9 +1074,7 @@ describe('detectMissingAnchors', () => {
     // handling. DOM textContent omits both layers of `> ` plus the bullet
     // marker, so the anchor only has the inner prose.
     const clean = '> > - Inner bullet one\n> > - Inner bullet two';
-    const comments = [
-      { id: 'a', anchor: 'Inner bullet one\nInner bullet two' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Inner bullet one\nInner bullet two' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -1015,9 +1093,7 @@ describe('detectMissingAnchors', () => {
 
   it('strips reference definitions with quoted titles', () => {
     const clean = 'See [docs][r] today.\n\n[r]: https://example.com "title text"';
-    const comments = [
-      { id: 'a', anchor: 'See docs today.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'See docs today.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -1036,18 +1112,14 @@ describe('detectMissingAnchors', () => {
     // bracket handler bails out and the text is preserved verbatim so users
     // can comment on it.
     const clean = 'Math: <3 km away';
-    const comments = [
-      { id: 'a', anchor: 'Math: <3 km away' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Math: <3 km away' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('strips collapsed reference links [text][]', () => {
     const clean = 'See [the docs][] for info.\n\n[the docs]: https://example.com';
-    const comments = [
-      { id: 'a', anchor: 'See the docs for info.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'See the docs for info.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -1056,36 +1128,28 @@ describe('detectMissingAnchors', () => {
     // CommonMark only escapes ASCII punctuation; `\f`, `\foo`, etc. should
     // keep both the backslash and the following char.
     const clean = 'Path: C:\\foo and \\bar end';
-    const comments = [
-      { id: 'a', anchor: 'Path: C:\\foo and \\bar end' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Path: C:\\foo and \\bar end' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('does not flag a blockquoted task list', () => {
     const clean = '> - [ ] Task in quote\n> - [x] Done in quote';
-    const comments = [
-      { id: 'a', anchor: 'Task in quote\nDone in quote' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'Task in quote\nDone in quote' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('does not flag a deeply nested list (4-space indent)', () => {
     const clean = '- A\n    - B\n        - C';
-    const comments = [
-      { id: 'a', anchor: 'A\nB\nC' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'A\nB\nC' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
 
   it('does not flag inline HTML with attributes', () => {
     const clean = 'See <a href="https://x.com" target="_blank">click here</a> please.';
-    const comments = [
-      { id: 'a', anchor: 'See click here please.' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: 'See click here please.' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -1290,9 +1354,7 @@ Final checklist is complete.
   it('does not flag agent anchor with mixed formatting markers', () => {
     // `**Still selected + content changed**` → plain `Still selected + content changed`
     const clean = 'State: **Still selected + content changed** triggers a diff.';
-    const comments = [
-      { id: 'a', anchor: '**Still selected + content changed**' },
-    ] as MdComment[];
+    const comments = [{ id: 'a', anchor: '**Still selected + content changed**' }] as MdComment[];
     const missing = detectMissingAnchors(clean, comments);
     expect(missing.has('a')).toBe(false);
   });
@@ -2761,11 +2823,7 @@ describe('moveComment', () => {
   });
 
   it('uses hintOffset to disambiguate duplicate anchor occurrences', () => {
-    const raw = insertComment(
-      'first foo then second foo in doc',
-      'first foo',
-      'note',
-    );
+    const raw = insertComment('first foo then second foo in doc', 'first foo', 'note');
     const { comments } = parseComments(raw);
     const commentId = comments[0].id;
 

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -869,10 +869,7 @@ export function removeReply(rawMarkdown: string, commentId: string, replyId: str
  * an external editor (typically an LLM agent) just added so we can override
  * them.
  */
-export function findNewReplyIds(
-  oldComments: MdComment[],
-  newComments: MdComment[],
-): Set<string> {
+export function findNewReplyIds(oldComments: MdComment[], newComments: MdComment[]): Set<string> {
   const newReplyIds = new Set<string>();
   const oldById = new Map(oldComments.map((c) => [c.id, c]));
   for (const newC of newComments) {
@@ -1066,8 +1063,7 @@ export function stripInlineFormatting(md: string): {
   // brackets, but a literal `[Note]` with no definition stays bracketed,
   // so we only strip when we know there's a real label.
   const refLabels = new Set<string>();
-  const normalizeRefLabel = (label: string) =>
-    label.replace(/\s+/g, ' ').trim().toLowerCase();
+  const normalizeRefLabel = (label: string) => label.replace(/\s+/g, ' ').trim().toLowerCase();
   const REF_DEF_RE =
     /(?:^|\n)\[([^\n\]]+)\]:[ \t]+(?:<[^<>\n]*>|\S+)(?:[ \t]+(?:"[^"\n]*"|'[^'\n]*'|\([^()\n]*\)))?[ \t]*(?=\n|$)/g;
   for (let m: RegExpExecArray | null; (m = REF_DEF_RE.exec(md)) !== null; ) {
@@ -1474,8 +1470,60 @@ export function stripInlineFormatting(md: string): {
 }
 
 /**
- * Check if ordered parts appear contiguously in text, with only whitespace between them.
- * Used for flexible anchor detection when exact string match fails.
+ * Structural markdown that can sit between two words of an anchor without the
+ * anchored text having changed: list bullets, blockquote arrows, heading
+ * hashes, and a table's delimiter row. Anchors are captured from rendered
+ * text, where none of this is visible, so a selection crossing table cells or
+ * block boundaries has to be recognized in the source too.
+ *
+ * These characters are only structural at a line start, so they are skipped
+ * only once the gap between two parts has crossed a newline. Skipping them
+ * mid-line would read visible punctuation as invisible markup and report
+ * "alpha beta" as still present in "alpha: beta", which is a genuine edit the
+ * viewer's own matcher would not follow — the comment would lose its highlight
+ * without ever being flagged for re-anchoring.
+ */
+const LINE_START_SCAFFOLDING = /[>#+*:=-]/;
+
+/**
+ * The one piece of structure that is legitimately mid-line: a table's cell
+ * separator. Rendered text shows cells side by side with no pipe.
+ */
+const CELL_SEPARATOR = '|';
+
+function skipWhitespace(text: string, from: number): number {
+  let pos = from;
+  while (pos < text.length && /\s/.test(text[pos])) pos++;
+  return pos;
+}
+
+/**
+ * Position just past `part` when it can be reached from `from` across nothing
+ * but whitespace and structural markdown, or null when it cannot. Each
+ * character is consumed one at a time and the part is retried at every
+ * resulting position, so a part that itself opens with one of those characters
+ * ("-20%") still matches.
+ */
+function advancePastPart(text: string, from: number, part: string): number | null {
+  let pos = skipWhitespace(text, from);
+  let crossedNewline = text.slice(from, pos).includes('\n');
+  for (;;) {
+    if (text.startsWith(part, pos)) return pos + part.length;
+    if (pos >= text.length) return null;
+    const char = text[pos];
+    const structural =
+      char === CELL_SEPARATOR || (crossedNewline && LINE_START_SCAFFOLDING.test(char));
+    if (!structural) return null;
+    const next = skipWhitespace(text, pos + 1);
+    if (text.slice(pos + 1, next).includes('\n')) crossedNewline = true;
+    pos = next;
+  }
+}
+
+/**
+ * Check if ordered parts appear contiguously in text, separated only by
+ * whitespace and structural markdown. Used for flexible anchor detection when
+ * exact string match fails.
  */
 function partsAppearContiguously(text: string, parts: string[]): boolean {
   let searchFrom = 0;
@@ -1485,19 +1533,12 @@ function partsAppearContiguously(text: string, parts: string[]): boolean {
     let pos = firstIdx + parts[0].length;
     let matched = true;
     for (let i = 1; i < parts.length; i++) {
-      // Skip whitespace so cross-line selections still match
-      while (pos < text.length && /\s/.test(text[pos])) pos++;
-      // After whitespace, skip optional block-level markers at line start (list bullets, blockquote)
-      if (pos < text.length && /[-*+>]/.test(text[pos]) && (pos === 0 || text[pos - 1] === '\n')) {
-        pos++;
-        while (pos < text.length && text[pos] === ' ') pos++;
-      }
-      if (text.startsWith(parts[i], pos)) {
-        pos += parts[i].length;
-      } else {
+      const next = advancePastPart(text, pos, parts[i]);
+      if (next === null) {
         matched = false;
         break;
       }
+      pos = next;
     }
     if (matched) return true;
     searchFrom = firstIdx + 1;

--- a/src/lib/copy-selection-html.test.ts
+++ b/src/lib/copy-selection-html.test.ts
@@ -1,0 +1,448 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { buildRangeHtml } from './copy-selection-html';
+
+function mount(html: string): HTMLElement {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  return container;
+}
+
+/** Select from the start of the first matching element's text to the end of the last's. */
+function rangeAcross(container: HTMLElement, selector: string): Range {
+  const els = [...container.querySelectorAll(selector)];
+  const first = els[0];
+  const last = els[els.length - 1];
+  const startText = document.createTreeWalker(first, NodeFilter.SHOW_TEXT).nextNode()!;
+  const walker = document.createTreeWalker(last, NodeFilter.SHOW_TEXT);
+  let endText: Node = startText;
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) endText = n;
+  const range = document.createRange();
+  range.setStart(startText, 0);
+  range.setEnd(endText, (endText.textContent ?? '').length);
+  return range;
+}
+
+describe('buildRangeHtml', () => {
+  it('returns null without a container', () => {
+    const container = mount('<p>Plain paragraph</p>');
+    expect(buildRangeHtml(rangeAcross(container, 'p'), null)).toBeNull();
+  });
+
+  it('returns null for a collapsed range', () => {
+    const container = mount('<p>Plain paragraph</p>');
+    const range = document.createRange();
+    range.setStart(container.querySelector('p')!.firstChild!, 2);
+    range.collapse(true);
+    expect(buildRangeHtml(range, container)).toBeNull();
+  });
+
+  it('keeps inline formatting inside the selection', () => {
+    const container = mount('<p>Ship <strong>fast</strong> today</p>');
+    const html = buildRangeHtml(rangeAcross(container, 'p'), container) ?? '';
+    expect(html).toContain('<strong>fast</strong>');
+  });
+
+  it('keeps a wrapper that tightly contains the whole selection', () => {
+    const container = mount('<p><a href="https://example.com">the docs</a></p>');
+    expect(buildRangeHtml(rangeAcross(container, 'a'), container)).toContain(
+      '<a href="https://example.com">the docs</a>',
+    );
+  });
+
+  it('keeps the heading element when a heading is fully selected', () => {
+    const container = mount('<div><h2>Current Strategy</h2></div>');
+    expect(buildRangeHtml(rangeAcross(container, 'h2'), container)).toContain(
+      '<h2>Current Strategy</h2>',
+    );
+  });
+
+  it('keeps list structure across items', () => {
+    const container = mount('<ul><li>first</li><li>second</li></ul>');
+    const html = buildRangeHtml(rangeAcross(container, 'li'), container) ?? '';
+    expect(html).toContain('<ul>');
+    expect(html).toContain('<li>first</li>');
+    expect(html).toContain('<li>second</li>');
+  });
+
+  it('re-wraps bare list items when the list itself is outside the range', () => {
+    const container = mount('<ul><li>skipped</li><li>second</li><li>third</li></ul>');
+    const els = [...container.querySelectorAll('li')].slice(1);
+    const range = document.createRange();
+    range.setStart(els[0].firstChild!, 0);
+    range.setEnd(els[1].firstChild!, els[1].textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html.startsWith('<ul>')).toBe(true);
+    expect(html).not.toContain('skipped');
+  });
+
+  it('carries ordered-list numbering across when the list itself is outside the range', () => {
+    const container = mount('<ol><li>one</li><li>two</li><li>three</li><li>four</li></ol>');
+    const els = [...container.querySelectorAll('li')].slice(2);
+    const range = document.createRange();
+    range.setStart(els[0].firstChild!, 0);
+    range.setEnd(els[1].firstChild!, els[1].textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html.startsWith('<ol start="3">')).toBe(true);
+    expect(html).not.toContain('one');
+  });
+
+  it('honors an existing start attribute on the source list', () => {
+    const container = mount('<ol start="5"><li>five</li><li>six</li><li>seven</li></ol>');
+    const els = [...container.querySelectorAll('li')].slice(1);
+    const range = document.createRange();
+    range.setStart(els[0].firstChild!, 0);
+    range.setEnd(els[1].firstChild!, els[1].textContent!.length);
+    expect(buildRangeHtml(range, container)?.startsWith('<ol start="6">')).toBe(true);
+  });
+
+  it('omits the start attribute for an unordered list', () => {
+    const container = mount('<ul><li>alpha</li><li>beta</li><li>gamma</li></ul>');
+    const els = [...container.querySelectorAll('li')].slice(1);
+    const range = document.createRange();
+    range.setStart(els[0].firstChild!, 0);
+    range.setEnd(els[1].firstChild!, els[1].textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html.startsWith('<ul>')).toBe(true);
+    expect(html).not.toContain('start=');
+  });
+
+  it('numbers correctly when the selection starts mid-item', () => {
+    // Text matching would fail here: the cloned first item holds a partial
+    // string, so the offset has to come from the source item structurally.
+    const container = mount('<ol><li>one</li><li>two</li><li>three item</li><li>four</li></ol>');
+    const items = [...container.querySelectorAll('li')];
+    const range = document.createRange();
+    range.setStart(items[2].firstChild!, 6); // mid-way into "three item"
+    range.setEnd(items[3].firstChild!, items[3].textContent!.length);
+    expect(buildRangeHtml(range, container)?.startsWith('<ol start="3">')).toBe(true);
+  });
+
+  it('numbers correctly when two items read identically', () => {
+    const container = mount('<ol><li>dup</li><li>dup</li><li>tail</li></ol>');
+    const items = [...container.querySelectorAll('li')];
+    const range = document.createRange();
+    range.setStart(items[1].firstChild!, 0);
+    range.setEnd(items[2].firstChild!, items[2].textContent!.length);
+    expect(buildRangeHtml(range, container)?.startsWith('<ol start="2">')).toBe(true);
+  });
+
+  it('keeps a trailing paragraph when the selection runs out of the list', () => {
+    const container = mount(
+      '<div><ul><li>first</li><li>second</li></ul><p>after the list</p></div>',
+    );
+    const items = [...container.querySelectorAll('li')];
+    const tail = container.querySelector('p')!;
+    const range = document.createRange();
+    range.setStart(items[1].firstChild!, 0);
+    range.setEnd(tail.firstChild!, tail.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html).toContain('<ul><li>second</li></ul>');
+    expect(html).toContain('after the list');
+  });
+
+  it('does not re-tag a nested selection with the inner list type', () => {
+    const container = mount('<ul><li>alpha<ol><li>x</li><li>y</li></ol></li><li>beta</li></ul>');
+    const nested = [...container.querySelectorAll('ol > li')][1];
+    const range = document.createRange();
+    range.setStart(nested.firstChild!, 0);
+    range.setEnd(nested.firstChild!, nested.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    // The outer list keeps its own type; the sublist is numbered from its own
+    // items, so "y" pastes as 2 rather than restarting at 1.
+    expect(html.startsWith('<ul>')).toBe(true);
+    expect(html).toContain('<ol start="2">');
+    expect(html).toContain('y');
+  });
+
+  it('numbers a nested ordered selection from its own list', () => {
+    const container = mount(
+      '<ol><li>one<ol><li>n1</li><li>n2</li><li>n3</li></ol></li><li>two</li></ol>',
+    );
+    const nested = [...container.querySelectorAll('ol ol > li')];
+    const range = document.createRange();
+    range.setStart(nested[1].firstChild!, 0);
+    range.setEnd(nested[2].firstChild!, nested[2].textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    // The clone is anchored on the outer item that contains the sublist, so
+    // the numbering belongs to the outer list, not a phantom "2." item.
+    expect(html).toContain('n2');
+    expect(html).toContain('n3');
+    expect(html).not.toContain('<li></li>');
+  });
+
+  it('does not stamp an outer list with a sublist item index', () => {
+    // Selecting from mid-sublist through the end of the section: the clone's
+    // top-level list is the OUTER one, so its numbering must come from the
+    // outer list's own items, not from "b3 is item 3 of the sublist".
+    const container = mount(
+      '<div><ol><li>x<ol><li>b1</li><li>b2</li><li>b3</li></ol></li><li>y</li></ol><p>tail</p></div>',
+    );
+    const b3 = [...container.querySelectorAll('ol ol > li')][2];
+    const tail = container.querySelector('p')!;
+    const range = document.createRange();
+    range.setStart(b3.firstChild!, 0);
+    range.setEnd(tail.firstChild!, tail.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    // The outer list starts at its own first item, so it carries no start; the
+    // sublist carries the 3 that belongs to it.
+    expect(html.startsWith('<ol>')).toBe(true);
+    expect(html).toContain('<ol start="3">');
+    expect(html).toContain('tail');
+  });
+
+  it('numbers a sublist selection that ends flush on its last item', () => {
+    // The flush end widens the range past the sublist, lifting the common
+    // ancestor above it. The numbering still belongs to the sublist.
+    const container = mount('<ul><li>u1<ol><li>n1</li><li>n2</li><li>n3</li></ol></li></ul>');
+    const items = [...container.querySelectorAll('ol > li')];
+    const range = document.createRange();
+    range.setStart(items[1].firstChild!, 0);
+    range.setEnd(items[2].firstChild!, items[2].textContent!.length);
+    expect(buildRangeHtml(range, container)).toContain('<ol start="2">');
+  });
+
+  it('numbers a list wrapped in a blockquote when the selection ends flush', () => {
+    const container = mount('<blockquote><ol><li>q1</li><li>q2</li><li>q3</li></ol></blockquote>');
+    const items = [...container.querySelectorAll('li')];
+    const range = document.createRange();
+    range.setStart(items[1].firstChild!, 0);
+    range.setEnd(items[2].firstChild!, items[2].textContent!.length);
+    expect(buildRangeHtml(range, container)).toContain('<ol start="2">');
+  });
+
+  it('leaves the source document untouched', () => {
+    const markup = '<ol><li>one</li><li>two</li><li>three</li></ol>';
+    const container = mount(markup);
+    const items = [...container.querySelectorAll('li')];
+    const range = document.createRange();
+    range.setStart(items[1].firstChild!, 0);
+    range.setEnd(items[2].firstChild!, items[2].textContent!.length);
+    buildRangeHtml(range, container);
+    expect(container.innerHTML).toBe(markup);
+  });
+
+  it('numbers both lists when a selection spans a sublist and its outer list', () => {
+    const container = mount(
+      '<div><ol><li>x1</li><li>x2</li><li>x3<ol><li>b1</li><li>b2</li></ol></li><li>x4</li></ol><p>tail</p></div>',
+    );
+    const b2 = [...container.querySelectorAll('ol ol > li')][1];
+    const tail = container.querySelector('p')!;
+    const range = document.createRange();
+    range.setStart(b2.firstChild!, 0);
+    range.setEnd(tail.firstChild!, tail.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    // Outer resumes at its own third item, sublist at its own second.
+    expect(html.startsWith('<ol start="3">')).toBe(true);
+    expect(html).toContain('<ol start="2">');
+  });
+
+  it('numbers every level of a deeply nested selection', () => {
+    // A two-slot outer/inner model silently drops the middle list here.
+    const container = mount(
+      '<div><ol><li>a<ol><li>b1</li><li>b2<ol><li>c1</li><li>c2</li><li>c3</li></ol></li></ol></li><li>z</li></ol><p>t</p></div>',
+    );
+    const c2 = [...container.querySelectorAll('ol ol ol > li')][1];
+    const tail = container.querySelector('p')!;
+    const range = document.createRange();
+    range.setStart(c2.firstChild!, 0);
+    range.setEnd(tail.firstChild!, tail.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    // Outer starts at its first item (no attribute), middle resumes at 2, and
+    // the innermost resumes at 2.
+    expect(html.startsWith('<ol><li>')).toBe(true);
+    expect(html.match(/<ol start="2">/g)?.length).toBe(2);
+  });
+
+  it('numbers four levels of nesting', () => {
+    const container = mount(
+      '<ol><li>L1a</li><li>L1b<ol><li>L2a</li><li>L2b<ol><li>L3a</li><li>L3b<ol><li>L4a</li><li>L4b</li></ol></li></ol></li></ol></li></ol>',
+    );
+    const deepest = [...container.querySelectorAll('ol ol ol ol > li')][1];
+    const range = document.createRange();
+    range.setStart(deepest.firstChild!, 0);
+    range.setEnd(deepest.firstChild!, deepest.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html.match(/<ol start="2">/g)?.length).toBe(4);
+  });
+
+  it('drops the mermaid fullscreen button the viewer injects', () => {
+    const container = mount(
+      '<div class="mermaid-block"><p>Diagram</p><button class="mermaid-block-expand" data-mermaid-source="graph TD">open</button></div>',
+    );
+    const range = document.createRange();
+    range.selectNodeContents(container.querySelector('.mermaid-block')!);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html).not.toContain('mermaid-block-expand');
+    expect(html).toContain('Diagram');
+  });
+
+  it('returns null instead of throwing when serialization fails', () => {
+    // This runs inside resolveSelection on every mouseup: a throw here would
+    // leave the app with no selection at all and the previous one stranded.
+    const container = mount('<ol><li>one</li><li>two</li></ol>');
+    const items = [...container.querySelectorAll('li')];
+    const real = document.createRange();
+    real.setStart(items[0].firstChild!, 0);
+    real.setEnd(items[1].firstChild!, items[1].textContent!.length);
+
+    const hostile = new Proxy(real, {
+      get(target, prop, receiver) {
+        if (prop === 'cloneRange') return () => hostile;
+        if (prop === 'cloneContents') {
+          return () => {
+            throw new Error('serialization blew up');
+          };
+        }
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as Range;
+
+    expect(() => buildRangeHtml(hostile, container)).not.toThrow();
+    expect(buildRangeHtml(hostile, container)).toBeNull();
+    // The transient tag must not survive the failure either.
+    expect(container.querySelector('[data-mdr-copy-list]')).toBeNull();
+  });
+
+  it('unwraps the table scroll wrappers the pipeline injects', () => {
+    const container = mount(
+      '<div class="table-scroll"><div class="table-scroll__viewport"><table><tbody><tr><td>alpha</td></tr></tbody></table></div></div><p>after</p>',
+    );
+    const cell = container.querySelector('td')!;
+    const tail = container.querySelector('p')!;
+    const range = document.createRange();
+    range.setStart(cell.firstChild!, 0);
+    range.setEnd(tail.firstChild!, tail.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html).not.toContain('table-scroll');
+    expect(html.startsWith('<table>')).toBe(true);
+    expect(html).toContain('after');
+  });
+
+  it('keeps table structure', () => {
+    const container = mount(
+      '<table><tbody><tr><td>Autonomous</td><td>EasyMate</td></tr></tbody></table>',
+    );
+    const html = buildRangeHtml(rangeAcross(container, 'td'), container) ?? '';
+    expect(html).toContain('<td>Autonomous</td>');
+    expect(html).toContain('<td>EasyMate</td>');
+  });
+
+  it('rebuilds the table around a partial table selection', () => {
+    // Stray <tr>/<td> at a fragment's top level are dropped by the HTML
+    // fragment parser and their text foster-parented, so the paste would lose
+    // the table entirely.
+    const container = mount(
+      '<table><thead><tr><th>h1</th><th>h2</th></tr></thead><tbody><tr><td>alpha</td><td>beta</td></tr><tr><td>gamma</td><td>delta</td></tr></tbody></table>',
+    );
+    const cells = [...container.querySelectorAll('td')];
+    const range = document.createRange();
+    range.setStart(cells[0].firstChild!, 2);
+    range.setEnd(cells[2].firstChild!, 3);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html.startsWith('<table>')).toBe(true);
+    expect(html).toContain('<tbody>');
+    expect(html).toContain('<td>beta</td>');
+  });
+
+  it('rebuilds the table around a whole-row selection', () => {
+    const container = mount(
+      '<table><tbody><tr><td>alpha</td><td>beta</td></tr><tr><td>gamma</td><td>delta</td></tr></tbody></table>',
+    );
+    const row = container.querySelector('tr')!;
+    const range = document.createRange();
+    range.selectNodeContents(row);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html.startsWith('<table>')).toBe(true);
+    expect(html).toContain('<td>alpha</td>');
+  });
+
+  it('clears an inherited start when the selection begins at item one', () => {
+    // `0.` is valid CommonMark and the pipeline emits <ol start="0">.
+    const container = mount('<ol start="0"><li>z</li><li>a</li><li>b</li></ol>');
+    const items = [...container.querySelectorAll('li')];
+    const range = document.createRange();
+    range.setStart(items[1].firstChild!, 0);
+    range.setEnd(items[2].firstChild!, items[2].textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    // Items "a" and "b" are 1 and 2 in a list numbered from 0, which is the
+    // default numbering, so the inherited start="0" must be cleared entirely.
+    expect(html.startsWith('<ol>')).toBe(true);
+    expect(html).not.toContain('start=');
+  });
+
+  it('copies a value out of one cell as text, not a one-cell table', () => {
+    const container = mount('<table><tbody><tr><td>30s</td><td>other</td></tr></tbody></table>');
+    const cell = container.querySelector('td')!;
+    const range = document.createRange();
+    range.selectNodeContents(cell);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html).toBe('30s');
+  });
+
+  it('copies a partial cell value as text', () => {
+    const container = mount('<table><tbody><tr><td>30s</td><td>other</td></tr></tbody></table>');
+    const cell = container.querySelector('td')!;
+    const range = document.createRange();
+    range.setStart(cell.firstChild!, 0);
+    range.setEnd(cell.firstChild!, 2);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html).toBe('30');
+  });
+
+  it('keeps a header cell selection as text', () => {
+    const container = mount('<table><thead><tr><th>Value</th><th>Unit</th></tr></thead></table>');
+    const cell = container.querySelector('th')!;
+    const range = document.createRange();
+    range.selectNodeContents(cell);
+    expect(buildRangeHtml(range, container)).toBe('Value');
+  });
+
+  it('still rebuilds when two cells are selected', () => {
+    const container = mount('<table><tbody><tr><td>alpha</td><td>beta</td></tr></tbody></table>');
+    const cells = [...container.querySelectorAll('td')];
+    const range = document.createRange();
+    range.setStart(cells[0].firstChild!, 0);
+    range.setEnd(cells[1].firstChild!, cells[1].textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html.startsWith('<table>')).toBe(true);
+    expect(html).toContain('<td>alpha</td>');
+  });
+
+  it('unwraps the app highlight marks', () => {
+    const container = mount(
+      '<p><mark class="comment-highlight">flagged</mark> and <mark class="search-highlight">found</mark></p>',
+    );
+    const html = buildRangeHtml(rangeAcross(container, 'p'), container) ?? '';
+    expect(html).not.toContain('<mark');
+    expect(html).toContain('flagged');
+    expect(html).toContain('found');
+  });
+
+  it('strips viewer chrome that overlaps the selection', () => {
+    const container = mount('<p>kept<span data-drag-handle>handle</span> also kept</p>');
+    const html = buildRangeHtml(rangeAcross(container, 'p'), container) ?? '';
+    expect(html).not.toContain('data-drag-handle');
+    expect(html).toContain('kept');
+  });
+
+  it('spans block boundaries', () => {
+    const container = mount('<div><p>opening line</p><p>closing line</p></div>');
+    const html = buildRangeHtml(rangeAcross(container, 'p'), container) ?? '';
+    expect(html).toContain('<p>opening line</p>');
+    expect(html).toContain('closing line');
+  });
+
+  it('does not widen past a partially selected boundary', () => {
+    const container = mount('<p>keep this <em>drop that</em></p>');
+    const em = container.querySelector('em')!;
+    const range = document.createRange();
+    range.setStart(container.querySelector('p')!.firstChild!, 0);
+    range.setEnd(em.firstChild!, 4);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html).toContain('keep this');
+    expect(html).not.toContain('that');
+  });
+});

--- a/src/lib/copy-selection-html.ts
+++ b/src/lib/copy-selection-html.ts
@@ -1,0 +1,413 @@
+/**
+ * Serializes a document selection as HTML for the clipboard's rich-text flavor.
+ *
+ * Captured at selection time, before the viewer repaints. The rendered view
+ * wraps the pending selection in `mark.selection-highlight`, which replaces the
+ * selected text nodes and collapses the browser's range, so nothing usable
+ * survives to copy time. Snapshotting the range here keeps the rich flavor
+ * independent of whether (or how) the highlight paints.
+ */
+
+/** Highlight wrappers the app paints. None of them are document content. */
+const APP_MARK_SELECTOR =
+  'mark.selection-highlight, mark.comment-highlight, mark.comment-highlight-sent, mark.comment-highlight-active, mark.search-highlight, mark.search-highlight-active';
+
+/** List containers whose items must stay wrapped to paste as a list. */
+const LIST_TAGS = new Set(['UL', 'OL']);
+
+function unwrapAppMarks(root: DocumentFragment | HTMLElement): void {
+  for (const mark of Array.from(root.querySelectorAll(APP_MARK_SELECTOR))) {
+    const parent = mark.parentNode;
+    if (!parent) continue;
+    while (mark.firstChild) parent.insertBefore(mark.firstChild, mark);
+    parent.removeChild(mark);
+  }
+}
+
+/**
+ * UI the viewer injects into the prose. None of it is document content, and a
+ * selection spanning a Mermaid diagram would otherwise carry its fullscreen
+ * button (icon and all) into the paste.
+ */
+const VIEWER_CHROME_SELECTOR = '[data-drag-handle], [data-comment-form], .mermaid-block-expand';
+
+/**
+ * Layout scaffolding the pipeline wraps around content (see
+ * `src/markdown/pipeline.ts`). Unlike viewer chrome these hold the content, so
+ * they are unwrapped rather than removed: a selection running from a table into
+ * the prose after it clones the scroll wrapper as a top-level node, and pasting
+ * app-specific containers into a rich editor is exactly what CONTENT_WRAPPERS
+ * exists to prevent.
+ */
+const LAYOUT_WRAPPER_SELECTOR = '.table-scroll, .table-scroll__viewport';
+
+/** Drop UI the viewer overlays on the prose so it never lands on the clipboard. */
+function stripViewerChrome(root: DocumentFragment | HTMLElement): void {
+  for (const el of Array.from(root.querySelectorAll(VIEWER_CHROME_SELECTOR))) {
+    el.remove();
+  }
+  for (const el of Array.from(root.querySelectorAll(LAYOUT_WRAPPER_SELECTOR))) {
+    const parent = el.parentNode;
+    if (!parent) continue;
+    while (el.firstChild) parent.insertBefore(el.firstChild, el);
+    parent.removeChild(el);
+  }
+}
+
+/**
+ * Elements the boundary walk may climb into. Document structure only: layout
+ * wrappers (the doc sheet, the table scroll box) carry app classes and styles
+ * that have no business on the clipboard, and stopping at them keeps the
+ * snapshot to content the user can see.
+ */
+const CONTENT_WRAPPERS = new Set([
+  'A',
+  'ABBR',
+  'BLOCKQUOTE',
+  'CODE',
+  'DD',
+  'DEL',
+  'DL',
+  'DT',
+  'EM',
+  'FIGCAPTION',
+  'FIGURE',
+  'H1',
+  'H2',
+  'H3',
+  'H4',
+  'H5',
+  'H6',
+  'INS',
+  'KBD',
+  'LI',
+  'MARK',
+  'OL',
+  'P',
+  'PRE',
+  'S',
+  'SMALL',
+  'SPAN',
+  'STRONG',
+  'SUB',
+  'SUP',
+  'TABLE',
+  'TBODY',
+  'TD',
+  'TFOOT',
+  'TH',
+  'THEAD',
+  'TR',
+  'UL',
+]);
+
+function isIgnorable(node: Node): boolean {
+  return node.nodeType === Node.TEXT_NODE && (node.textContent ?? '').trim().length === 0;
+}
+
+function meaningfulChildren(parent: Node): Node[] {
+  return Array.from(parent.childNodes).filter((n) => !isIgnorable(n));
+}
+
+/** Table-internal elements that cannot stand alone at a fragment's top level. */
+const TABLE_SECTIONS = new Set(['TBODY', 'THEAD', 'TFOOT']);
+const TABLE_SCOPED = new Set(['TBODY', 'THEAD', 'TFOOT', 'TR', 'TD', 'TH']);
+
+/**
+ * Rebuild the `<table>` around table-internal nodes left at the fragment's top
+ * level, the same problem `wrapLooseListItems` solves for lists: a selection
+ * that does not cover the whole table clones rows or cells without their table
+ * ancestor. The HTML fragment parser drops stray `<tr>`/`<td>` and
+ * foster-parents their text, so pasting one loses the table entirely.
+ */
+function rebuildTableWrapper(fragment: DocumentFragment, doc: Document): void {
+  const topLevel = meaningfulChildren(fragment);
+  if (topLevel.length === 0) return;
+  if (!topLevel.every((n) => n instanceof Element && TABLE_SCOPED.has(n.tagName))) return;
+
+  const table = doc.createElement('table');
+  let section: Element | null = null;
+  let row: Element | null = null;
+  for (const node of topLevel as Element[]) {
+    if (TABLE_SECTIONS.has(node.tagName)) {
+      table.appendChild(node);
+      section = null;
+      row = null;
+      continue;
+    }
+    if (!section) {
+      section = doc.createElement('tbody');
+      table.appendChild(section);
+    }
+    if (node.tagName === 'TR') {
+      section.appendChild(node);
+      row = null;
+      continue;
+    }
+    if (!row) {
+      row = doc.createElement('tr');
+      section.appendChild(row);
+    }
+    row.appendChild(node);
+  }
+  fragment.appendChild(table);
+}
+
+/**
+ * A selection that lives inside a single cell is a text selection, not a table
+ * selection. Boundary widening lifts it to the enclosing table, so without this
+ * copying one value out of a spec's config table would paste a 1x1 table.
+ * Applies only when the clone holds exactly one cell and nothing else.
+ */
+function unwrapSingleCell(fragment: DocumentFragment): void {
+  const topLevel = meaningfulChildren(fragment);
+  if (topLevel.length !== 1) return;
+  const only = topLevel[0];
+  if (!(only instanceof Element)) return;
+  if (only.tagName !== 'TABLE' && !TABLE_SCOPED.has(only.tagName)) return;
+
+  const cells =
+    only.tagName === 'TD' || only.tagName === 'TH'
+      ? [only]
+      : Array.from(only.querySelectorAll('td, th'));
+  if (cells.length !== 1) return;
+  const cell = cells[0];
+  if ((only.textContent ?? '').trim() !== (cell.textContent ?? '').trim()) return;
+
+  while (fragment.firstChild) fragment.removeChild(fragment.firstChild);
+  while (cell.firstChild) fragment.appendChild(cell.firstChild);
+}
+
+/**
+ * A range across list items clones to bare `<li>` elements when the `<ul>` sits
+ * above the range's common ancestor. Rich-text targets need the list container
+ * to render them as a list, so put it back. An ordered list also carries its
+ * numbering across: copying items 3 through 5 pastes as 3, 4, 5 rather than
+ * restarting at 1.
+ */
+function wrapLooseListItems(
+  fragment: DocumentFragment,
+  doc: Document,
+  source: Element,
+): Element | null {
+  const topLevel = meaningfulChildren(fragment);
+  const leading: Node[] = [];
+  for (const node of topLevel) {
+    if (node.nodeType !== Node.ELEMENT_NODE || (node as Element).tagName !== 'LI') break;
+    leading.push(node);
+  }
+  if (leading.length === 0) return null;
+
+  // Only the leading run is re-wrapped: a selection can run out of a list and
+  // into the paragraph below it, and those trailing blocks are not list items.
+  const list = doc.createElement(source.tagName.toLowerCase());
+  fragment.insertBefore(list, leading[0]);
+  for (const node of leading) list.appendChild(node);
+  return list;
+}
+
+/**
+ * Carry an ordered list's numbering across, so copying items 3 through 5
+ * pastes as 3, 4, 5 rather than restarting at 1. Runs after any re-wrap,
+ * because the list element reaches the fragment two different ways: cloned
+ * along with the range when the selection ends on the list's last item, or
+ * rebuilt by wrapLooseListItems when it does not.
+ *
+ * The offset comes from the source item the range started in, not from
+ * matching text: a selection that starts mid-item clones a partial string,
+ * and two items can read identically.
+ */
+function restoreOrderedStart(
+  list: Element | null,
+  source: Element | null,
+  startItem: Element | null,
+): void {
+  if (!list || !source || list.tagName !== 'OL' || source.tagName !== 'OL') return;
+
+  const items = Array.from(source.children).filter((el) => el.tagName === 'LI');
+  const offset = startItem ? items.indexOf(startItem) : -1;
+  const parsed = Number.parseInt(source.getAttribute('start') ?? '1', 10);
+  const sourceStart = Number.isFinite(parsed) ? parsed : 1;
+  const start = sourceStart + Math.max(0, offset);
+  // The clone may already carry the source's `start`, so 1 has to clear it
+  // rather than fall through: a `0.` list (valid CommonMark, and what the
+  // pipeline emits) would otherwise keep numbering from 0.
+  if (start === 1) list.removeAttribute('start');
+  else list.setAttribute('start', String(start));
+}
+
+/**
+ * Climb from a boundary through every ancestor the selection starts (or ends)
+ * flush against. `cloneContents` only reproduces ancestors the range crosses,
+ * so a link or heading wrapped tightly around the selected text would otherwise
+ * be flattened to bare words. Stopping at the first ancestor the boundary is
+ * not flush against keeps unselected content out of the range.
+ */
+function expandBoundaries(range: Range, container: Element): void {
+  const startNode = range.startContainer;
+  const startFlush =
+    startNode.nodeType === Node.TEXT_NODE
+      ? (startNode.textContent ?? '').slice(0, range.startOffset).trim().length === 0
+      : range.startOffset === 0;
+  if (startFlush) {
+    let node: Node = startNode;
+    while (
+      node.parentElement &&
+      node.parentElement !== container &&
+      CONTENT_WRAPPERS.has(node.parentElement.tagName) &&
+      meaningfulChildren(node.parentElement)[0] === node
+    ) {
+      node = node.parentElement;
+    }
+    if (node !== startNode) range.setStartBefore(node);
+  }
+
+  const endNode = range.endContainer;
+  const endFlush =
+    endNode.nodeType === Node.TEXT_NODE
+      ? (endNode.textContent ?? '').slice(range.endOffset).trim().length === 0
+      : range.endOffset === endNode.childNodes.length;
+  if (endFlush) {
+    let node: Node = endNode;
+    while (
+      node.parentElement &&
+      node.parentElement !== container &&
+      CONTENT_WRAPPERS.has(node.parentElement.tagName)
+    ) {
+      const siblings = meaningfulChildren(node.parentElement);
+      if (siblings[siblings.length - 1] !== node) break;
+      node = node.parentElement;
+    }
+    if (node !== endNode) range.setEndAfter(node);
+  }
+}
+
+/** Transient attribute used to find a source list's clone. Never serialized. */
+const CLONE_MARK = 'data-mdr-copy-list';
+
+/** A list the selection passes through, paired with the item it starts at. */
+interface ListLevel {
+  list: Element;
+  item: Element;
+}
+
+/**
+ * Every list the range's start sits inside, outermost first, each paired with
+ * the item at that list's own level.
+ *
+ * Nesting is arbitrarily deep and every level carries its own numbering, so
+ * this walks the whole chain rather than modelling a fixed outer/inner pair —
+ * a two-slot model silently drops the numbering of any list between the two.
+ */
+function collectListLevels(range: Range, container: Element): ListLevel[] {
+  const { startContainer, startOffset } = range;
+  const atBoundary =
+    startContainer.nodeType === Node.ELEMENT_NODE
+      ? (startContainer.childNodes[startOffset] ?? startContainer)
+      : startContainer;
+  const host = atBoundary instanceof Element ? atBoundary : (atBoundary?.parentElement ?? null);
+
+  const levels: ListLevel[] = [];
+  let item = host?.closest('li') ?? null;
+  while (item && container.contains(item)) {
+    const list = item.parentElement?.closest('ul, ol') ?? null;
+    if (!list || !container.contains(list)) break;
+    levels.unshift({ list, item });
+    item = list.parentElement?.closest('li') ?? null;
+  }
+  return levels;
+}
+
+/**
+ * The list that owns the fragment's top-level items. `cloneContents` puts the
+ * widened range's common ancestor's children at the top level, so that
+ * ancestor decides which list the clone's loose items belong to. Reading it
+ * off the range's innermost item instead would re-wrap a nested selection in
+ * the sublist's tag, pasting a bullet list as a numbered one.
+ */
+function owningList(range: Range): Element | null {
+  const common = range.commonAncestorContainer;
+  const commonEl =
+    common.nodeType === Node.ELEMENT_NODE ? (common as Element) : common.parentElement;
+  if (!commonEl) return null;
+  if (LIST_TAGS.has(commonEl.tagName)) return commonEl;
+
+  const startEl =
+    range.startContainer.nodeType === Node.ELEMENT_NODE
+      ? ((range.startContainer.childNodes[range.startOffset] ?? range.startContainer) as Element)
+      : range.startContainer.parentElement;
+  let node: Element | null = startEl instanceof Element ? startEl : null;
+  while (node && node.parentElement !== commonEl) node = node.parentElement;
+  return node && LIST_TAGS.has(node.tagName) ? node : null;
+}
+
+/**
+ * Snapshot `range` as clipboard-ready HTML, or null when it holds no markup
+ * worth carrying. Never mutates the live document beyond a transient tag that
+ * is always removed: the passed range is cloned before its boundaries widen.
+ *
+ * Never throws. This runs inside `resolveSelection` on every mouseup, so a
+ * failure here would leave the app without a selection at all — no pill, no
+ * comment form, and the previous selection stranded in state for the next
+ * Cmd+Enter to anchor against. The rich clipboard flavor is a nicety; losing
+ * it silently is the right trade against losing the core interaction.
+ */
+export function buildRangeHtml(range: Range, container: Element | null): string | null {
+  try {
+    return serializeRange(range, container);
+  } catch {
+    return null;
+  }
+}
+
+function serializeRange(range: Range, container: Element | null): string | null {
+  if (!container) return null;
+  const doc = container.ownerDocument;
+  if (!doc) return null;
+
+  let working: Range;
+  try {
+    working = range.cloneRange();
+    expandBoundaries(working, container);
+  } catch {
+    return null;
+  }
+
+  // A source list's counterpart inside the clone cannot be found by search:
+  // nesting, partial ancestors and dropped leading siblings all move it. Tag
+  // each level for the duration of the clone instead. The attribute is removed
+  // from the live document in a finally, and from the clone before serializing.
+  const levels = collectListLevels(working, container);
+  levels.forEach(({ list }, depth) => list.setAttribute(CLONE_MARK, String(depth)));
+  let fragment: DocumentFragment;
+  try {
+    fragment = working.cloneContents();
+  } finally {
+    for (const { list } of levels) list.removeAttribute(CLONE_MARK);
+  }
+  unwrapAppMarks(fragment);
+  stripViewerChrome(fragment);
+
+  // The outermost list's items can be the fragment's top-level nodes, in which
+  // case the list element itself was never cloned and has to be rebuilt.
+  const wrapList = owningList(working);
+  const rebuilt = wrapList ? wrapLooseListItems(fragment, doc, wrapList) : null;
+  rebuildTableWrapper(fragment, doc);
+  unwrapSingleCell(fragment);
+
+  // Every level the selection passes through carries its own numbering.
+  levels.forEach(({ list, item }, depth) => {
+    const clone =
+      fragment.querySelector(`[${CLONE_MARK}="${depth}"]`) ?? (list === wrapList ? rebuilt : null);
+    restoreOrderedStart(clone, list, item);
+  });
+
+  for (const marked of Array.from(fragment.querySelectorAll(`[${CLONE_MARK}]`))) {
+    marked.removeAttribute(CLONE_MARK);
+  }
+
+  const holder = doc.createElement('div');
+  holder.appendChild(fragment);
+  const html = holder.innerHTML.trim();
+  return html.length > 0 ? html : null;
+}

--- a/src/lib/copy-selection.test.ts
+++ b/src/lib/copy-selection.test.ts
@@ -35,6 +35,45 @@ describe('getCopySelectionFallbackText', () => {
     ).toBeNull();
   });
 
+  it('applies in the comment composer when its caret is collapsed', () => {
+    expect(
+      getCopySelectionFallbackText({
+        nativeSelectionText: '',
+        viewerSelectionText: 'Selected review text',
+        activeElement: { tagName: 'TEXTAREA', isContentEditable: false },
+        viewMode: 'rendered',
+        inCommentComposer: true,
+        composerCaretCollapsed: true,
+      }),
+    ).toBe('Selected review text');
+  });
+
+  it('leaves the native copy alone when text is selected inside the composer', () => {
+    expect(
+      getCopySelectionFallbackText({
+        nativeSelectionText: '',
+        viewerSelectionText: 'Selected review text',
+        activeElement: { tagName: 'TEXTAREA', isContentEditable: false },
+        viewMode: 'rendered',
+        inCommentComposer: true,
+        composerCaretCollapsed: false,
+      }),
+    ).toBeNull();
+  });
+
+  it('does not treat other textareas as the composer', () => {
+    expect(
+      getCopySelectionFallbackText({
+        nativeSelectionText: '',
+        viewerSelectionText: 'Selected review text',
+        activeElement: { tagName: 'TEXTAREA', isContentEditable: false },
+        viewMode: 'rendered',
+        inCommentComposer: false,
+        composerCaretCollapsed: true,
+      }),
+    ).toBeNull();
+  });
+
   it('does not apply outside rendered mode', () => {
     expect(
       getCopySelectionFallbackText({

--- a/src/lib/copy-selection.ts
+++ b/src/lib/copy-selection.ts
@@ -3,6 +3,10 @@ interface CopySelectionFallbackOptions {
   viewerSelectionText: string | null;
   activeElement: { tagName?: string | null; isContentEditable?: boolean | null } | null;
   viewMode: string;
+  /** True when focus sits in the comment composer's textarea. */
+  inCommentComposer?: boolean;
+  /** True when that textarea has no selection of its own (a plain caret). */
+  composerCaretCollapsed?: boolean;
 }
 
 export function getCopySelectionFallbackText({
@@ -10,6 +14,8 @@ export function getCopySelectionFallbackText({
   viewerSelectionText,
   activeElement,
   viewMode,
+  inCommentComposer = false,
+  composerCaretCollapsed = false,
 }: CopySelectionFallbackOptions): string | null {
   if (viewMode !== 'rendered') return null;
   if (nativeSelectionText.trim().length > 0) return null;
@@ -17,7 +23,11 @@ export function getCopySelectionFallbackText({
   const tagName = activeElement?.tagName?.toUpperCase();
   const isEditable =
     activeElement?.isContentEditable === true || tagName === 'INPUT' || tagName === 'TEXTAREA';
-  if (isEditable) return null;
+  // Quick comment focuses the composer the moment a selection is made, so a
+  // bare caret there still means "copy what I highlighted in the document".
+  // Text selected inside the composer keeps the native copy.
+  const isComposerCaret = inCommentComposer && composerCaretCollapsed;
+  if (isEditable && !isComposerCaret) return null;
 
   const text = viewerSelectionText?.trim();
   return text && text.length > 0 ? text : null;

--- a/src/lib/path-utils.test.ts
+++ b/src/lib/path-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getPathBasename, tildeShortenPath } from './path-utils';
+import { getParentDir, getPathBasename, tildeShortenPath } from './path-utils';
 
 describe('getPathBasename', () => {
   it('returns the basename for POSIX paths', () => {
@@ -53,5 +53,32 @@ describe('tildeShortenPath', () => {
 
   it('replaces a leading Windows-style home dir prefix with ~', () => {
     expect(tildeShortenPath('C:\\Users\\dennisju\\dev', 'C:\\Users\\dennisju')).toBe('~\\dev');
+  });
+});
+
+describe('getParentDir', () => {
+  it('returns the directory for a POSIX path', () => {
+    expect(getParentDir('/Users/dennis/docs/spec.md')).toBe('/Users/dennis/docs');
+  });
+
+  it('returns the root for a file directly under it', () => {
+    expect(getParentDir('/spec.md')).toBe('/');
+  });
+
+  it('handles Windows separators', () => {
+    expect(getParentDir('C:\\docs\\spec.md')).toBe('C:\\docs');
+  });
+
+  it('keeps the separator on a drive root', () => {
+    expect(getParentDir('C:\\spec.md')).toBe('C:\\');
+  });
+
+  it('returns an empty string when there is no directory part', () => {
+    expect(getParentDir('spec.md')).toBe('');
+    expect(getParentDir('')).toBe('');
+  });
+
+  it('ignores a trailing separator', () => {
+    expect(getParentDir('/Users/dennis/docs/')).toBe('/Users/dennis');
   });
 });

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -27,3 +27,21 @@ export function tildeShortenPath(path: string, homeDir: string): string {
   }
   return path;
 }
+
+/**
+ * Directory portion of a path, for both POSIX and Windows separators.
+ * Returns an empty string when the path has no directory part, so callers can
+ * tell "no parent" from "the root". A POSIX root (`/`) is its own parent; a
+ * bare drive (`C:\`) has no parent and returns an empty string.
+ */
+export function getParentDir(path: string): string {
+  if (!path) return '';
+  const trimmed = path.replace(/[\\/]+$/, '');
+  if (!trimmed) return path.slice(0, 1);
+  const lastSep = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+  if (lastSep < 0) return '';
+  if (lastSep === 0) return trimmed.slice(0, 1);
+  // A drive root keeps its separator: "C:\\file.md" -> "C:\\".
+  const parent = trimmed.slice(0, lastSep);
+  return /^[A-Za-z]:$/.test(parent) ? parent + trimmed[lastSep] : parent;
+}

--- a/src/lib/selection-resolver.ts
+++ b/src/lib/selection-resolver.ts
@@ -1,4 +1,5 @@
 import type { SelectionInfo } from '../types';
+import { buildRangeHtml } from './copy-selection-html';
 import { getVisibleTextContent, getVisibleTextOffset } from './visible-text';
 
 export function resolveSelection(containerEl: HTMLElement): SelectionInfo | null {
@@ -29,6 +30,7 @@ export function resolveSelection(containerEl: HTMLElement): SelectionInfo | null
 
   return {
     text,
+    html: buildRangeHtml(range, containerEl) ?? undefined,
     rect,
     contextBefore,
     contextAfter,

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -114,6 +114,38 @@ describe('parseSettings docWidth', () => {
   });
 });
 
+describe('parseSettings superseded default template set', () => {
+  const supersededDefaults = [
+    { label: 'Rewrite this', text: 'Rewrite this section to make it clearer.' },
+    { label: 'Add detail', text: 'Add more detail here.' },
+    { label: 'Remove', text: 'Remove this; it is not needed.' },
+    { label: 'Needs example', text: 'Add an example to illustrate this.' },
+    { label: 'Too vague', text: 'This is too vague. Be more specific.' },
+    { label: 'Fix formatting', text: 'Fix the formatting in this section.' },
+    { label: 'Factually wrong', text: 'This is factually incorrect. Please verify and correct.' },
+    { label: 'Out of scope', text: 'This is out of scope. Remove it or move it to a separate doc.' },
+  ];
+
+  it('replaces an untouched old default set with the current defaults', () => {
+    expect(parseSettings({ templates: supersededDefaults }).templates).toEqual(DEFAULT_TEMPLATES);
+  });
+
+  it('leaves the list alone once any template was customized', () => {
+    const customized = [
+      ...supersededDefaults.slice(0, 7),
+      { label: 'Out of scope', text: 'Move this to the appendix.' },
+    ];
+    expect(parseSettings({ templates: customized }).templates).toEqual(customized);
+  });
+
+  it('upgrades the em-dash era default set all the way to the current defaults', () => {
+    const emDashEra = supersededDefaults.map((t) =>
+      t.label === 'Too vague' ? { ...t, text: 'This is too vague — be more specific.' } : t,
+    );
+    expect(parseSettings({ templates: emDashEra }).templates).toEqual(DEFAULT_TEMPLATES);
+  });
+});
+
 describe('parseSettings legacy template migration', () => {
   it('rewrites persisted copies of the old em-dash default texts', () => {
     const parsed = parseSettings({

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -34,7 +34,27 @@ export interface AppSettings {
   proseSize: ProseSize;
 }
 
+/**
+ * Shipped templates. The first two are the one-tap pills on the selection
+ * pill, so the two most-used verdicts lead: approve, then rewrite.
+ */
 export const DEFAULT_TEMPLATES: CommentTemplate[] = [
+  { label: 'Agreed', text: 'Agreed with this. No change needed here.' },
+  { label: 'Rewrite this', text: 'Rewrite this section to make it clearer and more specific.' },
+  { label: 'Add detail', text: 'Add more detail here.' },
+  { label: 'Remove', text: 'Remove this; it is not needed.' },
+  { label: 'Needs example', text: 'Add an example to illustrate this.' },
+  { label: 'Why this?', text: 'Why this approach over the alternatives? Explain the reasoning.' },
+  { label: 'Factually wrong', text: 'This is factually incorrect. Please verify and correct.' },
+  { label: 'Out of scope', text: 'This is out of scope. Remove it or move it to a separate doc.' },
+];
+
+/**
+ * The pre-2026-07-28 shipped set (post-em-dash cleanup). A stored list that
+ * still matches this exactly is an untouched default, so it is replaced with
+ * the current defaults at parse time; any customization keeps the list as-is.
+ */
+const SUPERSEDED_DEFAULT_TEMPLATES: CommentTemplate[] = [
   { label: 'Rewrite this', text: 'Rewrite this section to make it clearer.' },
   { label: 'Add detail', text: 'Add more detail here.' },
   { label: 'Remove', text: 'Remove this; it is not needed.' },
@@ -44,6 +64,17 @@ export const DEFAULT_TEMPLATES: CommentTemplate[] = [
   { label: 'Factually wrong', text: 'This is factually incorrect. Please verify and correct.' },
   { label: 'Out of scope', text: 'This is out of scope. Remove it or move it to a separate doc.' },
 ];
+
+function isSupersededDefaultSet(templates: CommentTemplate[]): boolean {
+  return (
+    templates.length === SUPERSEDED_DEFAULT_TEMPLATES.length &&
+    templates.every(
+      (t, i) =>
+        t.label === SUPERSEDED_DEFAULT_TEMPLATES[i].label &&
+        t.text === SUPERSEDED_DEFAULT_TEMPLATES[i].text,
+    )
+  );
+}
 
 /**
  * Earlier default template texts, upgraded in place at parse time. Only
@@ -101,8 +132,9 @@ export function parseSettings(input: unknown): AppSettings {
           return upgraded ? { ...template, text: upgraded } : template;
         })
     : DEFAULT_SETTINGS.templates;
+  const templates = validTemplates as CommentTemplate[];
   return {
-    templates: validTemplates as CommentTemplate[],
+    templates: isSupersededDefaultSet(templates) ? DEFAULT_TEMPLATES : templates,
     commentMaxLength:
       typeof parsed.commentMaxLength === 'number' && parsed.commentMaxLength > 0
         ? parsed.commentMaxLength

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,11 @@ export interface ParseResult {
 
 export interface SelectionInfo {
   text: string;
+  /**
+   * The selection serialized as HTML, snapshotted before the viewer's highlight
+   * repaint destroys the range. Feeds the clipboard's rich-text flavor.
+   */
+  html?: string;
   rect: DOMRect;
   contextBefore: string;
   contextAfter: string;


### PR DESCRIPTION
Six reported problems, each with its own commit.

**The settings gear was pushed out of the sidebar by a long file list.** The explorer panel sized itself `h-full` inside the sidebar's flex column, so it claimed the full panel height on top of the rows above it and overflowed the bottom. It is now `flex-1 min-h-0`, so a long listing scrolls inside the panel.

**"Reveal in Explorer Sidebar" did nothing when the explorer already sat in the target directory.** The menu item only set the explorer's directory, which had not changed, so nothing re-browsed. `revealDirInExplorer` now bumps a nonce the panel re-browses on. A reveal applies exactly once, the revealed row scrolls into view and flashes when it is not the active file, and consumption is owned by `App` because the panel unmounts on every sidebar toggle, Outline switch and focus-mode entry. Parent directories are derived through one separator-aware helper, so this also works on Windows paths and for a file at the root, where the old `lastIndexOf('/')` left the item permanently disabled.

**Cmd/Ctrl+C copied nothing with Quick comment on, and lost all formatting otherwise.** The viewer paints the pending selection as `mark.selection-highlight`, which replaces the selected text nodes and collapses the browser's range, so a native copy has nothing to serialize. The fallback now fires when focus sits in the comment composer with a collapsed caret, and `buildRangeHtml` snapshots the selection as HTML at selection time, before the repaint destroys the range. Pastes keep headings, bold, links, list nesting with per-level numbering, and tables. Right-click Copy writes the same two flavors.

**Selecting a multi-block region painted no highlight, and commenting on it immediately reported a lost anchor.** `stripInlineFormatting` reads markdown source syntax, so on an anchor captured from rendered text it took the `1. ` opening a heading like `## 1. Current Strategy` for an ordered-list marker and dropped it. The flexible-whitespace search on the original text now runs ahead of the stripped tier, hint aware and bounded.

**Anchors crossing a table were flagged as orphans.** `detectMissingAnchors` searches the markdown source, where the anchor runs into cell pipes the reader never sees. Structural markdown is now skipped between anchor words, restricted to line starts and cell separators so visible punctuation is not mistaken for markup.

**The default comment templates had no way to express agreement.** Added `Agreed` in the first one-tap pill slot and `Why this?`, dropped `Fix formatting`, folded `Too vague` into `Rewrite this`. Stored lists that still match the previous defaults migrate; any customization is left untouched.

## Testing

`tsc -b`, lint, build and `eval:dry` clean. 1530 unit tests and the full 305-test e2e suite pass. Every commit typechecks and passes tests on its own, so the history is bisectable. The three failures in `server/mcp-stdio-subprocess.test.ts` that appear intermittently also fail on `main`.

New coverage: a clipboard serializer suite including nested-list numbering, partial tables and single cells; explorer reveal tests covering consume-once, remount, stale listings and the flash lifecycle; anchor tier and orphan matcher regressions; and an e2e spec that intercepts the copy event to assert both clipboard flavors.

## Notes for review

`AGENTS.md` documents the reveal ownership model, the clipboard serialization rules, the anchor matching tiers and the orphan matcher's tolerances.

Two follow-ups are deliberately not in this PR: a selection running from a table into the paragraph after it pastes the rows as flattened text, and an anchor spanning an image is reported orphaned because `stripInlineFormatting` drops alt text (which reproduces on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)