### PR TITLE
fix: run document body copy at full ink, split emphasis on dark themes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -711,10 +711,69 @@ Note on templates: the default template texts contain no em-dashes; `parseSettin
 Light: light, sepia, solarized, github. Dark: dark, nord, rose-pine, catppuccin. System follows OS.
 The default light and dark themes use a red-pen palette (warm neutrals, crimson accent).
 The document viewer renders on a raised sheet via the `.doc-sheet` class, with the shadow
-value supplied per-theme through `--theme-sheet-shadow`. Rendered code blocks (`pre`) use
-`--theme-code-text`, falling back to `--theme-text-secondary` when a theme doesn't set it;
-the dark theme sets it to `#cdc6b9`, a step brighter than its secondary text color, so code
-stays readable against `--theme-bg-inset`. Other themes are unaffected.
+value supplied per-theme through `--theme-sheet-shadow`. Rendered code blocks (`pre`) and
+raw-view fenced code use `--theme-code-text`, falling back to `--theme-text` so that a theme
+setting no value renders code at the same strength as the prose around it. No theme
+currently overrides it.
+
+Document body copy runs at full ink in every theme and both views: `--tw-prose-body` is
+`--theme-text` (not `--theme-text-secondary`), and `.raw-line-content` / `.raw-table` match.
+Emphasis is carried by weight, not color: `--tw-prose-bold` falls back to `--theme-text`, so
+bold and body are the same color unless a theme opts out. Light themes take that default
+unchanged, at the typography plugin's stock 400/600.
+
+The four dark themes opt out, because light-on-dark text blooms: strokes optically thicken,
+which compresses the 400/600 gap until bold stops reading as bold. The effect is worse here
+than in the sans-set readers that ship weight-only emphasis, since a serif at 600 thickens
+its stems but leaves hairlines thin. Dark themes therefore split the difference across both
+channels rather than pushing either hard, via four tokens set in each theme's own block:
+
+| Token | Default when unset | Dark themes |
+| --- | --- | --- |
+| `--theme-prose-bold` | `--theme-text` | one step brighter than `--theme-text` |
+| `--theme-prose-body-weight` | 400 | 350 |
+| `--theme-prose-bold-weight` | 600 | 780 |
+| `--theme-raw-bold-weight` | 600 | 700 |
+
+Measured ink coverage is 1.68x body against 1.19x for stock. Source Serif 4 is a variable
+face, so the off-scale weights cost no extra file. Adding a theme therefore needs no changes
+outside its own token block: the rules that consume these are unconditional, with the stock
+pair as the `var()` fallback, so a theme that sets none of them gets plugin defaults.
+
+`--theme-raw-bold-weight` is separate because the source view is 13px mono, where the
+rendered view's 780 is too heavy and its 350 body goes spindly; raw line content stays at
+400 in every theme. Counters, bullets, captions, and `.raw-blockquote` track
+`--theme-text-secondary` rather than `--theme-text-muted`: muted falls under 3.5:1 on the
+Nord, Rosé Pine, and Catppuccin backgrounds, which was tolerable when body was dimmed too
+and is not now.
+
+Both weight rules are scoped, and the scoping is load-bearing rather than cosmetic.
+Blockquote paragraphs keep the plugin's 500 body weight: that block is italic as a whole,
+and italics carry less ink than roman at the same weight, so the plugin pays the difference
+back in weight. Inline `em` is deliberately not exempt, since lifting it alone would make
+italic phrases heavier than the roman text around them.
+
+Headings are the only block with a `strong` ladder of its own in the plugin (h1 900 down
+through h4 700), so `strong` inside `h1`–`h4` is excluded from the body bold weight and
+keeps that ladder; applied flat, the rule drags `# Title **bold**` down to 600 inside a 700
+heading and renders emphasis *lighter* than the text around it. Blockquotes and `thead th`
+are deliberately **not** excluded even though the plugin has `strong` rules for them: those
+rules set `color: inherit` only, with no weight, so there is no ladder to defer to and
+excluding them leaves bold in a quote or a table header identical to its surroundings.
+
+Comment and selection highlights pin their text to `--theme-text` so it stays legible on the
+amber fill. Because bold now sits a step *above* full ink on the dark themes, that pin is
+scoped back off `strong`: an anchor covering exactly a bold run nests the `mark` inside the
+`<strong>` where the pin would win, while an anchor spilling past it nests the other way, so
+without the exception the same phrase renders two different colors depending on how far the
+selection ran.
+
+`e2e/prose-emphasis.spec.ts` asserts the dark-theme values by direction (body thinner than
+stock, bold heavier and tonally above body) rather than by number, so retuning 350/780/700
+does not require editing tests. The plugin's own stock values are asserted literally, since
+changing those means the plugin changed under us and the test should say so.
+`e2e/drag-regression.spec.ts` covers the reflow side: switching theme or typeface must not
+strand the drag handles away from their mark.
 
 Document links in rendered prose are ink-colored with a quiet accent-colored underline
 (`--theme-accent` at 45% via `color-mix`), switching to crimson only on hover; raw-view

