### PR TITLE
feat: render YAML and TOML frontmatter as commentable content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -674,6 +674,39 @@ the default baked into the generated HTML. The active-comment highlight and
 the scroll-to jump flash still target the marker span itself, so both keep
 working regardless of fold state.
 
+### Frontmatter
+YAML and TOML frontmatter renders as document content above the first heading
+(`.doc-frontmatter`), not hidden the way most renderers treat it. In a review
+tool it is content: a skill file's `description` is the text an agent reads to
+decide whether to load the skill, an ADR's `status` is a claim worth arguing
+with. `remark-rehype` has no handler for `yaml` / `toml` nodes, so
+`pipeline.ts` supplies one; keys get a `.doc-frontmatter__key` span for
+styling and everything else passes through as text.
+
+The emitted text is byte-identical to the source, fences excluded, and that is
+a correctness requirement rather than a style choice. Comments anchor by
+searching the raw markdown for the text the DOM handed over, so any
+transformation (a prettified key, a stripped quote, a re-wrapped fold) means
+`insertComment` can't find the anchor and returns the document unchanged: the
+comment vanishes with no marker and no error. Style it with CSS, never by
+rewriting the string. `white-space: pre-wrap` is load-bearing for the same
+reason.
+
+Commenting on a field works through the normal selection flow. The marker
+lands after the closing fence (see Protected containers under Comment format).
+
+Known gap, pre-existing and not specific to frontmatter: relocation makes
+`cleanOffset` non-unique, since every marker pushed out of the same container
+lands on the same offset. `MarkdownViewer` groups highlights by
+`` `${cleanOffset}:${anchor}` ``, so two comments on different fields that share
+a value (`false` in two booleans) collide into one group and paint a single
+highlight on the first occurrence, with the second comment's id riding along on
+the same `<mark>`. The `contextBefore` that would separate them is stored but
+never consulted, because grouping happens before matching. The same collapse
+reproduces with two comments on repeated text inside one code fence, so it
+predates frontmatter rendering. The plain-text offset drift is a red herring
+here: it measures 4 characters and the creation path resolves correctly.
+
 ### Mermaid fullscreen view
 Click the expand button (top-right of any Mermaid diagram on hover) to open the
 diagram in a fullscreen modal with pan/zoom and a docked comment panel. The modal

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ This makes feedback:
 
 - Real-time reload via SSE when files change externally
 - Mermaid diagram rendering with commentable text
+- YAML and TOML frontmatter rendered as commentable content, not hidden
 - Local image embeds and clickable links between markdown files
 - Customizable comment templates
 - 8 themes: Light, Dark, Sepia, Nord, Solarized, GitHub, Rosé Pine, Catppuccin

