### PR TITLE
fix: keep comment markers out of frontmatter and HTML comments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,18 @@ Some text <!-- @comment{"id":"uuid","anchor":"highlighted text","text":"comment 
 - Strip all `<!-- @comment{...} -->` markers to get clean content
 - Marker position disambiguates when the same text appears multiple times
 
+### Protected containers
+
+Some containers can't hold an inline marker, so `insertComment` relocates one that
+resolves inside them. The `anchor` is never rewritten: it stays the real text, so
+highlighting, orphan detection, and agent handoff are unaffected.
+
+| Container | Where the marker goes | Why |
+|---|---|---|
+| Fenced code block | Before the opening fence, own line | A marker inside is literal text |
+| YAML/TOML frontmatter (offset 0 only) | After the closing fence, own line | It can't go before, and a comment body containing `: ` breaks the YAML parse |
+| HTML comment | Before the block; own line only when the comment owns its line | Nested comments don't exist: the first `-->` closes the outer one and the rest becomes visible text |
+
 ## API endpoints
 
 **Files**

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -2033,6 +2033,99 @@ describe('insertComment inside fenced code blocks', () => {
     expect(fenceLine).toBe('~~~');
   });
 
+  describe('inside frontmatter', () => {
+    const skillFile =
+      '---\nname: mcp2cli\ndescription: Use when an MCP server should be driven\n  from the shell.\n---\n\n# Overview\n\nBody text.\n';
+
+    it('places the marker after the closing fence, not inside the block', () => {
+      const result = insertComment(skillFile, 'Use when an MCP server should be driven', 'why?');
+      const block = result.slice(0, result.indexOf('\n---\n') + 5);
+      expect(block).not.toContain('@comment');
+      expect(result).toContain('---\n<!-- @comment');
+    });
+
+    it('leaves the frontmatter block byte-identical', () => {
+      const result = insertComment(skillFile, 'Use when an MCP server should be driven', 'why?');
+      expect(result.startsWith(skillFile.slice(0, skillFile.indexOf('\n---\n') + 5))).toBe(true);
+    });
+
+    it('keeps the YAML parseable when the comment body contains a colon', () => {
+      // `: ` inside the fences is what breaks a YAML parse outright, so this
+      // is the case that matters most.
+      const result = insertComment(skillFile, 'mcp2cli', 'Note: rename this');
+      const fenceEnd = result.indexOf('\n---\n') + 5;
+      expect(result.slice(0, fenceEnd)).not.toContain('@comment');
+    });
+
+    it('round-trips and keeps the anchor resolvable', () => {
+      const result = insertComment(skillFile, 'Use when an MCP server should be driven', 'why?');
+      const parsed = parseComments(result);
+      expect(parsed.comments).toHaveLength(1);
+      expect(parsed.comments[0].anchor).toBe('Use when an MCP server should be driven');
+      expect(parsed.cleanMarkdown).toBe(skillFile);
+      expect(detectMissingAnchors(parsed.cleanMarkdown, parsed.comments).size).toBe(0);
+    });
+
+    it('handles TOML frontmatter', () => {
+      const raw = '+++\ntitle = "Post"\n+++\n\n# Heading\n';
+      const result = insertComment(raw, 'Post', 'rename');
+      expect(result.slice(0, result.indexOf('\n+++\n') + 5)).not.toContain('@comment');
+      expect(parseComments(result).cleanMarkdown).toBe(raw);
+    });
+
+    it('handles a frontmatter-only document with no trailing newline', () => {
+      const raw = '---\nname: stub\n---';
+      const result = insertComment(raw, 'stub', 'flesh this out');
+      expect(result.startsWith('---\nname: stub\n---\n')).toBe(true);
+      // The marker can't share the closing fence's line, so the file gains a
+      // final newline. Everything above it is untouched.
+      expect(parseComments(result).cleanMarkdown).toBe(raw + '\n');
+    });
+
+    it('treats a mid-document --- as a thematic break, not frontmatter', () => {
+      const raw = '# Title\n\nIntro text.\n\n---\n\nMore text.\n';
+      const result = insertComment(raw, 'More text', 'expand');
+      // No relocation: the marker sits inline immediately before the anchor.
+      expect(result).toMatch(/@comment.*-->More text/);
+      expect(parseComments(result).cleanMarkdown).toBe(raw);
+    });
+  });
+
+  describe('inside HTML comments', () => {
+    it('places the marker before a block-level comment, not nested inside it', () => {
+      const raw = '# Notes\n\n<!-- TODO: decide on the retry loop -->\n\nBody.\n';
+      const result = insertComment(raw, 'decide on the retry loop', 'why?');
+      expect(result).toContain('<!-- TODO: decide on the retry loop -->');
+      expect(result).not.toMatch(/<!-- TODO: <!--/);
+      const parsed = parseComments(result);
+      expect(parsed.comments).toHaveLength(1);
+      expect(parsed.cleanMarkdown).toBe(raw);
+    });
+
+    it('gives a block-level comment marker its own line', () => {
+      const raw = '# Notes\n\n<!-- TODO: decide on the retry loop -->\n\nBody.\n';
+      const result = insertComment(raw, 'decide on the retry loop', 'why?');
+      const markerLine = result.split('\n').find((l) => l.includes('@comment'));
+      expect(markerLine).not.toContain('TODO');
+    });
+
+    it('keeps an inline comment inline', () => {
+      const raw = 'Text before <!-- inline note --> text after.\n';
+      const result = insertComment(raw, 'inline note', 'clarify');
+      expect(result).not.toMatch(/<!-- <!--/);
+      // The paragraph must stay on one line, with no newline injected mid-sentence.
+      expect(result.split('\n')[0]).toContain('text after.');
+      expect(parseComments(result).cleanMarkdown).toBe(raw);
+    });
+
+    it('does not nest inside a malformed @comment marker left in the document', () => {
+      const raw = '# H\n\n<!-- @comment{"id":"x","text":"unclosed -->\n\nbody\n';
+      const result = insertComment(raw, 'unclosed', 'broken marker');
+      expect(result).not.toMatch(/<!-- @comment\{"id":"x","text":"<!--/);
+      expect(parseComments(result).comments).toHaveLength(1);
+    });
+  });
+
   it('preserves fence when code block is at document start', () => {
     const raw = '```js\nconst x = 1;\n```\n\nEnd.';
     const result = insertComment(raw, 'const x = 1;', 'refactor');

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -54,6 +54,41 @@ function getCodeBlockRanges(rawMarkdown: string): CodeBlockRange[] {
   return codeBlockRanges;
 }
 
+/**
+ * Range of the document's leading YAML/TOML frontmatter block, fences
+ * included, extending through the newline after the closing fence. Returns
+ * null when there is none.
+ *
+ * Frontmatter is only frontmatter at offset 0. A `---` further down is a
+ * thematic break and a `+++` is ordinary text, so this deliberately anchors
+ * to the start of the string.
+ */
+export function getFrontmatterRange(markdown: string): CodeBlockRange | null {
+  const match = /^(---|\+\+\+)[ \t]*\r?\n[\s\S]*?\r?\n\1[ \t]*(?:\r?\n|$)/.exec(markdown);
+  if (!match) return null;
+  return { start: 0, end: match[0].length };
+}
+
+/**
+ * Ranges of ordinary HTML comments. A marker cannot nest inside one: the
+ * first `-->` closes the outer comment, so everything after it becomes
+ * visible text in other renderers even though mdr itself round-trips fine.
+ *
+ * Callers pass clean markdown, where well-formed `@comment` markers are
+ * already stripped. A malformed marker survives stripping and is matched
+ * here as an ordinary comment, which is what we want: nothing should be
+ * inserted inside it either.
+ */
+function getHtmlCommentRanges(markdown: string): CodeBlockRange[] {
+  const ranges: CodeBlockRange[] = [];
+  const regex = /<!--[\s\S]*?-->/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(markdown)) !== null) {
+    ranges.push({ start: match.index, end: match.index + match[0].length });
+  }
+  return ranges;
+}
+
 function isInsideCodeBlock(offset: number, codeBlockRanges: CodeBlockRange[]): boolean {
   for (const range of codeBlockRanges) {
     if (offset >= range.start && offset < range.end) return true;
@@ -550,42 +585,64 @@ export function insertComment(
 
   if (insertionCleanOffset === null) return rawMarkdown;
 
-  // If the insertion point falls inside a fenced code block, move it before the block.
-  // HTML comment markers are literal text inside code blocks, so the marker must go outside.
-  let movedBeforeFence = false;
+  // Some containers cannot hold an inline marker: it is literal text inside a
+  // fenced code block, illegal nesting inside an HTML comment (the first
+  // `-->` closes the outer comment and the rest becomes visible text), and
+  // invalid syntax inside frontmatter (a comment body containing `: ` breaks
+  // the YAML parse outright). When the resolved insertion point lands in one,
+  // relocate it to the nearest legal position outside the container. The
+  // anchor is unaffected: it stays the real text, so highlighting, orphan
+  // detection, and agent handoff all keep working.
+  let ownLine = false;
+  let leadingNewline = false;
   {
-    const fenceRegex = /^ {0,3}(`{3,}|~{3,}).*$/gm;
-    let fm: RegExpExecArray | null;
-    let openF: { marker: string; start: number } | null = null;
-    while ((fm = fenceRegex.exec(cleanMarkdown)) !== null) {
-      const marker = fm[1];
-      if (!openF) {
-        openF = { marker: marker[0].repeat(marker.length), start: fm.index };
-      } else if (marker[0] === openF.marker[0] && marker.length >= openF.marker.length) {
-        if (
-          insertionCleanOffset >= openF.start &&
-          insertionCleanOffset <= fm.index + fm[0].length
-        ) {
-          insertionCleanOffset = openF.start;
-          movedBeforeFence = true;
-        }
-        openF = null;
+    // Fenced blocks: before the opening fence.
+    for (const range of getCodeBlockRanges(cleanMarkdown)) {
+      if (insertionCleanOffset >= range.start && insertionCleanOffset <= range.end) {
+        insertionCleanOffset = range.start;
+        ownLine = true;
+      }
+    }
+    // Frontmatter: after the closing fence. It cannot go before, since
+    // frontmatter is only recognized at offset 0, so this is the one
+    // container the marker trails rather than leads.
+    const frontmatter = getFrontmatterRange(cleanMarkdown);
+    if (
+      frontmatter &&
+      insertionCleanOffset >= frontmatter.start &&
+      insertionCleanOffset < frontmatter.end
+    ) {
+      insertionCleanOffset = frontmatter.end;
+      ownLine = true;
+      // A frontmatter-only document has no newline after the closing fence,
+      // so break the line first or the marker lands on the `---` itself.
+      leadingNewline = cleanMarkdown[frontmatter.end - 1] !== '\n';
+    }
+    // HTML comments: before the block. Only claim a whole line when the
+    // comment owns one; an inline note keeps its paragraph intact.
+    for (const range of getHtmlCommentRanges(cleanMarkdown)) {
+      if (insertionCleanOffset >= range.start && insertionCleanOffset < range.end) {
+        insertionCleanOffset = range.start;
+        ownLine = range.start === 0 || cleanMarkdown[range.start - 1] === '\n';
       }
     }
   }
 
   // Insert marker BEFORE the anchor text in the raw markdown.
-  // When moved before a code fence, place the marker on its own line so the
+  // When relocated out of a container, place the marker on its own line so the
   // opening fence stays at column 0 (otherwise other renderers won't parse it).
   const rawInsertionPoint = cleanToRawOffset(insertionCleanOffset);
 
   const marker = serializeComment(comment);
-  if (movedBeforeFence) {
-    return (
-      rawMarkdown.slice(0, rawInsertionPoint) + marker + '\n' + rawMarkdown.slice(rawInsertionPoint)
-    );
-  }
-  return rawMarkdown.slice(0, rawInsertionPoint) + marker + rawMarkdown.slice(rawInsertionPoint);
+  const before = leadingNewline ? '\n' : '';
+  const after = ownLine ? '\n' : '';
+  return (
+    rawMarkdown.slice(0, rawInsertionPoint) +
+    before +
+    marker +
+    after +
+    rawMarkdown.slice(rawInsertionPoint)
+  );
 }
 
 export function removeComment(rawMarkdown: string, commentId: string): string {

--- a/src/lib/mermaid-diagram-comments.test.ts
+++ b/src/lib/mermaid-diagram-comments.test.ts
@@ -69,6 +69,27 @@ describe('commentsForDiagram', () => {
     expect(commentsForDiagram(diagram, [c], md).map((c) => c.id)).toEqual([]);
   });
 
+  it('does not attribute a frontmatter comment to a diagram that opens the body', () => {
+    // insertComment pushes a frontmatter-anchored marker past the closing
+    // `---`. When the body starts with a fence on the very next line, that
+    // lands on the same offset the diagram claims as its own.
+    const diagram = 'graph TD\n    A --> B';
+    const md = '---\ntitle: Flow spec\n---\n```mermaid\n' + diagram + '\n```\n';
+    const fenceOffset = md.indexOf('```mermaid');
+    const c: MdComment = { ...makeComment('fm', 'Flow spec'), cleanOffset: fenceOffset };
+    expect(commentsForDiagram(diagram, [c], md).map((c) => c.id)).toEqual([]);
+  });
+
+  it('still attributes a diagram comment sitting on the fence below frontmatter', () => {
+    // Same geometry, but the anchor is a node label rather than a field value,
+    // so the tie-break must keep it.
+    const diagram = 'graph TD\n    A[Login] --> B';
+    const md = '---\ntitle: Flow spec\n---\n```mermaid\n' + diagram + '\n```\n';
+    const fenceOffset = md.indexOf('```mermaid');
+    const c: MdComment = { ...makeComment('node', 'Login'), cleanOffset: fenceOffset };
+    expect(commentsForDiagram(diagram, [c], md).map((c) => c.id)).toEqual(['node']);
+  });
+
   it('without cleanMarkdown, falls back to plain anchor matching (no disambiguation)', () => {
     const diagram = `flowchart TD\n  A[API Gateway]`;
     const c1: MdComment = { ...makeComment('c1', 'API Gateway'), cleanOffset: 9999 };

--- a/src/lib/mermaid-diagram-comments.ts
+++ b/src/lib/mermaid-diagram-comments.ts
@@ -1,5 +1,15 @@
 import type { MdComment } from '../types';
-import { extractMermaidText } from './comment-parser';
+import { extractMermaidText, getFrontmatterRange } from './comment-parser';
+
+/**
+ * Whether an anchor's text comes from the document's frontmatter. Used to
+ * break the tie when a marker sits exactly on a diagram's opening fence.
+ */
+function anchorLivesInFrontmatter(cleanMarkdown: string, anchor: string): boolean {
+  const range = getFrontmatterRange(cleanMarkdown);
+  if (!range) return false;
+  return cleanMarkdown.slice(range.start, range.end).includes(anchor);
+}
 
 /**
  * Filter comments down to those that belong to a specific Mermaid diagram.
@@ -85,7 +95,16 @@ export function commentsForDiagram(
     // Exclusive upper bound: a marker AT claimEnd lives in the trailing
     // newline / whitespace AFTER the closing fence, which belongs to the
     // following prose, not to the diagram.
-    return c.cleanOffset >= claimStart && c.cleanOffset < claimEnd;
+    if (c.cleanOffset < claimStart || c.cleanOffset >= claimEnd) return false;
+    // A marker sitting exactly ON the opening fence is ambiguous when the
+    // block is the first thing after frontmatter: it could be a diagram
+    // comment relocated out of the block, or a frontmatter comment pushed
+    // down past the closing `---` onto the same offset. Position alone can't
+    // separate them, so defer to where the anchor text actually lives.
+    if (c.cleanOffset === claimStart && anchorLivesInFrontmatter(cleanMarkdown, c.anchor)) {
+      return false;
+    }
+    return true;
   });
 }
 


### PR DESCRIPTION
## Problem

`insertComment` finds the anchor text in the clean markdown and inserts the marker immediately before it. It had exactly one guard for containers that can't hold an inline HTML comment: fenced code blocks relocate the marker to the opening fence line. YAML/TOML frontmatter and HTML comments have the same constraint and no guard, so the marker went inside.

Anchor on text inside frontmatter:

```yaml
---
name: mcp2cli
description: <!-- @comment{"id":"...","text":"is this right?"} -->Use when an MCP server...
---
```

Anchor on text inside an HTML comment:

```
<!-- TODO: <!-- @comment{"id":"...","text":"why?"} -->decide whether we keep the retry loop -->
```

## Why it matters

Frontmatter, by comment text:

| comment text | result when the file is YAML-parsed |
|---|---|
| `is this right?` | parses, but `description` now begins with the marker |
| `Note: fix this` | parse error, `bad indentation of a mapping entry` |
| `see #12` | parses, value silently truncated at the `#` |

For a Claude Code skill file the first row is already a failure: `description` is the string the model reads to decide whether to load the skill.

HTML comments: nested comments don't exist. The first `-->` closes the outer comment, so the remaining text becomes visible content in GitHub, VS Code preview, and every other renderer.

Both cases round-trip cleanly inside mdr, since `parseComments` strips our marker and returns the original text. That's what makes it worth fixing: the corruption is invisible here and obvious everywhere else.

Reachability today is agent-only, through `mdr_review` / `mdr_ask` with an anchor whose text lives in either container. Users can't reach it because neither construct renders. #20 and #21 both change that, which is why this lands first.

## What changed

Generalizes the fence check into a protected-regions pass covering fenced blocks (already handled), leading `---` / `+++` frontmatter, and `<!-- ... -->` spans. A marker resolving inside one relocates to a legal position outside it: after the closing `---` for frontmatter (it can't go before, frontmatter starts at byte 0), before the block for HTML comments. Inline HTML comments keep their marker inline so the paragraph isn't split.

Anchors are never rewritten. They stay the real text, so highlighting, orphan detection, and agent handoff are unaffected.

One consequence needed its own fix: relocating past frontmatter can land a marker on the exact offset a Mermaid block claims, when the body opens with a fence on the line right after the closing `---`. The frontmatter comment then surfaced in that diagram's thread panel. Position alone can't separate the two cases, since a real diagram comment relocated out of its block lands on the same offset, so `commentsForDiagram` breaks the tie on whether the anchor text lives in the frontmatter.

## Tests

13 new cases: both repros, the `: ` comment body, TOML, a frontmatter-only document, a mid-document `---` staying a thematic break, inline versus block HTML comments, a malformed `@comment` marker (which survives stripping and is now treated as an ordinary comment, so nothing nests inside it either), and both sides of the Mermaid tie-break. The Mermaid regression test was checked against a reverted fix to confirm it fails for the stated reason.

Full suite green apart from `server/mcp-stdio-subprocess.test.ts`, which fails the same way on a clean tree in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tof5nvvxJVHNRrYQViAvV2