--- a/e2e/drag-regression.spec.ts
+++ b/e2e/drag-regression.spec.ts
@@ -13,7 +13,7 @@ import { writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { FORMATTED_DOC_BASELINE } from './helpers/fixture-baselines';
-import { resetTestAppState } from './helpers/test-state';
+import { clearPersistedPreferences, resetTestAppState } from './helpers/test-state';
 import { withMod } from './helpers/shortcuts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -27,6 +27,10 @@ test.beforeEach(async ({ page }) => {
 
 test.afterAll(() => {
   writeFileSync(FIXTURE, FIXTURE_ORIGINAL);
+  // The theme and typeface tests below persist their settings server-side, and
+  // the prefs file is shared across specs. Later specs that do not reset in
+  // beforeEach would otherwise boot into Dark and Sans.
+  clearPersistedPreferences();
 });
 
 async function openFixture(page: Page) {
@@ -257,5 +261,90 @@ test.describe('Drag handles reposition on container resize', () => {
     // edge (both offset by a couple px for the handle's own width/inset).
     expect(Math.abs(startBox!.x - markBox!.x)).toBeLessThanOrEqual(8);
     expect(Math.abs(endBox!.x - (markBox!.x + markBox!.width))).toBeLessThanOrEqual(8);
+  });
+
+  /**
+   * Each handle sits at a fixed inset from its end of the mark, so the
+   * invariant across a reflow is that the gap is preserved. Asserting absolute
+   * proximity instead needs a tolerance wider than the drift being guarded
+   * against, and passes with the handles frozen.
+   *
+   * Measured against the mark's first and last client rects, which is what
+   * computePositions itself uses. The union bounding box would agree only while
+   * the anchor stays on one line: if it ever wraps, x and width change meaning
+   * and both gaps jump by tens of px on correct code. rectCount is returned so
+   * a wrap shows up in the failure message instead of looking like drift.
+   */
+  async function handleGaps(page: Page) {
+    return page.evaluate(() => {
+      const mark = document.querySelector('mark.comment-highlight-active');
+      const handles = document.querySelectorAll('[data-drag-handle]');
+      if (!mark || handles.length < 2) throw new Error('mark or handles missing');
+      const rects = mark.getClientRects();
+      const first = rects[0];
+      const last = rects[rects.length - 1];
+      const start = handles[0].getBoundingClientRect();
+      const end = handles[handles.length - 1].getBoundingClientRect();
+      return {
+        start: start.left - first.left,
+        end: end.left - last.right,
+        rectCount: rects.length,
+      };
+    });
+  }
+
+  async function commentAndActivate(page: Page, label: string) {
+    await openFixture(page);
+    await addComment(page, 'followed by regular text', label);
+    await getCard(page, label).click();
+    await expect(page.locator('[data-drag-handle]')).toHaveCount(2);
+    await stableHandlePositions(page);
+  }
+
+  // Presentation attributes reflow the text under the marks without resizing
+  // any observed box, so neither the scroll listener nor the ResizeObserver
+  // fires. Both cases below leave the handles parked at their old x without the
+  // presentation observer in useDragHandles.
+  test('handles stay aligned with the mark after switching to a dark theme', async ({ page }) => {
+    await commentAndActivate(page, 'Theme reposition test');
+    const before = await handleGaps(page);
+
+    // Dark themes set their own body and bold font-weights.
+    await page.keyboard.press(withMod('k'));
+    await page.getByPlaceholder('Type a command...').fill('Theme: Dark');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('[data-theme="dark"]')).toBeVisible();
+    await stableHandlePositions(page);
+
+    const after = await handleGaps(page);
+    // Repositioning derives both handles from the same rects the assertion
+    // reads, so the correct-path delta is 0. The tolerance only absorbs
+    // subpixel rounding; the drift it guards against is 1-9px.
+    expect(after.rectCount).toBe(before.rectCount);
+    expect(Math.abs(after.start - before.start)).toBeLessThanOrEqual(0.25);
+    expect(Math.abs(after.end - before.end)).toBeLessThanOrEqual(0.25);
+  });
+
+  test('handles stay aligned with the mark after switching the prose typeface', async ({
+    page,
+  }) => {
+    await commentAndActivate(page, 'Typeface reposition test');
+    const before = await handleGaps(page);
+
+    // Serif to sans is a bigger metric change than any weight swap, and it
+    // lands on a different element and attribute than the theme does.
+    await page.locator('button[title*="Settings"]').click();
+    await page.getByRole('button', { name: 'Sans', exact: true }).click();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('[data-prose-font="sans"]')).toBeVisible();
+    await stableHandlePositions(page);
+
+    const after = await handleGaps(page);
+    // Repositioning derives both handles from the same rects the assertion
+    // reads, so the correct-path delta is 0. The tolerance only absorbs
+    // subpixel rounding; the drift it guards against is 1-9px.
+    expect(after.rectCount).toBe(before.rectCount);
+    expect(Math.abs(after.start - before.start)).toBeLessThanOrEqual(0.25);
+    expect(Math.abs(after.end - before.end)).toBeLessThanOrEqual(0.25);
   });
 });