--- a/e2e/frontmatter.spec.ts
+++ b/e2e/frontmatter.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type Page } from '@playwright/test';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { addComment } from './helpers/comments';
+import { resetTestAppState } from './helpers/test-state';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMP_FIXTURE_DIR = resolve(__dirname, '..', 'node_modules', '.md-redline-e2e');
+
+const SKILL_DOC = `---
+name: mcp2cli
+description: Use when an MCP server should be driven from the shell
+tools:
+  - Read
+  - Write
+---
+
+# Overview
+
+Body text that follows the frontmatter.
+`;
+
+let fixtureDir = '';
+let fixturePath = '';
+
+test.beforeEach(async ({ page }, testInfo) => {
+  mkdirSync(TEMP_FIXTURE_DIR, { recursive: true });
+  fixtureDir = resolve(
+    TEMP_FIXTURE_DIR,
+    `frontmatter-${process.pid}-${testInfo.retry}-${Date.now()}`,
+  );
+  mkdirSync(fixtureDir, { recursive: true });
+  fixturePath = resolve(fixtureDir, 'skill-doc.md');
+  writeFileSync(fixturePath, SKILL_DOC);
+  await resetTestAppState(page);
+});
+
+test.afterEach(async () => {
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+async function openFixture(page: Page) {
+  await page.goto(`/?file=${fixturePath}`);
+  await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible({ timeout: 10_000 });
+}
+
+test.describe('Frontmatter in the rendered view', () => {
+  test('renders the block above the first heading with its text intact', async ({ page }) => {
+    await openFixture(page);
+
+    const block = page.locator('.doc-frontmatter');
+    await expect(block).toBeVisible();
+
+    // Byte-identical to the source between the fences. Comment anchoring
+    // searches the raw file for whatever the DOM hands it, so any
+    // transformation here breaks commenting silently.
+    const text = await block.innerText();
+    const expected = SKILL_DOC.split('---\n')[1].replace(/\n$/, '');
+    expect(text.replace(/\r/g, '')).toBe(expected);
+  });
+
+  test('comments on a frontmatter value without corrupting the block', async ({ page }) => {
+    await openFixture(page);
+
+    await addComment(
+      page,
+      'Use when an MCP server should be driven from the shell',
+      'too vague, name the shapes',
+    );
+
+    await expect
+      .poll(() => readFileSync(fixturePath, 'utf-8'), { timeout: 10_000 })
+      .toContain('too vague, name the shapes');
+
+    const content = readFileSync(fixturePath, 'utf-8');
+    // The marker sits after the closing fence, never inside it.
+    const fenceEnd = content.indexOf('\n---\n') + '\n---\n'.length;
+    expect(content.slice(0, fenceEnd)).not.toContain('@comment');
+    expect(content.startsWith('---\nname: mcp2cli\n')).toBe(true);
+    expect(content).toContain('description: Use when an MCP server should be driven from the shell');
+
+    // And the highlight paints on the field itself.
+    const mark = page.locator('.doc-frontmatter mark');
+    await expect(mark).toHaveText('Use when an MCP server should be driven from the shell');
+  });
+
+  test('leaves a document without frontmatter alone', async ({ page }) => {
+    writeFileSync(fixturePath, '# Plain\n\nNo frontmatter here.\n');
+    await page.goto(`/?file=${fixturePath}`);
+    await expect(page.getByRole('heading', { name: 'Plain' })).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('.doc-frontmatter')).toHaveCount(0);
+  });
+});

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -9,6 +9,7 @@ import {
   matchTableScroll,
 } from './MarkdownViewer';
 import { renderMarkdown } from '../markdown/pipeline';
+import { insertComment, parseComments } from '../lib/comment-parser';
 
 describe('matchTableScroll', () => {
   it('restores offsets to the same tables when nothing changed', () => {
@@ -199,6 +200,39 @@ describe('MarkdownViewer comment highlights — markdown-formatted anchor fallba
       const mark = container.querySelector('mark.comment-highlight');
       expect(mark).not.toBeNull();
       expect(mark?.textContent).toBe('Hello world');
+    });
+  });
+});
+
+describe('MarkdownViewer comment highlights — frontmatter fields', () => {
+  it('paints a highlight on a frontmatter value, from a marker parsed out of the file', async () => {
+    // End to end for the frontmatter feature: insertComment relocates the
+    // marker past the closing fence, parseComments reads it back, and the
+    // highlight has to land on the rendered field rather than nowhere.
+    const source =
+      '---\nname: mcp2cli\ndescription: Use when a server should be driven from the shell\n---\n\n# Overview\n\nBody text.\n';
+    const raw = insertComment(source, 'Use when a server should be driven from the shell', 'too vague?');
+    const { comments, cleanMarkdown } = parseComments(raw);
+    expect(comments).toHaveLength(1);
+    expect(cleanMarkdown).toBe(source);
+
+    const { container } = render(
+      <MarkdownViewer
+        html={renderMarkdown(cleanMarkdown)}
+        cleanMarkdown={cleanMarkdown}
+        comments={comments}
+        activeCommentId={null}
+        selectionText={null}
+        selectionOffset={null}
+        onHighlightClick={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      const mark = container.querySelector('mark.comment-highlight');
+      expect(mark).not.toBeNull();
+      expect(mark?.textContent).toBe('Use when a server should be driven from the shell');
+      expect(mark?.closest('.doc-frontmatter')).not.toBeNull();
     });
   });
 });

--- a/src/index.css
+++ b/src/index.css
@@ -727,6 +727,31 @@ body {
   color: inherit;
 }
 
