### PR TITLE
ci: build server bundles so the MCP stdio tests actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,5 +65,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # The MCP stdio subprocess tests spawn `bin/md-redline mcp`, which needs
+      # dist/server.js (its production-mode probe) and dist/mcp-stdio.js (the
+      # bundle it runs). Without them the whole suite skips itself, so the
+      # spawn path shipped untested for as long as this job has been green.
+      # build:server is esbuild only, no tsc or vite, and takes well under a
+      # second, so this buys real coverage on all three platforms for
+      # essentially no runtime. Spawning is exactly what this matrix is for.
+      - name: Build server bundles
+        run: npm run build:server
+
       - name: Unit and CLI tests
         run: npm run test:unit


### PR DESCRIPTION
## Problem

The `unit` job runs `npm ci` then `npm run test:unit` with no build step, and `dist` is gitignored. So `dist/mcp-stdio.js` never exists on a runner, and `server/mcp-stdio-subprocess.test.ts` gates on it:

```ts
const HAS_DIST = existsSync(DIST_MCP);
(HAS_DIST ? describe : describe.skip)('mdr mcp stdio (subprocess)', () => {
```

Those three tests have been skipping themselves on every CI run. The spawn path behind `mdr mcp`, which is how every agent connects to md-redline, has had no CI coverage while the job reported green.

## Fix

Add `npm run build:server` before the tests. That's esbuild only, no `tsc` and no `vite`, and it produces exactly the two files the bin needs:

- `dist/server.js` for the production-mode probe (`isProductionMode()` only stats this)
- `dist/mcp-stdio.js` for the bundle it runs

Locally it takes **0.26s**, and the three tests pass against a `dist` containing only those two outputs, so the full build isn't needed.

## Why here rather than in `checks`

Moving the tests into the `checks` job would get them running for free, since that job already builds, but only on Linux. The matrix comment in this file says it exists because "this is where platform-specific behaviour lives: process spawning, path handling, and the browser launcher." A test that spawns `bin/md-redline` as a subprocess is precisely that, so it should run on all three.

## What to watch on this PR

This is the first time these tests have ever executed in CI, so this run is the experiment. The per-step ceilings are 5s for initialize, 5s for tools/list, 10s for tools/call, inside a 15s test timeout. Windows spawn is the slowest of the three and is the plausible failure point. If it flakes there, raise the ceilings rather than dropping back to Linux-only, since cross-OS coverage of a spawn path is the whole point.

Independent of #27, which fixes the local-side version of the same confusion. Either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tof5nvvxJVHNRrYQViAvV2