--- a/e2e/fixtures/baselines/emphasis-doc.md
+++ b/e2e/fixtures/baselines/emphasis-doc.md
@@ -1,0 +1,22 @@
+# Emphasis Fixture
+
+**Lead-in claim.** Body copy follows the claim and runs long enough to wrap
+across a couple of lines in the rendered column.
+
+## Section with **bold inside the heading**
+
+- List item with **bold inside it**
+- Second item for the ordered sibling below
+
+1. Numbered item, so counters render
+2. Second numbered item
+
+> Quoted passage with **bold inside the quote**.
+
+| Column | Header with **bold** |
+| --- | --- |
+| Row | Cell text with **bold inside it** |
+
+```js
+const codeBlock = 'fenced code renders at code ink';
+```

--- a/e2e/fixtures/emphasis-doc.md
+++ b/e2e/fixtures/emphasis-doc.md
@@ -1,0 +1,22 @@
+# Emphasis Fixture
+
+**Lead-in claim.** Body copy follows the claim and runs long enough to wrap
+across a couple of lines in the rendered column.
+
+## Section with **bold inside the heading**
+
+- List item with **bold inside it**
+- Second item for the ordered sibling below
+
+1. Numbered item, so counters render
+2. Second numbered item
+
+> Quoted passage with **bold inside the quote**.
+
+| Column | Header with **bold** |
+| --- | --- |
+| Row | Cell text with **bold inside it** |
+
+```js
+const codeBlock = 'fenced code renders at code ink';
+```

--- a/e2e/helpers/fixture-baselines.ts
+++ b/e2e/helpers/fixture-baselines.ts
@@ -16,3 +16,4 @@ export const TOC_DOC_BASELINE = readBaseline('toc-doc.md');
 export const HIGHLIGHT_SEAM_DOC_BASELINE = readBaseline('highlight-seam-doc.md');
 export const TABLE_DUPLICATES_DOC_BASELINE = readBaseline('table-duplicates-doc.md');
 export const ANCHOR_EDGE_CASES_DOC_BASELINE = readBaseline('anchor-edge-cases-doc.md');
+export const EMPHASIS_DOC_BASELINE = readBaseline('emphasis-doc.md');

--- a/e2e/helpers/test-state.ts
+++ b/e2e/helpers/test-state.ts
@@ -13,3 +13,13 @@ export async function resetTestAppState(page: Page) {
   rmSync(prefsFile, { force: true });
   await page.goto('/');
 }
+
+/**
+ * Drop persisted preferences without needing a page. Specs that change a
+ * persisted setting (theme, prose font) should call this in `afterAll`: the
+ * prefs file is shared and workers is 1, so whatever they leave behind is what
+ * later specs boot into, and not every spec resets in `beforeEach`.
+ */
+export function clearPersistedPreferences() {
+  rmSync(prefsFile, { force: true });
+}

