### PR TITLE
chore: stop local test runs collecting foreign specs and stale-bundle failures

### DIFF
--- a/server/mcp-stdio-subprocess.test.ts
+++ b/server/mcp-stdio-subprocess.test.ts
@@ -1,11 +1,50 @@
 import { describe, it, expect } from 'vitest';
 import { spawn } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 
 const BIN = join(__dirname, '..', 'bin', 'md-redline');
 const DIST_MCP = join(__dirname, '..', 'dist', 'mcp-stdio.js');
-const HAS_DIST = existsSync(DIST_MCP);
+
+/**
+ * Whether the built MCP bundle is current enough to spawn.
+ *
+ * `mdr mcp` refuses to start on a stale bundle, since it would otherwise run
+ * pre-edit code. Existence alone is therefore not enough to decide these tests
+ * can run: editing any bundled source without rebuilding leaves a bundle that
+ * exists but is rejected, and every test here then burns its 15s ceiling
+ * waiting for a subprocess that already exited. Mirror the bin's own rule
+ * (bin/md-redline, `mdr mcp bundle is stale`) over the same three roots so the
+ * suite skips for the same reason the binary refuses.
+ */
+function bundleIsRunnable(): boolean {
+  let bundleMtime: number;
+  try {
+    bundleMtime = statSync(DIST_MCP).mtimeMs;
+  } catch {
+    return false;
+  }
+  const root = join(__dirname, '..');
+  const stack = [join(root, 'server'), join(root, 'src', 'lib'), join(root, 'src', 'types.ts')];
+  while (stack.length) {
+    const path = stack.pop();
+    if (!path) continue;
+    let entry;
+    try {
+      entry = statSync(path);
+    } catch {
+      continue; // vanished between readdir and stat
+    }
+    if (entry.isDirectory()) {
+      for (const child of readdirSync(path)) stack.push(join(path, child));
+    } else if (entry.mtimeMs > bundleMtime) {
+      return false;
+    }
+  }
+  return true;
+}
+
+const HAS_DIST = existsSync(DIST_MCP) && bundleIsRunnable();
 
 interface JsonRpcResponse {
   jsonrpc: '2.0';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,10 +36,19 @@ export function mdrIdentityPlugin(): Plugin {
 export default defineConfig({
   plugins: [react(), tailwindcss(), ignoreMarkdownHotUpdatePlugin(), mdrIdentityPlugin()],
   test: {
-    // Exclude .worktrees/** so vitest doesn't pick up nested e2e specs from
-    // sibling git worktrees (e.g. .worktrees/<feature>/e2e/foo.spec.ts) and
-    // try to run them as unit tests. demo/ contains a Playwright spec too.
-    exclude: ['e2e/**', 'demo/**', 'node_modules/**', '.worktrees/**'],
+    // Exclude nested checkouts so vitest doesn't pick up their e2e specs
+    // (e.g. <worktree>/e2e/foo.spec.ts) and try to run them as unit tests.
+    // Two locations in practice: .worktrees/ for hand-made worktrees, and
+    // .claude/worktrees/ for the ones Claude Code creates. Without the second,
+    // a worktree left behind by another session adds ~70 failing "test files"
+    // to every local run. demo/ contains a Playwright spec too.
+    exclude: [
+      'e2e/**',
+      'demo/**',
+      'node_modules/**',
+      '.worktrees/**',
+      '.claude/**',
+    ],
   },
   server: {
     // Bind IPv4 loopback explicitly so the CLI's 127.0.0.1 probe of


### PR DESCRIPTION
Two things made `npx vitest run` misleading locally. Neither affects CI or product behavior.

## Foreign specs collected

The exclude list covered `.worktrees/` but not `.claude/worktrees/`, which is where Claude Code puts its worktrees. A worktree left behind by another session added ~70 Playwright specs to every local run as failing "test files": 394 files collected instead of 81.

## Stale-bundle failures reported as test failures

The MCP stdio subprocess tests gated on `dist/mcp-stdio.js` existing. But `mdr mcp` refuses to start on a bundle that exists and is stale, since it would otherwise run pre-edit code:

```
mdr mcp failed: mdr mcp bundle is stale
(src/lib/mermaid-diagram-comments.ts is 708s newer than dist/mcp-stdio.js).
```

So editing any bundled source without rebuilding left all three tests spawning a process that had already exited, each burning its 15s ceiling before failing. That reads as flakiness and isn't: it's deterministic on a stale bundle.

They now mirror the bin's own staleness rule over the same three roots (`server/`, `src/lib/`, `src/types.ts`), so they skip for the same reason the binary refuses.

## Verification

| | before | after |
|---|---|---|
| files collected | 394 | 81 |
| `npx vitest run`, stale bundle | 3 failed, ~45s of timeouts | 3 skipped |
| `npm run build` then re-run | 3 passed | 3 passed |
| full suite, no flags | 3 failed | 1552 passed |

`tsc -b` and eslint clean.

## Known gap this exposed, not addressed here

These three tests are skipped in CI entirely: the `unit` job runs `npm ci` then `vitest run` with no build step, and `dist` is gitignored, so the bundle never exists there. The MCP stdio path therefore has no CI coverage. Follow-up PR adds a build step to that job so they actually run, kept separate because it changes runtime on every push and may need tuning for the Windows spawn ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tof5nvvxJVHNRrYQViAvV2