+/* Frontmatter block.
+   Rendered as document content because in a review tool it is content: a skill
+   file's `description` is what an agent reads, an ADR's `status` is a claim
+   worth arguing with. Styled as a quiet preamble rather than a table so it
+   reads as metadata about the document and never competes with the first
+   heading. `pre-wrap` is load-bearing, not cosmetic: the DOM text has to stay
+   byte-identical to the source or comment anchoring can't find it, so the
+   newlines and nesting indentation must survive layout. */
+.doc-frontmatter {
+  white-space: pre-wrap;
+  margin-bottom: 1.75em;
+  padding: 0.6em 0.85em;
+  border-radius: 6px;
+  background-color: var(--theme-bg-secondary);
+  color: var(--theme-text-muted);
+  font-size: 0.75em;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.doc-frontmatter__key {
+  color: var(--theme-text-secondary);
+  font-weight: 500;
+}
+
 /* Image sizing.
    Constrain to the prose container width and preserve aspect ratio.
    The server-side /api/asset route injects width/height attributes for

--- a/src/markdown/pipeline.test.ts
+++ b/src/markdown/pipeline.test.ts
@@ -60,12 +60,55 @@ describe('renderMarkdown', () => {
     expect(html).toContain('class="custom"');
   });
 
-  it('handles YAML frontmatter (should not appear in output)', () => {
+  it('renders YAML frontmatter as document content', () => {
     const md = '---\ntitle: Test\nauthor: Someone\n---\n\n# Content';
     const html = renderMarkdown(md);
-    expect(html).not.toContain('title: Test');
-    expect(html).not.toContain('author: Someone');
+    expect(html).toContain('class="doc-frontmatter"');
+    expect(html).toContain('title');
+    expect(html).toContain('Someone');
     expect(html).toContain('<h1>Content</h1>');
+  });
+
+  it('renders TOML frontmatter too', () => {
+    const html = renderMarkdown('+++\ntitle = "Post"\n+++\n\n# Content');
+    expect(html).toContain('class="doc-frontmatter"');
+    expect(html).toContain('"Post"');
+  });
+
+  it('emits frontmatter text byte-identically, fences excluded', () => {
+    // Comment anchoring searches the raw markdown for text the DOM handed it,
+    // so any transformation here silently breaks comment creation. Compare the
+    // element's text content against the source block verbatim.
+    const body = 'name: mcp2cli\ndescription: Use when a server should be driven\n  from the shell.\ntools:\n  - Read';
+    const html = renderMarkdown(`---\n${body}\n---\n\n# Overview`);
+    const inner = html.slice(
+      html.indexOf('<div class="doc-frontmatter">') + '<div class="doc-frontmatter">'.length,
+      html.indexOf('</div>'),
+    );
+    const text = inner.replace(/<[^>]+>/g, '');
+    expect(text).toBe(body);
+  });
+
+  it('does not treat a mid-document --- as frontmatter', () => {
+    const html = renderMarkdown('# Title\n\ntext\n\n---\n\nmore');
+    expect(html).not.toContain('doc-frontmatter');
+    expect(html).toContain('<hr>');
+  });
+
+  it('escapes HTML inside frontmatter values', () => {
+    const html = renderMarkdown('---\nx: <script>alert(1)</script>\n---\n\n# H');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('doc-frontmatter');
+  });
+
+  it('leaves a document without frontmatter unchanged', () => {
+    const html = renderMarkdown('# Title\n\nBody.');
+    expect(html).not.toContain('doc-frontmatter');
+  });
+
+  it('drops an empty frontmatter block instead of rendering an empty box', () => {
+    expect(renderMarkdown('---\n---\n\n# H')).not.toContain('doc-frontmatter');
+    expect(renderMarkdown('---\n\n---\n\n# H')).not.toContain('doc-frontmatter');
   });
 
   it('handles empty input', () => {

--- a/src/markdown/pipeline.ts
+++ b/src/markdown/pipeline.ts
@@ -88,12 +88,70 @@ function rehypeWrapTables() {
   };
 }
 
+/**
+ * Render a frontmatter block as visible document content.
+ *
+ * Frontmatter is content in a review tool: a skill file's `description` is the
+ * text an agent reads to decide whether to load the skill, an ADR's `status`
+ * is a claim someone will want to argue with. remark-rehype has no handler for
+ * `yaml` / `toml` nodes, so without this they never reach the HTML.
+ *
+ * The emitted text is byte-identical to the source, fences excluded. That is a
+ * hard requirement, not a stylistic one: comments anchor by searching the raw
+ * markdown for the text the DOM handed us, so any transformation here (a
+ * prettified key, a stripped quote, a re-wrapped fold) means `insertComment`
+ * can't find the anchor and returns the document unchanged, so the comment
+ * vanishes with no marker and no error. Style it with CSS, never by rewriting
+ * the string.
+ *
+ * Keys are wrapped in a span for styling only; the delimiter and value stay in
+ * their own text nodes so the concatenated text still matches the source.
+ */
+function frontmatterHandler(_state: unknown, node: { value: string }): Element | undefined {
+  // An empty block (`---\n---`) would otherwise render as a bare tinted box
+  // above the first heading. Returning undefined drops the node entirely.
+  if (node.value.trim() === '') return undefined;
+
+  const children: (Element | { type: 'text'; value: string })[] = [];
+  const lines = node.value.split('\n');
+
+  lines.forEach((line, index) => {
+    // `key:` for YAML, `key =` for TOML. Anything else (list items, nested
+    // maps, folded continuation lines) passes through untouched.
+    const keyed = /^([ \t]*)([A-Za-z0-9_.-]+)([ \t]*[:=])(.*)$/.exec(line);
+    if (keyed) {
+      const [, indent, key, delimiter, rest] = keyed;
+      if (indent) children.push({ type: 'text', value: indent });
+      children.push({
+        type: 'element',
+        tagName: 'span',
+        properties: { className: ['doc-frontmatter__key'] },
+        children: [{ type: 'text', value: key }],
+      });
+      children.push({ type: 'text', value: delimiter + rest });
+    } else if (line) {
+      children.push({ type: 'text', value: line });
+    }
+    if (index < lines.length - 1) children.push({ type: 'text', value: '\n' });
+  });
+
+  return {
+    type: 'element',
+    tagName: 'div',
+    properties: { className: ['doc-frontmatter'] },
+    children: children as Element['children'],
+  };
+}
+
 function buildProcessor(filePath?: string) {
   return unified()
     .use(remarkParse)
     .use(remarkFrontmatter, ['yaml', 'toml'])
     .use(remarkGfm)
-    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(remarkRehype, {
+      allowDangerousHtml: true,
+      handlers: { yaml: frontmatterHandler, toml: frontmatterHandler },
+    })
     .use(rehypeRaw)
     .use(rewriteLocalUrls, { filePath })
     .use(rehypeSanitize, sanitizeSchema)


### PR DESCRIPTION
Closes #20.

## Why

Most renderers hide frontmatter, and for a general renderer that's correct. A review tool has a different contract. A skill file's `description` is the text an agent reads to decide whether to load the skill, an ADR's `status` is a claim worth arguing with, and the rendered view is where reviewing happens. Thanks to @sethfitz for the report and the diagnosis.

`remark-rehype` has no handler for `yaml` / `toml` nodes, so they never reached the HTML. This adds one.

## What it looks like

A quiet preamble above the first heading rather than a table, so it reads as metadata and doesn't compete with the first heading. Keys are picked out with a span; everything else is text. Renders in both light and dark themes off the existing theme variables.

## The constraint worth knowing about

The emitted text is byte-identical to the source, fences excluded. That's a correctness requirement rather than a style choice: comments anchor by searching the raw markdown for the text the DOM handed over, so any transformation (a prettified key, a stripped quote, a re-wrapped fold) would make `insertComment` fail to find the anchor and return the document unchanged. The comment would vanish with no marker and no error. `white-space: pre-wrap` is load-bearing for the same reason. There's a test asserting the round trip exactly.

## Commenting

Works through the normal selection flow with no special casing. The marker lands outside the fences via the protected-regions guard in #24, the highlight paints on the field, and the rail, open count, and handoff all pick it up.

Verified end to end in the app: commenting on a `description` with a body containing `: ` (the string that used to break the YAML parse) leaves the block byte-identical and the file still parses.

Known gap, recorded in AGENTS.md and pre-existing rather than introduced here: relocation makes `cleanOffset` non-unique, so two comments on different fields sharing a value (`false` in two booleans) collide in `MarkdownViewer`'s highlight grouping and paint one highlight on the first occurrence. The same collapse reproduces with two comments on repeated text inside a single code fence, with no frontmatter involved. Fix is a follow-up PR and benefits the fence case equally.

## Tests

8 unit cases on the pipeline (verbatim text, TOML, HTML escaping, empty block dropped, mid-document `---` untouched), 1 integration case proving the highlight lands on the field from a marker parsed back out of the file, and 3 e2e covering the render, the full comment round trip against the file on disk, and a document without frontmatter.

Full unit suite, Playwright suite (305 passed), `tsc -b`, eslint, and `eval:dry` all green. The `10-frontmatter` eval fixture still passes unchanged, since rendering doesn't alter bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tof5nvvxJVHNRrYQViAvV2