--- a/e2e/prose-emphasis.spec.ts
+++ b/e2e/prose-emphasis.spec.ts
@@ -1,0 +1,307 @@
+import { test, expect, type Page } from '@playwright/test';
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { addComment } from './helpers/comments';
+import { EMPHASIS_DOC_BASELINE } from './helpers/fixture-baselines';
+import { withMod } from './helpers/shortcuts';
+import { clearPersistedPreferences, resetTestAppState } from './helpers/test-state';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dirname, 'fixtures/emphasis-doc.md');
+const FIXTURE_ORIGINAL = EMPHASIS_DOC_BASELINE;
+
+/**
+ * Emphasis contract, rendered and raw.
+ *
+ * Body copy renders at full ink in every theme, and emphasis is carried by
+ * weight, with bold defaulting to the same color as body. Dark themes opt out
+ * through per-theme tokens (--theme-prose-bold, --theme-prose-body-weight,
+ * --theme-prose-bold-weight, --theme-raw-bold-weight) because light-on-dark
+ * text blooms and eats the stock 400/600 gap.
+ *
+ * These assert the token contract and its direction, not the literal design
+ * values, so a theme that never opts in keeps the plugin's stock pair and
+ * retuning the numbers does not require editing tests.
+ */
+
+test.beforeEach(async ({ page }) => {
+  writeFileSync(FIXTURE, FIXTURE_ORIGINAL);
+  await resetTestAppState(page);
+});
+
+test.afterAll(() => {
+  writeFileSync(FIXTURE, FIXTURE_ORIGINAL);
+  // These tests switch themes, which persists server-side into a prefs file
+  // shared by every spec.
+  clearPersistedPreferences();
+});
+
+async function openFixture(page: Page) {
+  await page.goto(`/?file=${FIXTURE}`);
+  await page.locator('.prose strong').first().waitFor({ timeout: 10_000 });
+}
+
+async function selectTheme(page: Page, themeName: string, themeKey: string) {
+  await page.keyboard.press(withMod('k'));
+  await page.getByPlaceholder('Type a command...').fill(`Theme: ${themeName}`);
+  await page.keyboard.press('Enter');
+  await expect(page.getByPlaceholder('Type a command...')).not.toBeVisible();
+  // Settle gate: computed styles are only meaningful once the attribute flips.
+  await expect(page.locator(`[data-theme="${themeKey}"]`)).toBeVisible();
+}
+
+type Ink = { color: string; weight: number };
+
+async function ink(page: Page, selector: string): Promise<Ink> {
+  return page
+    .locator(selector)
+    .first()
+    .evaluate((el) => {
+      const cs = getComputedStyle(el);
+      return { color: cs.color, weight: Number(cs.fontWeight) };
+    });
+}
+
+/**
+ * Read a theme token off the root, not off `.prose`: the tokens are inherited
+ * custom properties and the raw view has no `.prose` element to hang them on.
+ */
+async function themeTone(page: Page, custom: string): Promise<string> {
+  const hex = await page.evaluate(
+    (name) => getComputedStyle(document.documentElement).getPropertyValue(name).trim(),
+    custom
+  );
+  return hexToRgb(hex);
+}
+
+/** Relative luminance, so "brighter" can be asserted without hardcoding hexes. */
+function luminance(cssColor: string): number {
+  const [r, g, b] = cssColor
+    .match(/\d+(\.\d+)?/g)!
+    .slice(0, 3)
+    .map(Number);
+  const lin = (c: number) => {
+    const s = c / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+}
+
+// [palette label, data-theme key]. Mirrors DARK_THEMES / LIGHT_THEMES in
+// src/lib/themes.ts; e2e specs do not import app source, so a theme added there
+// must be added here too. Every light theme is exercised, not just the default,
+// because the contract's claim is that a theme setting none of the tokens gets
+// the plugin's stock pair.
+const DARK_THEMES: Array<[string, string]> = [
+  ['Dark', 'dark'],
+  ['Nord', 'nord'],
+  ['Rosé Pine', 'rose-pine'],
+  ['Catppuccin', 'catppuccin'],
+];
+
+const LIGHT_THEMES: Array<[string, string]> = [
+  ['Light', 'light'],
+  ['Sepia', 'sepia'],
+  ['Solarized', 'solarized'],
+  ['GitHub', 'github'],
+];
+
+test.describe('Prose emphasis contract', () => {
+  test('light themes carry emphasis with weight alone', async ({ page }) => {
+    await openFixture(page);
+
+    // Selected explicitly rather than relying on how `system` resolves under
+    // Playwright's default colorScheme.
+    for (const [name, key] of LIGHT_THEMES) {
+      await selectTheme(page, name, key);
+
+      const body = await ink(page, '.prose p');
+      const bold = await ink(page, '.prose p strong');
+
+      // No theme tokens set, so the plugin's stock pair applies.
+      expect(body.weight, `${name} body weight`).toBe(400);
+      expect(bold.weight, `${name} bold weight`).toBe(600);
+      // Emphasis is weight, not color: --tw-prose-bold falls back to
+      // --theme-text.
+      expect(bold.color, `${name} bold color`).toBe(body.color);
+    }
+  });
+
+  test('body copy renders at full ink, not the secondary tone', async ({ page }) => {
+    await openFixture(page);
+
+    const text = await themeTone(page, '--theme-text');
+    const secondary = await themeTone(page, '--theme-text-secondary');
+    const body = await ink(page, '.prose p');
+
+    // Guards the regression this contract was written for: body used to resolve
+    // to --theme-text-secondary, which reads as gray against a dark sheet.
+    expect(text).not.toBe(secondary);
+    expect(body.color).toBe(text);
+  });
+
+  test('quiet document text clears the muted tone', async ({ page }) => {
+    await openFixture(page);
+
+    const secondary = await themeTone(page, '--theme-text-secondary');
+    const muted = await themeTone(page, '--theme-text-muted');
+    expect(secondary).not.toBe(muted);
+
+    // List markers are quieter than body but are still document content, and
+    // muted drops under 3.5:1 on three of the dark palettes.
+    const markerColor = await page
+      .locator('.prose ol li')
+      .first()
+      .evaluate((el) => getComputedStyle(el, '::marker').color);
+    expect(markerColor).toBe(secondary);
+
+    // Fenced code tracks body ink rather than the secondary, so code no longer
+    // trails the prose around it.
+    const code = await ink(page, '.prose pre');
+    expect(code.color).toBe(await themeTone(page, '--theme-text'));
+  });
+
+  test('heading and blockquote emphasis keeps the plugin ladder', async ({ page }) => {
+    await openFixture(page);
+
+    const themes: Array<[string, string]> = [...LIGHT_THEMES, ...DARK_THEMES];
+    for (const [name, key] of themes) {
+      await selectTheme(page, name, key);
+
+      const h2 = await ink(page, '.prose h2');
+      const h2strong = await ink(page, '.prose h2 strong');
+      const bodyStrong = await ink(page, '.prose p strong');
+      const quote = await ink(page, '.prose blockquote p');
+      const quoteStrong = await ink(page, '.prose blockquote strong');
+
+      // Emphasis inside a heading must never render lighter than the heading
+      // itself, which is what a flat body-copy weight rule does to it. Headings
+      // are the only block with a plugin strong ladder, so h2 strong outranks
+      // both its heading and ordinary body bold.
+      expect(h2strong.weight, `${name} h2 strong`).toBeGreaterThan(h2.weight);
+      expect(h2strong.weight, `${name} h2 strong vs body`).toBeGreaterThan(bodyStrong.weight);
+      // Quoted body keeps the plugin's 500 rather than the thinned body weight.
+      expect(quote.weight, `${name} blockquote body`).toBe(500);
+      // The plugin gives blockquote strong a color rule but no weight, so
+      // emphasis in a quote must take the same weight body bold gets. Asserting
+      // only that it beats the quote's own 500 would pass at the stock 600 and
+      // hide quoted bold being the weakest emphasis on the page.
+      expect(quoteStrong.weight, `${name} blockquote strong`).toBe(bodyStrong.weight);
+    }
+  });
+
+  test('list items and table cells track the body weight', async ({ page }) => {
+    await openFixture(page);
+
+    for (const [name, key] of [...LIGHT_THEMES, ...DARK_THEMES]) {
+      await selectTheme(page, name, key);
+
+      const body = await ink(page, '.prose p');
+      // The rule names p, li, and td explicitly; drop one and body copy in that
+      // block silently reverts to the inherited weight.
+      expect((await ink(page, '.prose li')).weight, `${name} li`).toBe(body.weight);
+      expect((await ink(page, '.prose td')).weight, `${name} td`).toBe(body.weight);
+      // Table headers have no plugin strong ladder either, so emphasis in a
+      // cell or a header takes the same weight body bold gets.
+      const bodyStrong = await ink(page, '.prose p strong');
+      expect((await ink(page, '.prose td strong')).weight, `${name} td strong`).toBe(
+        bodyStrong.weight
+      );
+      expect((await ink(page, '.prose th strong')).weight, `${name} th strong`).toBe(
+        bodyStrong.weight
+      );
+    }
+  });
+
+  test('dark themes thin body and lift bold past full ink', async ({ page }) => {
+    await openFixture(page);
+
+    for (const [name, key] of DARK_THEMES) {
+      await selectTheme(page, name, key);
+
+      const body = await ink(page, '.prose p');
+      const bold = await ink(page, '.prose p strong');
+
+      // Dark themes opt out of the stock pair in both directions.
+      expect(body.weight, `${name} body weight`).toBeLessThan(400);
+      expect(bold.weight, `${name} bold weight`).toBeGreaterThan(600);
+      // ...and bold sits above body tonally, never below it.
+      expect(luminance(bold.color), `${name} bold tone`).toBeGreaterThan(luminance(body.color));
+    }
+  });
+
+  test('highlighting a bold phrase does not change its ink', async ({ page }) => {
+    await openFixture(page);
+    await selectTheme(page, 'Dark', 'dark');
+
+    const bareBold = await ink(page, '.prose p strong');
+
+    // Anchoring exactly the bold run nests the mark INSIDE the <strong>
+    // (surroundContents), which is the shape where the mark's own color wins.
+    // An anchor that spilled past the bold would nest the other way and hide
+    // the defect, so the phrase has to match the bold run exactly.
+    await addComment(page, 'Lead-in claim.', 'Highlight ink test');
+    const mark = page.locator('.prose p strong mark.comment-highlight').first();
+    await expect(mark).toBeVisible();
+
+    const highlighted = await ink(page, '.prose p strong mark.comment-highlight');
+    expect(highlighted.color).toBe(bareBold.color);
+    expect(highlighted.weight).toBe(bareBold.weight);
+  });
+
+  test('raw view follows the same tokens', async ({ page }) => {
+    await openFixture(page);
+    await page.locator('button[title="View raw markdown"]').click();
+    await expect(page.locator('.raw-view-table')).toBeVisible();
+    await selectTheme(page, 'Light', 'light');
+
+    const lightLine = await ink(page, '.raw-line-content');
+    const lightBold = await ink(page, '.raw-bold');
+
+    // Light: markup is ink-colored at the stock weight, same as the source text.
+    expect(lightBold.weight).toBe(600);
+    expect(lightBold.color).toBe(lightLine.color);
+    // Source text is body ink, not the secondary it used to resolve to.
+    expect(lightLine.color).toBe(await themeTone(page, '--theme-text'));
+    // Table rows have always matched plain lines; they must not be left behind.
+    expect((await ink(page, '.raw-table')).color).toBe(lightLine.color);
+    // Quoted source lines are document text, so they clear the muted tone.
+    expect((await ink(page, '.raw-blockquote')).color).toBe(
+      await themeTone(page, '--theme-text-secondary')
+    );
+    // Fenced source blocks take --theme-code-text, which falls back to body ink
+    // rather than the secondary. No theme overrides it today, so this asserts
+    // the fallback arm the docs describe.
+    expect((await ink(page, '.raw-code-block')).color).toBe(
+      await themeTone(page, '--theme-text')
+    );
+    // Heading markup lifts with bold, sharing --theme-raw-bold-weight.
+    expect((await ink(page, '.raw-heading')).weight).toBe(lightBold.weight);
+
+    await selectTheme(page, 'Dark', 'dark');
+
+    const darkLine = await ink(page, '.raw-line-content');
+    const darkBold = await ink(page, '.raw-bold');
+
+    // Dark: markup lifts, but source text stays at 400. That view is 13px mono,
+    // where the rendered view's 350 goes spindly.
+    expect(darkLine.weight).toBe(400);
+    expect(darkBold.weight).toBeGreaterThan(600);
+    expect(luminance(darkBold.color)).toBeGreaterThan(luminance(darkLine.color));
+  });
+});
+
+/** `getPropertyValue` returns the authored hex; computed colors come back rgb(). */
+function hexToRgb(hex: string): string {
+  const h = hex.replace('#', '');
+  const full =
+    h.length === 3
+      ? h
+          .split('')
+          .map((c) => c + c)
+          .join('')
+      : h;
+  const n = parseInt(full, 16);
+  return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`;
+}

--- a/src/hooks/useDragHandles.ts
+++ b/src/hooks/useDragHandles.ts
@@ -183,10 +183,32 @@ export function useDragHandles({
     ro.observe(scrollContainer);
     const page = pageRef.current;
     if (page) ro.observe(page);
+    // Presentation attributes reflow the text under the marks. Theme is not
+    // purely chromatic (the dark ones set their own body and bold font-weights)
+    // and the typeface toggle swaps serif for sans, so either one re-measures
+    // every glyph and slides the marks horizontally. Line count usually holds,
+    // so no observed box resizes and none of the listeners above fire, leaving
+    // the handles parked at their old x until the next scroll. Size is included
+    // for completeness: it currently changes height too, so the ResizeObserver
+    // already catches it, but that is incidental rather than guaranteed.
+    //
+    // Observed with subtree, because these live on different elements: theme on
+    // the document element, the prose pair on the viewer wrapper. The filter
+    // keeps the callback off every other attribute mutation, and the rAF lets
+    // the reflow land before measuring.
+    const presentationObserver = new MutationObserver(() => {
+      requestAnimationFrame(handler);
+    });
+    presentationObserver.observe(document.documentElement, {
+      attributes: true,
+      subtree: true,
+      attributeFilter: ['data-theme', 'data-prose-font', 'data-prose-size'],
+    });
     return () => {
       scrollContainer.removeEventListener('scroll', handler);
       window.removeEventListener('resize', handler);
       ro.disconnect();
+      presentationObserver.disconnect();
     };
   }, [activeCommentId, scrollContainerRef, pageRef, updatePositions]);
 

--- a/src/index.css
+++ b/src/index.css
@@ -177,7 +177,12 @@ body {
   --theme-text-secondary: #b3ac9f;
   --theme-text-muted: #8d877b;
   --theme-text-faint: #57524a;
-  --theme-code-text: #cdc6b9;
+  /* Bold ink sits a step above --theme-text so body can hold full strength.
+     The weights compensate for halation; see the prose section for the reasoning. */
+  --theme-prose-bold: #f7f4ee;
+  --theme-prose-body-weight: 350;
+  --theme-prose-bold-weight: 780;
+  --theme-raw-bold-weight: 700;
   --theme-accent: #e0584f;
   --theme-accent-hover: #e97a72;
   --theme-accent-bg: rgba(224, 88, 79, 0.12);
@@ -310,6 +315,11 @@ body {
   --theme-text-secondary: #d8dee9;
   --theme-text-muted: #7b88a1;
   --theme-text-faint: #4c566a;
+  /* Bold ink sits a step above --theme-text; body holds full strength. */
+  --theme-prose-bold: #f7f9fc;
+  --theme-prose-body-weight: 350;
+  --theme-prose-bold-weight: 780;
+  --theme-raw-bold-weight: 700;
   --theme-accent: #88c0d0;
   --theme-accent-hover: #8fbcbb;
   --theme-accent-bg: rgba(136, 192, 208, 0.15);
@@ -376,6 +386,10 @@ body {
   --theme-text-secondary: #908caa;
   --theme-text-muted: #6e6a86;
   --theme-text-faint: #524f67;
+  --theme-prose-bold: #efedff;
+  --theme-prose-body-weight: 350;
+  --theme-prose-bold-weight: 780;
+  --theme-raw-bold-weight: 700;
   --theme-accent: #c4a7e7;
   --theme-accent-hover: #d4bdf7;
   --theme-accent-bg: rgba(196, 167, 231, 0.15);
@@ -574,6 +588,11 @@ body {
   --theme-text-secondary: #bac2de;
   --theme-text-muted: #6c7086;
   --theme-text-faint: #45475a;
+  /* Bold ink sits a step above --theme-text; body holds full strength. */
+  --theme-prose-bold: #dfe6ff;
+  --theme-prose-body-weight: 350;
+  --theme-prose-bold-weight: 780;
+  --theme-raw-bold-weight: 700;
   --theme-accent: #cba6f7;
   --theme-accent-hover: #d8bcf9;
   --theme-accent-bg: rgba(203, 166, 247, 0.15);
@@ -663,21 +682,73 @@ body {
 
 /* ========== Prose Theme Overrides ========== */
 .prose {
-  --tw-prose-body: var(--theme-text-secondary);
+  --tw-prose-body: var(--theme-text);
   --tw-prose-headings: var(--theme-text);
   --tw-prose-links: var(--theme-text);
-  --tw-prose-bold: var(--theme-text);
+  --tw-prose-bold: var(--theme-prose-bold, var(--theme-text));
   --tw-prose-code: var(--theme-text);
   --tw-prose-quotes: var(--theme-text-secondary);
   --tw-prose-quote-borders: var(--theme-border);
-  --tw-prose-counters: var(--theme-text-muted);
-  --tw-prose-bullets: var(--theme-text-muted);
+  /* Counters, bullets, and captions are quiet, but they are still document
+     content, so they sit one step under body rather than at --theme-text-muted.
+     Muted drops under 3.5:1 on the Nord, Rosé Pine, and Catppuccin backgrounds,
+     which was tolerable when body was also dimmed and is not now. */
+  --tw-prose-counters: var(--theme-text-secondary);
+  --tw-prose-bullets: var(--theme-text-secondary);
   --tw-prose-hr: var(--theme-border);
   --tw-prose-th-borders: var(--theme-border);
   --tw-prose-td-borders: var(--theme-border);
-  --tw-prose-captions: var(--theme-text-muted);
+  --tw-prose-captions: var(--theme-text-secondary);
   --tw-prose-pre-bg: var(--theme-bg-inset);
-  --tw-prose-pre-code: var(--theme-code-text, var(--theme-text-secondary));
+  /* Code falls back to body ink, not to the secondary: a theme that sets no
+     --theme-code-text should render code at the same strength as the prose
+     around it. */
+  --tw-prose-pre-code: var(--theme-code-text, var(--theme-text));
+}
+
+/* Body copy runs at full ink in every theme (see --tw-prose-body above), and
+   emphasis is weight, not color: --tw-prose-bold falls back to --theme-text, so
+   bold and body match unless a theme opts out. That is what light themes do, and
+   what GitHub and Obsidian both ship.
+
+   Dark themes need help the light ones don't. Light text on near-black blooms:
+   strokes optically thicken, which eats the 400-to-600 gap until bold stops
+   reading as bold. The serif makes it worse than it is for those two apps, since
+   both set their prose in a sans, where 600 thickens uniformly instead of leaving
+   hairlines thin. So dark themes split the difference across both channels rather
+   than pushing either one hard: body drops to 350, bold rises to 780, and
+   --theme-prose-bold lifts bold a step above --theme-text. Measured ink coverage
+   is 1.68x body, against 1.19x for the stock 400/600. Source Serif 4 is variable,
+   so the off-scale weights cost no extra file.
+
+   Both weights are per-theme tokens rather than theme-keyed selectors, so a new
+   theme opts in from its own block alongside its colors, and a theme that sets
+   neither gets the plugin's stock pair.
+
+   Blockquote paragraphs keep the plugin's 500. That block is italic as a whole,
+   and italics carry less ink than roman at the same weight, so the plugin pays
+   the difference back in weight; thinning it further would undo that. Inline
+   `em` is deliberately NOT exempt: it sits inside a line already set at the
+   body weight, and lifting it alone would make italic phrases heavier than the
+   roman text around them. */
+.prose :is(p, li, td):not(blockquote *) {
+  font-weight: var(--theme-prose-body-weight, 400);
+}
+
+/* Headings are the one block with its own strong ladder in the plugin: 900 for
+   h1 down through 700 for h4, each pitched above the heading it sits in. This
+   rule is about body copy and has to stay out of them, because applied flat it
+   drags `# Title **bold**` to 600 inside a 700 heading, rendering emphasis
+   lighter than the text around it.
+
+   Blockquotes and table headers are NOT excluded, despite also having plugin
+   `strong` rules: those rules set `color: inherit` only, with no weight, so
+   there is no ladder to defer to. Excluding them just left bold in a quote or a
+   table header identical to its surroundings, which is the exact defect this
+   branch exists to fix. They take the body weight and keep the inherited
+   color. */
+.prose strong:not(:where(h1, h2, h3, h4) *) {
+  font-weight: var(--theme-prose-bold-weight, 600);
 }
 
 /* Inline code stays neutral: the crimson accent is budgeted for review
@@ -718,7 +789,7 @@ body {
 
 .prose :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   background-color: var(--theme-bg-inset);
-  color: var(--theme-code-text, var(--theme-text-secondary));
+  color: var(--theme-code-text, var(--theme-text));
 }
 
 .prose :where(pre code):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
@@ -806,6 +877,24 @@ mark.comment-highlight {
     text-decoration-color 0.15s ease,
     outline-color 0.15s ease;
   line-height: inherit;
+}
+
+/* Highlights pin their text to full ink so it stays legible on the amber fill.
+   That was written when body copy was dimmer than --theme-text and is a no-op
+   for body text now, but bold sits a step above full ink on the dark themes, so
+   for bold the pin is a downgrade.
+
+   It only bites in one of the two shapes the viewer produces: wrapping an
+   anchor that covers exactly a bold run nests the mark inside the <strong>
+   (surroundContents), where the mark's own color wins, while an anchor that
+   spills past the bold nests the <strong> inside the mark, where it doesn't. So
+   without this the same phrase renders two different colors depending on how
+   far the selection ran, and the pending-selection preview flickers between
+   them mid-drag. Light themes leave --theme-prose-bold unset and are unchanged. */
+.prose
+  strong
+  :is(mark.comment-highlight, mark.comment-highlight-sent, mark.selection-highlight) {
+  color: var(--theme-prose-bold, var(--theme-text));
 }
 
 /* Mermaid highlights use inline styles — Chrome ignores class-based
@@ -1125,7 +1214,7 @@ body {
   padding-left: 1rem;
   white-space: pre-wrap;
   word-break: break-word;
-  color: var(--theme-text-secondary);
+  color: var(--theme-text);
 }
 
 /* Ensure empty lines still have height */
@@ -1207,14 +1296,18 @@ body {
 }
 
 /* --- Syntax highlighting --- */
+/* Same emphasis contract as the rendered view, driven by the same tokens: a
+   theme that sets neither gets ink-colored markup at 600. The weight is its own
+   token because this view is 13px mono, where the rendered view's 780 is too
+   heavy and its 350 body goes spindly. */
 .raw-heading {
-  color: var(--theme-text);
-  font-weight: 600;
+  color: var(--theme-prose-bold, var(--theme-text));
+  font-weight: var(--theme-raw-bold-weight, 600);
 }
 
 .raw-bold {
-  color: var(--theme-text);
-  font-weight: 600;
+  color: var(--theme-prose-bold, var(--theme-text));
+  font-weight: var(--theme-raw-bold-weight, 600);
 }
 
 .raw-italic {
@@ -1232,7 +1325,7 @@ body {
 }
 
 .raw-code-block {
-  color: var(--theme-code-text, var(--theme-text-secondary));
+  color: var(--theme-code-text, var(--theme-text));
   background-color: var(--theme-bg-inset);
   border-radius: 4px;
   display: inline;
@@ -1245,8 +1338,11 @@ body {
   text-underline-offset: 2px;
 }
 
+/* Quoted lines are document text, not syntax chrome, so they track the
+   secondary rather than the muted tone, which falls under 3.5:1 on the cooler
+   dark palettes. */
 .raw-blockquote {
-  color: var(--theme-text-muted);
+  color: var(--theme-text-secondary);
   border-left: 2px solid var(--theme-border);
   padding-left: 0.5em;
 }
@@ -1260,7 +1356,7 @@ body {
 }
 
 .raw-table {
-  color: var(--theme-text-secondary);
+  color: var(--theme-text);
 }
 
 .raw-frontmatter {


### PR DESCRIPTION
## The problem

Document body copy rendered at `--theme-text-secondary` in both the rendered and source views. On the dark themes that reads as gray against a near-black sheet, and it made bold jump to a brighter *color* rather than a heavier weight, since `strong` sat at `--theme-text`. In effect, 95% of the page was dimmed so that 5% of it would stand out.

## The change

Body now uses `--theme-text` in every theme and both views. Emphasis is carried by weight: `--tw-prose-bold` falls back to `--theme-text`, so bold and body share a color unless a theme opts out. Light themes take that default at the typography plugin's stock 400/600, which is what GitHub and Obsidian both ship (measured, not assumed).

The four dark themes opt out, because light-on-dark text blooms: strokes optically thicken, which eats the 400/600 gap until bold stops reading as bold. A serif suffers more than the sans those readers use, since 600 thickens the stems but leaves hairlines thin. Rather than push one channel hard, dark themes spend a little on each.

| | Light themes | Dark themes |
|---|---|---|
| Body color | `--theme-text` | `--theme-text` |
| Body weight | 400 | 350 |
| Bold color | same as body | `--theme-prose-bold`, one step above |
| Bold weight | 600 | 780 |

Measured ink coverage is 1.68x body, against 1.19x for stock. All four values are per-theme tokens with the stock pair as the `var()` fallback, so adding a theme needs no edits outside its own token block.

## Knock-on fixes

All four fall out of body getting brighter or lighter:

- Code text falls back to `--theme-text` rather than the secondary, so fenced code no longer trails the prose around it.
- Counters, bullets, captions, and `.raw-blockquote` move from `--theme-text-muted` to `--theme-text-secondary`. Muted sits at 2.6-2.9:1 on the Nord, Rose Pine, and Catppuccin backgrounds.
- Comment and selection highlights no longer pin bold to full ink. Anchoring exactly a bold run nests the mark inside the `<strong>` where the pin wins, while an anchor spilling past it nests the other way, so the same phrase rendered two different colors depending on how far the selection ran.
- `useDragHandles` observes `data-theme`, `data-prose-font`, and `data-prose-size`. Changing weight or typeface re-measures every glyph and slides the marks horizontally without resizing any observed box, so the drag handles used to stay parked 0.5-2.9px off until the next scroll.

## Review

Seven adversarial review rounds, ending on a clean verdict. Three defects were in the original change rather than in review churn: emphasis inside headings rendering *lighter* than the heading on light themes, the drag-handle staleness above, and the highlighted-bold dimming above.

Every new assertion was confirmed to fail with its fix reverted. That check caught one vacuous assertion whose tolerance was wider than the drift it guarded against.

Verified: lint, \`tsc -b\`, \`eval:dry\`, 1463 unit tests, and the full 312-test Playwright suite (312 passed, zero flaky). Accessibility checked under \`forced-colors: active\`, where the branch is net-positive: color collapses to CanvasText but weight survives, widening the emphasis gap from 200 to 430 units. Style recalc measured on a synthetic 24,800-element document: ~4ms per full invalidation, indistinguishable on initial load.

## Known and deferred

- `ThemePreview` still models ink at the old secondary tone. Symmetric across light and dark, `aria-hidden`, decorative.
- No `@media (forced-colors)` or `prefers-contrast` rules anywhere in the app. Pre-existing gap, not a regression.
- A theme switch costs 55-66ms of layout on that synthetic document versus 6-8ms before. Inherent to weight-based theming, one-off, sub-millisecond on realistic documents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SXP3jGALGSb2FANAAV89No