### PR TITLE
fix: review follow-ups for the frontmatter and marker-relocation work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -715,8 +715,9 @@ keep them apart:
 Neither is frontmatter-specific: the same collapse reproduces with two comments
 on repeated text inside one code fence.
 
-The plain-text offset drift is a red herring here: it measures 4 characters and
-the creation path resolves correctly.
+The plain-text offset drift is a red herring here: the two `---` fences stay in
+plain space and are absent from the DOM, and the creation path resolves
+correctly either way.
 
 ### Mermaid fullscreen view
 Click the expand button (top-right of any Mermaid diagram on hover) to open the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -698,16 +698,19 @@ lands after the closing fence (see Protected containers under Comment format).
 Relocation makes `cleanOffset` non-unique: every marker pushed out of the same
 container lands on the same offset, so two comments on fields that share a
 value (`false` in two booleans) can't be told apart by position. Two things
-keep them separate, and both matter:
+keep them apart:
 
-- `insertComment` backfills `contextBefore` / `contextAfter` from the position
-  the anchor actually resolved to whenever it relocates a marker and the caller
-  supplied none. Agents writing over MCP never supply them, so without this the
-  highest-volume writer produces indistinguishable markers.
-- `MarkdownViewer` includes those contexts in its highlight grouping key,
-  joined on an explicit `\u0000` escape. Grouping runs before matching, so a
-  key that omits context collapses the two comments into one group and paints a
-  single `<mark>` on the first occurrence.
+- `MarkdownViewer` includes `contextBefore` / `contextAfter` in its highlight
+  grouping key, joined on an explicit `\u0000` escape. Grouping runs before
+  matching, so a key of offset plus anchor alone collapses the two comments
+  into one group and paints a single `<mark>` on the first occurrence. The UI
+  always captures context from the selection; the MCP route forwards whatever
+  the agent supplied.
+- When no context is supplied at all, `insertComment` resolves the anchor to
+  its **first** match, since that path has no hint offset. Two such comments
+  therefore refer to the same occurrence and sharing one highlight is correct
+  rather than a collapse. That invariant is load-bearing: giving the MCP route
+  a hint offset without also giving it context would reintroduce the collapse.
 
 Neither is frontmatter-specific: the same collapse reproduces with two comments
 on repeated text inside one code fence.
@@ -740,8 +743,8 @@ its imperative DOM rebuild while a block is open and portals the editor into an
 in-flow host beside the hidden block(s). Code fences, tables, and Mermaid
 diagrams edit as source text (the rendered Mermaid block carries the source
 offsets, so clicking the diagram opens its ```mermaid``` source; the fullscreen
-button still works in edit mode). Frontmatter is not rendered, so it has no
-inline edit target (edit it via the raw view).
+button still works in edit mode). Frontmatter renders (see Frontmatter above) but is not an
+inline edit target; edit it via the raw view.
 
 Cross-block editing: the editable unit is a source range that can grow. Backspace
 at the block start merges the previous block (Delete at the end merges the next):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -695,17 +695,25 @@ reason.
 Commenting on a field works through the normal selection flow. The marker
 lands after the closing fence (see Protected containers under Comment format).
 
-Known gap, pre-existing and not specific to frontmatter: relocation makes
-`cleanOffset` non-unique, since every marker pushed out of the same container
-lands on the same offset. `MarkdownViewer` groups highlights by
-`` `${cleanOffset}:${anchor}` ``, so two comments on different fields that share
-a value (`false` in two booleans) collide into one group and paint a single
-highlight on the first occurrence, with the second comment's id riding along on
-the same `<mark>`. The `contextBefore` that would separate them is stored but
-never consulted, because grouping happens before matching. The same collapse
-reproduces with two comments on repeated text inside one code fence, so it
-predates frontmatter rendering. The plain-text offset drift is a red herring
-here: it measures 4 characters and the creation path resolves correctly.
+Relocation makes `cleanOffset` non-unique: every marker pushed out of the same
+container lands on the same offset, so two comments on fields that share a
+value (`false` in two booleans) can't be told apart by position. Two things
+keep them separate, and both matter:
+
+- `insertComment` backfills `contextBefore` / `contextAfter` from the position
+  the anchor actually resolved to whenever it relocates a marker and the caller
+  supplied none. Agents writing over MCP never supply them, so without this the
+  highest-volume writer produces indistinguishable markers.
+- `MarkdownViewer` includes those contexts in its highlight grouping key,
+  joined on an explicit `\u0000` escape. Grouping runs before matching, so a
+  key that omits context collapses the two comments into one group and paints a
+  single `<mark>` on the first occurrence.
+
+Neither is frontmatter-specific: the same collapse reproduces with two comments
+on repeated text inside one code fence.
+
+The plain-text offset drift is a red herring here: it measures 4 characters and
+the creation path resolves correctly.
 
 ### Mermaid fullscreen view
 Click the expand button (top-right of any Mermaid diagram on hover) to open the

--- a/e2e/frontmatter.spec.ts
+++ b/e2e/frontmatter.spec.ts
@@ -8,9 +8,14 @@ import { resetTestAppState } from './helpers/test-state';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMP_FIXTURE_DIR = resolve(__dirname, '..', 'node_modules', '.md-redline-e2e');
 
+// Deliberately contains the characters the HTML serializer has to escape
+// (<, >, &, both quote flavours). The innerText comparison below then proves
+// they survive the round trip and decode back to the source exactly, which is
+// what comment anchoring depends on.
 const SKILL_DOC = `---
 name: mcp2cli
 description: Use when an MCP server should be driven from the shell
+pattern: <server> & "tool" or 'alias'
 tools:
   - Read
   - Write

--- a/server/mcp-stdio-subprocess.test.ts
+++ b/server/mcp-stdio-subprocess.test.ts
@@ -37,14 +37,23 @@ function bundleIsRunnable(): boolean {
     }
     if (entry.isDirectory()) {
       for (const child of readdirSync(path)) stack.push(join(path, child));
-    } else if (entry.mtimeMs > bundleMtime) {
-      return false;
+    } else if (path.endsWith('.ts')) {
+      // Same two filters the bin applies. Test files don't reach the bundle,
+      // so editing one must not report staleness — without this, touching any
+      // of the ~30 *.test.ts files under these roots silently disables this
+      // suite while `mdr mcp` itself would start perfectly well. This file
+      // qualifies, which made the check disable itself on its own edit.
+      if (path.endsWith('.test.ts') || path.endsWith('.spec.ts')) continue;
+      if (entry.mtimeMs > bundleMtime) return false;
     }
   }
   return true;
 }
 
-const HAS_DIST = existsSync(DIST_MCP) && bundleIsRunnable();
+// The bin needs dist/server.js too: its production-mode probe stats that file
+// before it will run `mcp` at all.
+const HAS_DIST =
+  existsSync(DIST_MCP) && existsSync(join(__dirname, '..', 'dist', 'server.js')) && bundleIsRunnable();
 
 interface JsonRpcResponse {
   jsonrpc: '2.0';

--- a/server/theme-contrast.test.ts
+++ b/server/theme-contrast.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Contrast floor for the rendered frontmatter block, checked against every
+ * shipped theme.
+ *
+ * The block's first version used --theme-text-muted on --theme-bg-secondary,
+ * which measures 2.18:1 on Solarized and failed AA on six of the eight themes.
+ * The prose counters and bullets had already been moved off muted for exactly
+ * this reason (see the comment above --tw-prose-counters in index.css), so
+ * this was the codebase making the same mistake twice. The guard lives here
+ * rather than under src/ because it reads a file off disk, and only the node
+ * tsconfig covers that.
+ */
+const CSS = readFileSync(join(__dirname, '..', 'src', 'index.css'), 'utf-8');
+
+function luminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const full = h.length === 3 ? [...h].map((c) => c + c).join('') : h;
+  const channels = [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16) / 255);
+  const linear = channels.map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
+function contrast(a: string, b: string): number {
+  const [hi, lo] = [luminance(a), luminance(b)].sort((x, y) => y - x);
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+interface Theme {
+  name: string;
+  vars: Record<string, string>;
+}
+
+function themeBlocks(): Theme[] {
+  const blocks: Theme[] = [];
+  const re = /(:root, \[data-theme="light"\]|\[data-theme="[a-z-]+"\])\s*\{([\s\S]*?)\n\}/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(CSS)) !== null) {
+    const name = /"([a-z-]+)"/.exec(match[1])?.[1] ?? 'light';
+    const vars: Record<string, string> = {};
+    for (const v of match[2].matchAll(/--theme-([a-z-]+):\s*(#[0-9a-fA-F]{3,8})/g)) {
+      vars[v[1]] = v[2];
+    }
+    if (vars['bg-secondary']) blocks.push({ name, vars });
+  }
+  return blocks;
+}
+
+describe('frontmatter block contrast', () => {
+  const themes = themeBlocks();
+
+  it('finds every shipped theme', () => {
+    expect(themes.length).toBe(8);
+  });
+
+  it.each(themes.map((t) => [t.name, t] as const))('reads legibly on %s', (_name, theme) => {
+    // 4.3 is the floor Solarized sets with text-secondary, which is the same
+    // ink the app already ships for body copy. Below that is a regression.
+    expect(contrast(theme.vars['text-secondary'], theme.vars['bg-secondary'])).toBeGreaterThan(4.3);
+    expect(contrast(theme.vars['text'], theme.vars['bg-secondary'])).toBeGreaterThan(4.5);
+  });
+});

--- a/server/theme-contrast.test.ts
+++ b/server/theme-contrast.test.ts
@@ -9,10 +9,14 @@ import { join } from 'node:path';
  * The block's first version used --theme-text-muted on --theme-bg-secondary,
  * which measures 2.18:1 on Solarized and failed AA on six of the eight themes.
  * The prose counters and bullets had already been moved off muted for exactly
- * this reason (see the comment above --tw-prose-counters in index.css), so
- * this was the codebase making the same mistake twice. The guard lives here
- * rather than under src/ because it reads a file off disk, and only the node
- * tsconfig covers that.
+ * this reason (see the comment above --tw-prose-counters in index.css), so it
+ * was the codebase making the same mistake twice.
+ *
+ * The colours are read out of the `.doc-frontmatter` rule rather than named
+ * here. Asserting on --theme-text-secondary by name would pass just as happily
+ * after someone set the block back to muted, which is the one regression this
+ * file exists to catch. It lives under server/ because it reads a file off
+ * disk, and only the node tsconfig covers that.
  */
 const CSS = readFileSync(join(__dirname, '..', 'src', 'index.css'), 'utf-8');
 
@@ -49,17 +53,45 @@ function themeBlocks(): Theme[] {
   return blocks;
 }
 
+/** Body of a CSS rule, located by its selector. */
+function ruleBody(selector: string): string {
+  const start = CSS.indexOf(`${selector} {`);
+  if (start === -1) throw new Error(`no rule for ${selector}`);
+  return CSS.slice(start, CSS.indexOf('\n}', start));
+}
+
+/** Which --theme-* variable a property in that rule resolves to. */
+function themeVarFor(selector: string, property: string): string {
+  // Anchored to line start: an unanchored `color:` also matches inside
+  // `background-color:`, which silently reads the background as the ink and
+  // makes every contrast ratio 1.
+  const match = new RegExp(`\\n\\s*${property}:\\s*var\\(--theme-([a-z-]+)\\)`).exec(
+    ruleBody(selector),
+  );
+  if (!match) throw new Error(`no ${property} in ${selector}`);
+  return match[1];
+}
+
 describe('frontmatter block contrast', () => {
   const themes = themeBlocks();
+  const background = themeVarFor('.doc-frontmatter', 'background-color');
+  const valueInk = themeVarFor('.doc-frontmatter', 'color');
+  const keyInk = themeVarFor('.doc-frontmatter__key', 'color');
 
   it('finds every shipped theme', () => {
     expect(themes.length).toBe(8);
   });
 
+  it('reads its colours out of the rule', () => {
+    expect(background).toBe('bg-secondary');
+    expect(themes[0].vars[valueInk]).toBeTruthy();
+    expect(themes[0].vars[keyInk]).toBeTruthy();
+  });
+
   it.each(themes.map((t) => [t.name, t] as const))('reads legibly on %s', (_name, theme) => {
-    // 4.3 is the floor Solarized sets with text-secondary, which is the same
-    // ink the app already ships for body copy. Below that is a regression.
-    expect(contrast(theme.vars['text-secondary'], theme.vars['bg-secondary'])).toBeGreaterThan(4.3);
-    expect(contrast(theme.vars['text'], theme.vars['bg-secondary'])).toBeGreaterThan(4.5);
+    // 4.3 is the floor Solarized sets with text-secondary, the same ink the app
+    // already ships for body copy. Below that is a regression, not a trade-off.
+    expect(contrast(theme.vars[valueInk], theme.vars[background])).toBeGreaterThan(4.3);
+    expect(contrast(theme.vars[keyInk], theme.vars[background])).toBeGreaterThan(4.5);
   });
 });

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -285,12 +285,17 @@ export const MarkdownViewer = memo(
         if (enableResolve && getEffectiveStatus(comment) === 'resolved') continue;
         const plainOffset =
           comment.cleanOffset != null ? toPlainOffset(comment.cleanOffset) : undefined;
+        // Joined on an explicit NUL escape, never a raw NUL byte in the
+        // source (that made the whole file read as binary to grep and other
+        // tooling) and never a space, since a space separator lets
+        // ["a b", "c"] and ["a", "b c"] produce the same key: the very
+        // collision class this key exists to prevent.
         const key = [
           comment.cleanOffset ?? '',
           comment.anchor,
           comment.contextBefore ?? '',
           comment.contextAfter ?? '',
-        ].join(' ');
+        ].join('\u0000');
         const group = highlightGroups.get(key) || {
           ids: [],
           anchor: comment.anchor,

--- a/src/components/RawView.tsx
+++ b/src/components/RawView.tsx
@@ -14,7 +14,7 @@ import remarkParse from 'remark-parse';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
 import { highlightSearchMatches } from './MarkdownViewer';
-import { createCommentMarkerRegex } from '../lib/comment-parser';
+import { createCommentMarkerRegex, createFrontmatterRegex } from '../lib/comment-parser';
 import { uniqueSlugs } from '../lib/heading-slugs';
 import { type DiffLine } from '../lib/diff';
 
@@ -49,8 +49,10 @@ const SYNTAX_RULES: SyntaxRule[] = [
   { pattern: /^(-{3,}|\*{3,}|_{3,})\s*$/gm, className: 'raw-hr' },
   // Table pipes
   { pattern: /^\|.*\|$/gm, className: 'raw-table' },
-  // Frontmatter — no `m` flag so ^ only matches start of string
-  { pattern: /^---\n[\s\S]*?\n---/g, className: 'raw-frontmatter' },
+  // Frontmatter. Shares its pattern with getFrontmatterRange so the raw view
+  // and the renderer cannot disagree about what counts: `+++` as well as
+  // `---`, CRLF, and trailing whitespace on the fence line.
+  { pattern: createFrontmatterRegex('g'), className: 'raw-frontmatter' },
   // HTML comments (non-@comment ones)
   { pattern: /<!--(?! @comment)[\s\S]*?-->/g, className: 'raw-html-comment' },
 ];

--- a/src/components/RenderedDiffView.test.ts
+++ b/src/components/RenderedDiffView.test.ts
@@ -5,6 +5,8 @@ import {
   segmentDiffFenceAware,
   countChunks,
   findFenceRanges,
+  segmentIsDocumentStart,
+  type DiffSegment,
 } from './RenderedDiffView';
 import { renderMarkdown } from '../markdown/pipeline';
 
@@ -105,11 +107,13 @@ describe('findFenceRanges', () => {
 });
 
 /** Mirrors RenderedDiffView's render loop: only leading segments sit at offset 0. */
-function renderSegments(segments: { type: string; text: string }[]): string {
-  const documentStartCount =
-    segments[0]?.type === 'removed' && segments[1]?.type === 'added' ? 2 : 1;
+function renderSegments(segments: DiffSegment[]): string {
   return segments
-    .map((seg, i) => renderMarkdown(seg.text, undefined, { allowFrontmatter: i < documentStartCount }))
+    .map((seg, i) =>
+      renderMarkdown(seg.text, undefined, {
+        allowFrontmatter: segmentIsDocumentStart(segments, i),
+      }),
+    )
     .join('');
 }
 

--- a/src/components/RenderedDiffView.test.ts
+++ b/src/components/RenderedDiffView.test.ts
@@ -117,6 +117,21 @@ function renderSegments(segments: DiffSegment[]): string {
     .join('');
 }
 
+describe('findFenceRanges with frontmatter', () => {
+  it('does not pair a fence line inside frontmatter with a real one below', () => {
+    // `  ``` ` in a YAML block scalar would otherwise open a range that the
+    // real ```js line closes, swallowing the prose between them as code and
+    // leaving the actual block unranged. getCodeBlockRanges skips these lines
+    // for the same reason; the two must agree.
+    const doc =
+      '---\ncode: |\n  ```\n---\n\nPara one.\n\nPara two.\n\n```js\nconst x = 1;\n```\n';
+    expect(findFenceRanges(doc)).toEqual([
+      { start: 1, end: 4 },
+      { start: 10, end: 12 },
+    ]);
+  });
+});
+
 describe('frontmatter in the diff overlay', () => {
   it('does not invent a frontmatter box from a mid-document ---', () => {
     // The changed first line isolates the rest into a segment that happens to
@@ -138,8 +153,14 @@ describe('frontmatter in the diff overlay', () => {
     expect(segments[0].text).toBe('---\ntitle: Old Title\nstatus: draft\n---');
     expect(segments[1].text).toBe('---\ntitle: New Title\nstatus: draft\n---');
     const html = renderSegments(segments);
-    expect(html).toContain('doc-frontmatter');
-    expect(html).not.toMatch(/<h2>status/);
+    // BOTH versions must render as frontmatter: the removed one and the added
+    // one are each at the document's start. Asserting only that the string
+    // appears somewhere passes with the second segment rendered as a stray
+    // rule plus a Setext heading.
+    expect([...html.matchAll(/class="doc-frontmatter"/g)]).toHaveLength(2);
+    expect(html).toContain('Old Title');
+    expect(html).toContain('New Title');
+    expect(html).not.toMatch(/<h2>/);
   });
 });
 

--- a/src/components/RenderedDiffView.test.ts
+++ b/src/components/RenderedDiffView.test.ts
@@ -6,6 +6,7 @@ import {
   countChunks,
   findFenceRanges,
 } from './RenderedDiffView';
+import { renderMarkdown } from '../markdown/pipeline';
 
 describe('segmentDiff', () => {
   it('returns a single same segment for identical text', () => {
@@ -100,6 +101,41 @@ describe('findFenceRanges', () => {
     const ranges = findFenceRanges(text);
     // Unclosed backtick fence — extends to EOF
     expect(ranges).toEqual([{ start: 1, end: 3 }]);
+  });
+});
+
+/** Mirrors RenderedDiffView's render loop: only leading segments sit at offset 0. */
+function renderSegments(segments: { type: string; text: string }[]): string {
+  const documentStartCount =
+    segments[0]?.type === 'removed' && segments[1]?.type === 'added' ? 2 : 1;
+  return segments
+    .map((seg, i) => renderMarkdown(seg.text, undefined, { allowFrontmatter: i < documentStartCount }))
+    .join('');
+}
+
+describe('frontmatter in the diff overlay', () => {
+  it('does not invent a frontmatter box from a mid-document ---', () => {
+    // The changed first line isolates the rest into a segment that happens to
+    // begin with `---`. Rendered as a whole document that text is two Setext
+    // headings, not frontmatter.
+    const oldText = 'Line-old\n---\nkey: value\n---\nTrailer unchanged';
+    const newText = 'Line-new\n---\nkey: value\n---\nTrailer unchanged';
+    const segments = segmentDiffFenceAware(computeDiff(oldText, newText), oldText, newText);
+    expect(renderSegments(segments)).not.toContain('doc-frontmatter');
+  });
+
+  it('keeps real frontmatter in one segment when a field is edited', () => {
+    // Split across segments, the leading `---` renders as a rule, the changed
+    // lines as bare paragraphs, and the closing `---` turns the last field
+    // into a Setext heading and vanishes.
+    const oldText = '---\ntitle: Old Title\nstatus: draft\n---\n\nBody text.\n';
+    const newText = '---\ntitle: New Title\nstatus: draft\n---\n\nBody text.\n';
+    const segments = segmentDiffFenceAware(computeDiff(oldText, newText), oldText, newText);
+    expect(segments[0].text).toBe('---\ntitle: Old Title\nstatus: draft\n---');
+    expect(segments[1].text).toBe('---\ntitle: New Title\nstatus: draft\n---');
+    const html = renderSegments(segments);
+    expect(html).toContain('doc-frontmatter');
+    expect(html).not.toMatch(/<h2>status/);
   });
 });
 

--- a/src/components/RenderedDiffView.tsx
+++ b/src/components/RenderedDiffView.tsx
@@ -10,6 +10,7 @@ import {
 } from 'react';
 import { type DiffLine } from '../lib/diff';
 import { renderMarkdown } from '../markdown/pipeline';
+import { getFrontmatterRange } from '../lib/comment-parser';
 
 export type DiffSegmentType = 'same' | 'added' | 'removed';
 
@@ -95,6 +96,17 @@ interface FenceRange {
 export function findFenceRanges(text: string): FenceRange[] {
   const lines = text.split('\n');
   const ranges: FenceRange[] = [];
+  // Frontmatter is atomic for the same reason a code fence is: split it across
+  // segments and each piece renders as something it is not, with the closing
+  // delimiter turning the last field into a Setext heading and disappearing.
+  const frontmatter = getFrontmatterRange(text);
+  if (frontmatter) {
+    const linesBefore = text.slice(0, frontmatter.end).split('\n');
+    // end is exclusive of the trailing newline's own line, so drop the empty
+    // trailing element the split leaves behind.
+    const lastLine = linesBefore[linesBefore.length - 1] === '' ? linesBefore.length - 1 : linesBefore.length;
+    ranges.push({ start: 1, end: lastLine });
+  }
   let openLine = -1;
   let openMarkerChar = '';
   let openMarkerLen = 0;
@@ -282,8 +294,14 @@ export const RenderedDiffView = forwardRef<RenderedDiffViewHandle, Props>(
 
     const html = useMemo(() => {
       const parts: string[] = [];
-      for (const seg of segments) {
-        const inner = renderMarkdown(seg.text);
+      // Only the leading segment starts at the document's offset 0, so only it
+      // may render frontmatter. When frontmatter itself changed, the removed
+      // and added versions are the first pair and both qualify.
+      const documentStartCount = segments[0]?.type === 'removed' && segments[1]?.type === 'added' ? 2 : 1;
+      for (const [segIndex, seg] of segments.entries()) {
+        const inner = renderMarkdown(seg.text, undefined, {
+          allowFrontmatter: segIndex < documentStartCount,
+        });
         if (seg.type === 'same') {
           parts.push(inner);
         } else {

--- a/src/components/RenderedDiffView.tsx
+++ b/src/components/RenderedDiffView.tsx
@@ -100,17 +100,25 @@ export function findFenceRanges(text: string): FenceRange[] {
   // segments and each piece renders as something it is not, with the closing
   // delimiter turning the last field into a Setext heading and disappearing.
   const frontmatter = getFrontmatterRange(text);
+  let frontmatterLastLine = 0;
   if (frontmatter) {
     const linesBefore = text.slice(0, frontmatter.end).split('\n');
     // end is exclusive of the trailing newline's own line, so drop the empty
     // trailing element the split leaves behind.
-    const lastLine = linesBefore[linesBefore.length - 1] === '' ? linesBefore.length - 1 : linesBefore.length;
-    ranges.push({ start: 1, end: lastLine });
+    frontmatterLastLine =
+      linesBefore[linesBefore.length - 1] === '' ? linesBefore.length - 1 : linesBefore.length;
+    ranges.push({ start: 1, end: frontmatterLastLine });
   }
   let openLine = -1;
   let openMarkerChar = '';
   let openMarkerLen = 0;
   for (let i = 0; i < lines.length; i++) {
+    // A fence line inside frontmatter is YAML or TOML content, not a fence.
+    // Counting it pairs it with the next real fence in the document, which
+    // both mis-ranges the body and, since the frontmatter range above already
+    // covers these lines, emits them a second time. getCodeBlockRanges skips
+    // them for the same reason.
+    if (i < frontmatterLastLine) continue;
     const m = /^ {0,3}(`{3,}|~{3,})/.exec(lines[i]);
     if (!m) continue;
     const marker = m[1];
@@ -165,6 +173,19 @@ function assignChunkIndices(segments: DiffSegment[]): void {
  *
  * Exported for unit testing.
  */
+/**
+ * Whether a segment begins at the document's offset 0, and may therefore
+ * render frontmatter.
+ *
+ * Only the leading segment does. When frontmatter itself is what changed, the
+ * removed and added versions are the leading pair and both qualify. Exported
+ * so the tests exercise this rule rather than restating it.
+ */
+export function segmentIsDocumentStart(segments: DiffSegment[], index: number): boolean {
+  const changedAtTop = segments[0]?.type === 'removed' && segments[1]?.type === 'added';
+  return index < (changedAtTop ? 2 : 1);
+}
+
 export function segmentDiffFenceAware(
   diffLines: DiffLine[],
   oldText: string,
@@ -294,13 +315,9 @@ export const RenderedDiffView = forwardRef<RenderedDiffViewHandle, Props>(
 
     const html = useMemo(() => {
       const parts: string[] = [];
-      // Only the leading segment starts at the document's offset 0, so only it
-      // may render frontmatter. When frontmatter itself changed, the removed
-      // and added versions are the first pair and both qualify.
-      const documentStartCount = segments[0]?.type === 'removed' && segments[1]?.type === 'added' ? 2 : 1;
       for (const [segIndex, seg] of segments.entries()) {
         const inner = renderMarkdown(seg.text, undefined, {
-          allowFrontmatter: segIndex < documentStartCount,
+          allowFrontmatter: segmentIsDocumentStart(segments, segIndex),
         });
         if (seg.type === 'same') {
           parts.push(inner);

--- a/src/components/RenderedDiffView.tsx
+++ b/src/components/RenderedDiffView.tsx
@@ -163,17 +163,6 @@ function assignChunkIndices(segments: DiffSegment[]): void {
 }
 
 /**
- * Fence-aware segmenter. Like segmentDiff, but never splits a code fence
- * across segments. When any line inside a fenced block is added or removed,
- * the entire fence is emitted as a single removed segment (full old fence)
- * + a single added segment (full new fence). Without this, per-segment
- * markdown rendering produces nonsense for fences whose body changes —
- * the opening ``` line, the changed line, and the closing ``` end up as
- * three separate markdown documents and the fence never opens.
- *
- * Exported for unit testing.
- */
-/**
  * Whether a segment begins at the document's offset 0, and may therefore
  * render frontmatter.
  *
@@ -186,6 +175,17 @@ export function segmentIsDocumentStart(segments: DiffSegment[], index: number): 
   return index < (changedAtTop ? 2 : 1);
 }
 
+/**
+ * Fence-aware segmenter. Like segmentDiff, but never splits a code fence
+ * across segments. When any line inside a fenced block is added or removed,
+ * the entire fence is emitted as a single removed segment (full old fence)
+ * + a single added segment (full new fence). Without this, per-segment
+ * markdown rendering produces nonsense for fences whose body changes —
+ * the opening ``` line, the changed line, and the closing ``` end up as
+ * three separate markdown documents and the fence never opens.
+ *
+ * Exported for unit testing.
+ */
 export function segmentDiffFenceAware(
   diffLines: DiffLine[],
   oldText: string,

--- a/src/components/rawView.test.ts
+++ b/src/components/rawView.test.ts
@@ -126,6 +126,20 @@ describe('buildHighlightedHtml', () => {
       expect(html).toContain('class="raw-heading"');
     });
 
+    it('highlights TOML frontmatter', () => {
+      // The rendered view learned `+++` when frontmatter rendering landed; the
+      // raw view kept its own YAML-only regex until both were pointed at one
+      // shared definition. Without it, a `# heading` inside a TOML block was
+      // styled as a real heading.
+      const html = buildHighlightedHtml('+++\ntitle = "Post"\n# not a heading\n+++\n\n# Real\n');
+      expect(html).toContain('class="raw-frontmatter"');
+    });
+
+    it('highlights CRLF frontmatter', () => {
+      const html = buildHighlightedHtml('---\r\nname: x\r\n---\r\n\r\n# Real\r\n');
+      expect(html).toContain('class="raw-frontmatter"');
+    });
+
     it('does not highlight --- in middle of file as frontmatter', () => {
       const html = buildHighlightedHtml('# Title\n\n---\n\nMore text');
       // The --- should be an HR, not frontmatter

--- a/src/hooks/useComments.test.ts
+++ b/src/hooks/useComments.test.ts
@@ -355,6 +355,36 @@ describe('useComments', () => {
   // 8. handleAddComment — calls insertComment and updateAndSave
   // -----------------------------------------------------------------------
   describe('handleAddComment', () => {
+    it('reports a failure instead of saving a no-op when the anchor is not found', () => {
+      // insertComment returns the document unchanged when it cannot place the
+      // marker. Saving that as success loses the comment with no marker and no
+      // error, and asks focus for an id that was never written.
+      const setRawMarkdown = vi.fn();
+      const saveFile = vi.fn();
+      const showToast = vi.fn();
+      const requestCommentFocus = vi.fn();
+      const raw = 'Hello world';
+      const rawMarkdownRef = { current: raw };
+      const params = defaultParams({
+        rawMarkdown: raw,
+        rawMarkdownRef: rawMarkdownRef as unknown as UseCommentsParams['rawMarkdownRef'],
+        setRawMarkdown,
+        saveFile,
+        showToast,
+        requestCommentFocus,
+      });
+      const { result } = renderHook(() => useComments(params));
+
+      act(() => {
+        result.current.handleAddComment('text that is not in the document', 'note');
+      });
+
+      expect(saveFile).not.toHaveBeenCalled();
+      expect(setRawMarkdown).not.toHaveBeenCalled();
+      expect(requestCommentFocus).not.toHaveBeenCalled();
+      expect(showToast).toHaveBeenCalledWith(expect.stringContaining("Couldn't anchor"), 'error');
+    });
+
     it('calls setRawMarkdown, saveFile, and sets activeCommentId', () => {
       const setRawMarkdown = vi.fn();
       const saveFile = vi.fn();

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -23,6 +23,7 @@ import {
   resolveAllComments,
   removeResolvedComments,
   detectMissingAnchors,
+  orderCommentsByAnchor,
 } from '../lib/comment-parser';
 import { getEffectiveStatus } from '../types';
 import { renderMarkdown } from '../markdown/pipeline';
@@ -341,10 +342,18 @@ export function useComments(params: UseCommentsParams) {
     [updateAndSave, rawMarkdownRef],
   );
 
+  // Document order, not array order: markers relocated out of frontmatter or a
+  // code fence share one offset, so the raw array visits them in the order they
+  // were written rather than the order they appear.
+  const orderedComments = useMemo(
+    () => orderCommentsByAnchor(cleanMarkdown, comments),
+    [cleanMarkdown, comments],
+  );
+
   const handleJumpToNext = useCallback(() => {
     const navigable = enableResolve
-      ? comments.filter((c) => getEffectiveStatus(c) === 'open')
-      : comments;
+      ? orderedComments.filter((c) => getEffectiveStatus(c) === 'open')
+      : orderedComments;
     if (navigable.length === 0) return;
 
     const currentIdx = activeCommentId ? navigable.findIndex((c) => c.id === activeCommentId) : -1;
@@ -353,12 +362,12 @@ export function useComments(params: UseCommentsParams) {
     setActiveCommentId(next.id);
     viewerRef.current?.scrollToComment(next.id);
     rawViewRef.current?.scrollToComment(next.id);
-  }, [comments, activeCommentId, enableResolve, viewerRef, rawViewRef]);
+  }, [orderedComments, activeCommentId, enableResolve, viewerRef, rawViewRef]);
 
   const handleJumpToPrev = useCallback(() => {
     const navigable = enableResolve
-      ? comments.filter((c) => getEffectiveStatus(c) === 'open')
-      : comments;
+      ? orderedComments.filter((c) => getEffectiveStatus(c) === 'open')
+      : orderedComments;
     if (navigable.length === 0) return;
 
     const currentIdx = activeCommentId ? navigable.findIndex((c) => c.id === activeCommentId) : -1;
@@ -367,7 +376,7 @@ export function useComments(params: UseCommentsParams) {
     setActiveCommentId(prev.id);
     viewerRef.current?.scrollToComment(prev.id);
     rawViewRef.current?.scrollToComment(prev.id);
-  }, [comments, activeCommentId, enableResolve, viewerRef, rawViewRef]);
+  }, [orderedComments, activeCommentId, enableResolve, viewerRef, rawViewRef]);
 
   return {
     activeCommentId,

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -193,12 +193,31 @@ export function useComments(params: UseCommentsParams) {
         hintOffset,
         newCommentId,
       );
+      // insertComment returns the document unchanged when it cannot place the
+      // marker (anchor not found in the source). Saving that as if it worked
+      // loses the comment with no marker, no error, and a focus request for an
+      // id that was never written. The MCP route already reports this case;
+      // the UI used to swallow it.
+      if (newRaw === (rawMarkdownRef.current ?? '')) {
+        showToast("Couldn't anchor that comment. Try selecting the text again.", 'error');
+        clearSelection();
+        setAutoExpandForm(false);
+        return;
+      }
       updateAndSave(newRaw);
       requestCommentFocus(newCommentId, 'creation');
       clearSelection();
       setAutoExpandForm(false);
     },
-    [updateAndSave, clearSelection, author, rawMarkdownRef, requestCommentFocus, setAutoExpandForm],
+    [
+      updateAndSave,
+      clearSelection,
+      author,
+      rawMarkdownRef,
+      requestCommentFocus,
+      setAutoExpandForm,
+      showToast,
+    ],
   );
 
   const handleResolve = useCallback(

--- a/src/index.css
+++ b/src/index.css
@@ -812,14 +812,20 @@ body {
   padding: 0.6em 0.85em;
   border-radius: 6px;
   background-color: var(--theme-bg-secondary);
-  color: var(--theme-text-muted);
+  /* Values sit at body-copy ink, not muted. Muted on --theme-bg-secondary
+     measures 2.18:1 on Solarized, 2.57 on Catppuccin and 2.82 on Nord, so six
+     of the eight themes failed AA and three sat under the 3:1 floor. This is
+     the same trap the prose counters and bullets above already fell into and
+     were moved off; the block reads as quiet through its size and its tint,
+     which do not cost anyone legibility. */
+  color: var(--theme-text-secondary);
   font-size: 0.75em;
   line-height: 1.55;
   overflow-wrap: anywhere;
 }
 
 .doc-frontmatter__key {
-  color: var(--theme-text-secondary);
+  color: var(--theme-text);
   font-weight: 500;
 }
 

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -2159,6 +2159,19 @@ describe('insertComment inside fenced code blocks', () => {
       expect(parseComments(result).comments).toHaveLength(1);
     });
 
+    it('keeps a marker out of frontmatter that contains an unclosed <!--', () => {
+      // The container passes run in sequence over one mutable offset. An
+      // unclosed `<!--` in a YAML value would otherwise open a protected range
+      // reaching EOF, and the HTML pass would drag the offset back INTO the
+      // frontmatter that the frontmatter pass had just moved it out of.
+      const raw = '---\nnote: <!-- unclosed\ntitle: Spec\n---\n\n# Body\n\nSome body text.\n';
+      const result = insertComment(raw, 'unclosed', 'why?');
+      const fenceEnd = result.indexOf('\n---\n') + '\n---\n'.length;
+      expect(result.slice(0, fenceEnd)).not.toContain('@comment');
+      expect(result.startsWith('---\nnote: <!-- unclosed\ntitle: Spec\n---\n')).toBe(true);
+      expect(parseComments(result).comments).toHaveLength(1);
+    });
+
     it('treats a <!-- inside a code fence as sample text, not a comment', () => {
       // Otherwise an unclosed `<!--` in a code sample would mark the entire
       // rest of the document as protected.

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -2091,6 +2091,37 @@ describe('insertComment inside fenced code blocks', () => {
     });
   });
 
+  describe('two no-context comments on the same anchor', () => {
+    it('resolve to the same occurrence, so sharing one highlight is correct', () => {
+      // Agents over MCP pass no hint offset, so insertComment takes the first
+      // match. Two such comments therefore refer to the SAME `false`, not to
+      // one field each, and downstream merging them onto a single highlight is
+      // right. Recorded because it looks like the offset-collapse bug and
+      // isn't: the cure would be for the agent to pass context, which the MCP
+      // route already forwards.
+      const doc = '# Config\n\n```yaml\ndraft: false\narchived: false\n```\n';
+      let raw = insertComment(doc, 'false', 'first', 'Agent');
+      raw = insertComment(raw, 'false', 'second', 'Agent');
+      const { comments, cleanMarkdown } = parseComments(raw);
+      expect(comments).toHaveLength(2);
+      const firstFalse = cleanMarkdown.indexOf('false');
+      for (const c of comments) {
+        expect(cleanMarkdown.startsWith('false', firstFalse)).toBe(true);
+        expect(c.contextBefore).toBeUndefined();
+      }
+    });
+
+    it('stay distinct when the agent does supply context', () => {
+      const doc = '# Config\n\n```yaml\ndraft: false\narchived: false\n```\n';
+      let raw = insertComment(doc, 'false', 'first', 'Agent', 'draft: ', '\narchived');
+      raw = insertComment(raw, 'false', 'second', 'Agent', 'archived: ', '\n```');
+      const { comments } = parseComments(raw);
+      const keyOf = (c: (typeof comments)[number]) =>
+        [c.cleanOffset, c.anchor, c.contextBefore ?? '', c.contextAfter ?? ''].join('|');
+      expect(keyOf(comments[0])).not.toBe(keyOf(comments[1]));
+    });
+  });
+
   describe('inside HTML comments', () => {
     it('places the marker before a block-level comment, not nested inside it', () => {
       const raw = '# Notes\n\n<!-- TODO: decide on the retry loop -->\n\nBody.\n';

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -21,6 +21,7 @@ import {
   backfillReplyTimestamps,
   findNewReplyIds,
   moveComment,
+  orderCommentsByAnchor,
   transformCommentMarkers,
   extractMermaidText,
 } from './comment-parser';
@@ -769,6 +770,35 @@ describe('edge cases', () => {
     const reparsed = parseComments(rebuilt);
     expect(reparsed.comments).toHaveLength(2);
     expect(reparsed.cleanMarkdown).toBe(cleanMarkdown);
+  });
+});
+
+describe('orderCommentsByAnchor', () => {
+  it('visits two frontmatter comments top-down even when written bottom-up', () => {
+    const doc = '---\ntitle: Login flow\ndescription: A spec\n---\n\n# Body\n\nText.\n';
+    let raw = insertComment(doc, 'A spec', 'lower field', 'User', 'description: ', '\n---');
+    raw = insertComment(raw, 'Login flow', 'upper field', 'User', 'title: ', '\ndescription');
+    const { comments, cleanMarkdown } = parseComments(raw);
+    // Both markers park on the same offset, so array order is insertion order.
+    expect(comments[0].cleanOffset).toBe(comments[1].cleanOffset);
+    expect(comments.map((c) => c.text)).toEqual(['lower field', 'upper field']);
+    expect(orderCommentsByAnchor(cleanMarkdown, comments).map((c) => c.text)).toEqual([
+      'upper field',
+      'lower field',
+    ]);
+  });
+
+  it('leaves ordinary comments in document order untouched', () => {
+    const doc = '# T\n\nAlpha here.\n\nBeta there.\n\nGamma too.\n';
+    let raw = insertComment(doc, 'Gamma', 'third', 'User');
+    raw = insertComment(raw, 'Alpha', 'first', 'User');
+    raw = insertComment(raw, 'Beta', 'second', 'User');
+    const { comments, cleanMarkdown } = parseComments(raw);
+    expect(orderCommentsByAnchor(cleanMarkdown, comments).map((c) => c.text)).toEqual([
+      'first',
+      'second',
+      'third',
+    ]);
   });
 });
 

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -2149,6 +2149,28 @@ describe('insertComment inside fenced code blocks', () => {
       expect(parseComments(result).cleanMarkdown).toBe(raw);
     });
 
+    it('does not nest inside an UNCLOSED html comment', () => {
+      // Every HTML parser reads an unclosed comment as running to EOF. A
+      // marker placed inside would close it early with its own `-->` and spill
+      // the remainder as visible text.
+      const raw = '# T\n\n<!-- TODO: decide the retry loop\n\nBody.\n';
+      const result = insertComment(raw, 'decide the retry loop', 'why?');
+      expect(result).not.toMatch(/<!-- TODO: <!--/);
+      expect(parseComments(result).comments).toHaveLength(1);
+    });
+
+    it('treats a <!-- inside a code fence as sample text, not a comment', () => {
+      // Otherwise an unclosed `<!--` in a code sample would mark the entire
+      // rest of the document as protected.
+      const raw = '# T\n\n```html\n<!-- sample\n```\n\nReal body text here.\n';
+      const result = insertComment(raw, 'Real body text', 'note');
+      const parsed = parseComments(result);
+      expect(parsed.comments).toHaveLength(1);
+      expect(parsed.cleanMarkdown).toBe(raw);
+      // The marker belongs next to its anchor, not hoisted to the stray `<!--`.
+      expect(result).toMatch(/@comment.*-->Real body text/);
+    });
+
     it('does not nest inside a malformed @comment marker left in the document', () => {
       const raw = '# H\n\n<!-- @comment{"id":"x","text":"unclosed -->\n\nbody\n';
       const result = insertComment(raw, 'unclosed', 'broken marker');

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -2159,6 +2159,29 @@ describe('insertComment inside fenced code blocks', () => {
       expect(parseComments(result).comments).toHaveLength(1);
     });
 
+    it('does not let a fence line inside frontmatter mis-pair the real fences', () => {
+      // `  ```" in a YAML block scalar used to open a range that the real
+      // ```js line closed. Everything between them counted as code and the
+      // real block did not, so a body comment was hoisted out of its paragraph
+      // and then skipped on the way back in: written to disk, parsed as zero
+      // comments, marker text stranded in the document.
+      const raw =
+        '---\ncode: |\n  ```\n---\n\nPara one.\n\nPara two.\n\n```js\nconst x = 1;\n```\n';
+      const result = insertComment(raw, 'Para two.', 'note');
+      const parsed = parseComments(result);
+      expect(parsed.comments).toHaveLength(1);
+      expect(parsed.cleanMarkdown).toBe(raw);
+      expect(result).toMatch(/@comment.*-->Para two\./);
+    });
+
+    it('still relocates a comment on code inside the real fence of that document', () => {
+      const raw =
+        '---\ncode: |\n  ```\n---\n\nPara one.\n\n```js\nconst x = 1;\n```\n';
+      const result = insertComment(raw, 'const x = 1;', 'note');
+      expect(result).not.toMatch(/```js\n<!-- @comment/);
+      expect(parseComments(result).comments).toHaveLength(1);
+    });
+
     it('keeps a marker out of frontmatter that contains an unclosed <!--', () => {
       // The container passes run in sequence over one mutable offset. An
       // unclosed `<!--` in a YAML value would otherwise open a protected range

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -1709,6 +1709,35 @@ export function extractMermaidText(cleanMarkdown: string): string {
  * Returns a set of comment IDs with missing anchors.
  * Parts must appear contiguously (with only whitespace between them) to count as found.
  */
+/**
+ * Comments in the order a reader meets them in the document.
+ *
+ * `cleanOffset` is the MARKER's position, which for an ordinary comment is
+ * also its anchor's. Relocated markers break that: every marker pushed out of
+ * one container parks on the same offset, so ordering by it alone falls back
+ * to insertion order and two comments on two frontmatter fields are visited
+ * bottom-up if they were written bottom-up. The rail stacks its cards by
+ * measured DOM position and gets this right, so navigation that disagrees
+ * contradicts the cards sitting in front of the user.
+ *
+ * Offsets decide as before; the anchor's own position only breaks ties, so
+ * nothing changes for comments that were never relocated.
+ */
+export function orderCommentsByAnchor(cleanMarkdown: string, comments: MdComment[]): MdComment[] {
+  const anchorPosition = (comment: MdComment): number => {
+    if (comment.contextBefore) {
+      const withContext = cleanMarkdown.indexOf(comment.contextBefore + comment.anchor);
+      if (withContext !== -1) return withContext + comment.contextBefore.length;
+    }
+    const direct = cleanMarkdown.indexOf(comment.anchor);
+    return direct === -1 ? (comment.cleanOffset ?? 0) : direct;
+  };
+  return [...comments].sort(
+    (a, b) =>
+      (a.cleanOffset ?? 0) - (b.cleanOffset ?? 0) || anchorPosition(a) - anchorPosition(b),
+  );
+}
+
 export function detectMissingAnchors(cleanMarkdown: string, comments: MdComment[]): Set<string> {
   const missing = new Set<string>();
   if (!cleanMarkdown) return missing;

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -37,8 +37,19 @@ function getCodeBlockRanges(rawMarkdown: string): CodeBlockRange[] {
   const fenceRegex = /^ {0,3}(`{3,}|~{3,}).*$/gm;
   let fenceMatch: RegExpExecArray | null;
   let openFence: { marker: string; start: number } | null = null;
+  // A fence line inside frontmatter is YAML or TOML content (a block scalar
+  // holding a code sample, say), not a real fence. Counting it opens a range
+  // that the next real fence in the document closes, which mis-pairs every
+  // fence after it: text between them is treated as code, and the block that
+  // actually is code is not. Both insertComment and collectCommentRegions read
+  // these ranges, so a mismatch there loses comments silently rather than
+  // noisily. See the "fence line inside frontmatter" tests.
+  const frontmatter = getFrontmatterRange(rawMarkdown);
 
   while ((fenceMatch = fenceRegex.exec(rawMarkdown)) !== null) {
+    if (frontmatter && fenceMatch.index >= frontmatter.start && fenceMatch.index < frontmatter.end) {
+      continue;
+    }
     const marker = fenceMatch[1];
     if (!openFence) {
       openFence = { marker: marker[0].repeat(marker.length), start: fenceMatch.index };

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -79,12 +79,30 @@ export function getFrontmatterRange(markdown: string): CodeBlockRange | null {
  * here as an ordinary comment, which is what we want: nothing should be
  * inserted inside it either.
  */
-function getHtmlCommentRanges(markdown: string): CodeBlockRange[] {
+function getHtmlCommentRanges(
+  markdown: string,
+  fencedRanges: CodeBlockRange[] = [],
+): CodeBlockRange[] {
   const ranges: CodeBlockRange[] = [];
-  const regex = /<!--[\s\S]*?-->/g;
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(markdown)) !== null) {
-    ranges.push({ start: match.index, end: match.index + match[0].length });
+  let from = 0;
+  while (from < markdown.length) {
+    const start = markdown.indexOf('<!--', from);
+    if (start === -1) break;
+    // A `<!--` inside a fenced block is sample text, not a comment. It also
+    // can't need protecting: the fence pass has already moved the marker out.
+    if (isInsideCodeBlock(start, fencedRanges)) {
+      from = start + 4;
+      continue;
+    }
+    const closer = markdown.indexOf('-->', start + 4);
+    // An unclosed comment runs to the end of the document, because that is how
+    // every HTML parser reads it. Treating it as unprotected would let a
+    // marker land inside, and the marker's own `-->` would then close the
+    // outer comment early and expose the remainder as visible text: exactly
+    // the corruption the closed-comment case exists to prevent.
+    const end = closer === -1 ? markdown.length : closer + 3;
+    ranges.push({ start, end });
+    from = end;
   }
   return ranges;
 }
@@ -596,8 +614,9 @@ export function insertComment(
   let ownLine = false;
   let leadingNewline = false;
   {
+    const fencedRanges = getCodeBlockRanges(cleanMarkdown);
     // Fenced blocks: before the opening fence.
-    for (const range of getCodeBlockRanges(cleanMarkdown)) {
+    for (const range of fencedRanges) {
       if (insertionCleanOffset >= range.start && insertionCleanOffset <= range.end) {
         insertionCleanOffset = range.start;
         ownLine = true;
@@ -620,7 +639,7 @@ export function insertComment(
     }
     // HTML comments: before the block. Only claim a whole line when the
     // comment owns one; an inline note keeps its paragraph intact.
-    for (const range of getHtmlCommentRanges(cleanMarkdown)) {
+    for (const range of getHtmlCommentRanges(cleanMarkdown, fencedRanges)) {
       if (insertionCleanOffset >= range.start && insertionCleanOffset < range.end) {
         insertionCleanOffset = range.start;
         ownLine = range.start === 0 || cleanMarkdown[range.start - 1] === '\n';

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -74,8 +74,15 @@ function getCodeBlockRanges(rawMarkdown: string): CodeBlockRange[] {
  * thematic break and a `+++` is ordinary text, so this deliberately anchors
  * to the start of the string.
  */
+export function createFrontmatterRegex(flags = ''): RegExp {
+  // One definition, because two consumers drifting is how the raw view ended
+  // up recognising only `---` while the renderer had learned `+++`. No `m`
+  // flag ever: `^` must anchor to the start of the document.
+  return new RegExp(String.raw`^(---|\+\+\+)[ \t]*\r?\n[\s\S]*?\r?\n\1[ \t]*(?:\r?\n|$)`, flags);
+}
+
 export function getFrontmatterRange(markdown: string): CodeBlockRange | null {
-  const match = /^(---|\+\+\+)[ \t]*\r?\n[\s\S]*?\r?\n\1[ \t]*(?:\r?\n|$)/.exec(markdown);
+  const match = createFrontmatterRegex().exec(markdown);
   if (!match) return null;
   return { start: 0, end: match[0].length };
 }

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -81,16 +81,20 @@ export function getFrontmatterRange(markdown: string): CodeBlockRange | null {
  */
 function getHtmlCommentRanges(
   markdown: string,
-  fencedRanges: CodeBlockRange[] = [],
+  nonHtmlRegions: CodeBlockRange[] = [],
 ): CodeBlockRange[] {
   const ranges: CodeBlockRange[] = [];
   let from = 0;
   while (from < markdown.length) {
     const start = markdown.indexOf('<!--', from);
     if (start === -1) break;
-    // A `<!--` inside a fenced block is sample text, not a comment. It also
-    // can't need protecting: the fence pass has already moved the marker out.
-    if (isInsideCodeBlock(start, fencedRanges)) {
+    // Regions where `<!--` is not an HTML comment: a fenced block, where it is
+    // sample text, and frontmatter, which is YAML or TOML. Treating a stray
+    // `<!--` in a YAML value as a comment would extend a protected range from
+    // inside the frontmatter to EOF, and the pass below would then drag the
+    // marker back INTO the frontmatter, undoing the very protection the
+    // frontmatter pass just applied.
+    if (isInsideCodeBlock(start, nonHtmlRegions)) {
       from = start + 4;
       continue;
     }
@@ -615,6 +619,7 @@ export function insertComment(
   let leadingNewline = false;
   {
     const fencedRanges = getCodeBlockRanges(cleanMarkdown);
+    const frontmatter = getFrontmatterRange(cleanMarkdown);
     // Fenced blocks: before the opening fence.
     for (const range of fencedRanges) {
       if (insertionCleanOffset >= range.start && insertionCleanOffset <= range.end) {
@@ -625,7 +630,6 @@ export function insertComment(
     // Frontmatter: after the closing fence. It cannot go before, since
     // frontmatter is only recognized at offset 0, so this is the one
     // container the marker trails rather than leads.
-    const frontmatter = getFrontmatterRange(cleanMarkdown);
     if (
       frontmatter &&
       insertionCleanOffset >= frontmatter.start &&
@@ -639,7 +643,12 @@ export function insertComment(
     }
     // HTML comments: before the block. Only claim a whole line when the
     // comment owns one; an inline note keeps its paragraph intact.
-    for (const range of getHtmlCommentRanges(cleanMarkdown, fencedRanges)) {
+    // Order matters and is safe in exactly one direction: this pass can only
+    // move the offset to a `<!--` that lies outside every fence and outside
+    // the frontmatter, so it can never undo the two passes above. Reordering
+    // these three, or dropping the exclusions, breaks that.
+    const nonHtmlRegions = frontmatter ? [...fencedRanges, frontmatter] : fencedRanges;
+    for (const range of getHtmlCommentRanges(cleanMarkdown, nonHtmlRegions)) {
       if (insertionCleanOffset >= range.start && insertionCleanOffset < range.end) {
         insertionCleanOffset = range.start;
         ownLine = range.start === 0 || cleanMarkdown[range.start - 1] === '\n';

--- a/src/lib/copy-selection-html.test.ts
+++ b/src/lib/copy-selection-html.test.ts
@@ -321,6 +321,24 @@ describe('buildRangeHtml', () => {
     expect(html).toContain('after');
   });
 
+  it('unwraps the frontmatter box the pipeline injects', () => {
+    // Same class of wrapper as the table scroll containers: a presentation box
+    // around document text. A selection crossing out of it reconstructs the
+    // div via cloneContents and would paste an app class into someone else's
+    // document.
+    const container = mount(
+      '<div class="doc-frontmatter"><span class="doc-frontmatter__key">title</span>: Spec</div><p>after</p>',
+    );
+    const field = container.querySelector('.doc-frontmatter')!;
+    const tail = container.querySelector('p')!;
+    const range = document.createRange();
+    range.setStart(field.lastChild!, 0);
+    range.setEnd(tail.firstChild!, tail.textContent!.length);
+    const html = buildRangeHtml(range, container) ?? '';
+    expect(html).not.toContain('doc-frontmatter');
+    expect(html).toContain('after');
+  });
+
   it('keeps table structure', () => {
     const container = mount(
       '<table><tbody><tr><td>Autonomous</td><td>EasyMate</td></tr></tbody></table>',

--- a/src/lib/copy-selection-html.ts
+++ b/src/lib/copy-selection-html.ts
@@ -39,7 +39,12 @@ const VIEWER_CHROME_SELECTOR = '[data-drag-handle], [data-comment-form], .mermai
  * app-specific containers into a rich editor is exactly what CONTENT_WRAPPERS
  * exists to prevent.
  */
-const LAYOUT_WRAPPER_SELECTOR = '.table-scroll, .table-scroll__viewport';
+// .doc-frontmatter is a presentation box around document text, exactly like
+// the table scroll wrappers: a selection running from a frontmatter field into
+// the prose below reconstructs it via cloneContents and would otherwise paste
+// an app class into someone else's document.
+const LAYOUT_WRAPPER_SELECTOR =
+  '.table-scroll, .table-scroll__viewport, .doc-frontmatter';
 
 /** Drop UI the viewer overlays on the prose so it never lands on the clipboard. */
 function stripViewerChrome(root: DocumentFragment | HTMLElement): void {

--- a/src/lib/mermaid-diagram-comments.test.ts
+++ b/src/lib/mermaid-diagram-comments.test.ts
@@ -80,6 +80,16 @@ describe('commentsForDiagram', () => {
     expect(commentsForDiagram(diagram, [c], md).map((c) => c.id)).toEqual([]);
   });
 
+  it('keeps a diagram comment whose label also appears in the frontmatter', () => {
+    // A frontmatter field echoing a node label is ordinary ("title: Login
+    // flow" over a diagram containing A[Login]). Asking the frontmatter first
+    // would drop this comment entirely.
+    const diagram = 'graph TD\n    A[Login] --> B';
+    const md = '---\ntitle: Login flow\n---\n```mermaid\n' + diagram + '\n```\n';
+    const c: MdComment = { ...makeComment('node', 'Login'), cleanOffset: md.indexOf('```mermaid') };
+    expect(commentsForDiagram(diagram, [c], md, 0).map((c) => c.id)).toEqual(['node']);
+  });
+
   it('still attributes a diagram comment sitting on the fence below frontmatter', () => {
     // Same geometry, but the anchor is a node label rather than a field value,
     // so the tie-break must keep it.

--- a/src/lib/mermaid-diagram-comments.ts
+++ b/src/lib/mermaid-diagram-comments.ts
@@ -101,8 +101,16 @@ export function commentsForDiagram(
     // comment relocated out of the block, or a frontmatter comment pushed
     // down past the closing `---` onto the same offset. Position alone can't
     // separate them, so defer to where the anchor text actually lives.
-    if (c.cleanOffset === claimStart && anchorLivesInFrontmatter(cleanMarkdown, c.anchor)) {
-      return false;
+    //
+    // The diagram gets asked first. A frontmatter field that echoes a node
+    // label ("title: Login flow" over a diagram containing "A[Login]") is
+    // ordinary, not exotic, and asking the frontmatter first drops that
+    // diagram comment on the floor. Only when the label is NOT the diagram's
+    // does the frontmatter test decide.
+    if (c.cleanOffset === claimStart) {
+      const haystack = extractMermaidText(`\`\`\`mermaid\n${diagramSource}\n\`\`\``);
+      if (haystack.includes(c.anchor)) return true;
+      if (anchorLivesInFrontmatter(cleanMarkdown, c.anchor)) return false;
     }
     return true;
   });

--- a/src/markdown/pipeline.test.ts
+++ b/src/markdown/pipeline.test.ts
@@ -89,6 +89,18 @@ describe('renderMarkdown', () => {
     expect(text).toBe(body);
   });
 
+  it('does not style continuation lines as keys', () => {
+    // A folded value's continuation lines routinely contain a colon (a URL, a
+    // ratio, a time). Matching key shape alone painted `http` and `3` as keys,
+    // while a genuinely nested key under a valueless parent must still style.
+    const md =
+      '---\ndescription: See docs at\n  http://example.com:8080/path\nnote: Ratio is\n  3:4 approx\ntools:\n  - Read\nnested:\n  key: value\n---\n\n# H';
+    const keys = [...renderMarkdown(md).matchAll(/doc-frontmatter__key">([^<]*)</g)].map(
+      (m) => m[1],
+    );
+    expect(keys).toEqual(['description', 'note', 'tools', 'nested', 'key']);
+  });
+
   it('does not treat a mid-document --- as frontmatter', () => {
     const html = renderMarkdown('# Title\n\ntext\n\n---\n\nmore');
     expect(html).not.toContain('doc-frontmatter');

--- a/src/markdown/pipeline.ts
+++ b/src/markdown/pipeline.ts
@@ -105,7 +105,10 @@ function rehypeWrapTables() {
  * the string.
  *
  * Keys are wrapped in a span for styling only; the delimiter and value stay in
- * their own text nodes so the concatenated text still matches the source.
+ * their own text nodes so the concatenated text still matches the source. Key
+ * detection is a line-shape heuristic, not a YAML parse, so it is deliberately
+ * confined to styling: nothing downstream may depend on which runs get the
+ * span.
  */
 function frontmatterHandler(_state: unknown, node: { value: string }): Element | undefined {
   // An empty block (`---\n---`) would otherwise render as a bare tinted box
@@ -115,13 +118,27 @@ function frontmatterHandler(_state: unknown, node: { value: string }): Element |
   const children: (Element | { type: 'text'; value: string })[] = [];
   const lines = node.value.split('\n');
 
+  // A folded value continues on deeper-indented lines, and those lines
+  // routinely contain a colon of their own: a URL, a ratio, a time, a wrapped
+  // "Note: ...". Matching key shape alone paints `http` and `3` as keys. A
+  // continuation is a deeper-indented line following a key that already had a
+  // value on it; a deeper-indented line under a key with NO inline value is a
+  // nested key or a list item, which is a different thing. Presentation only:
+  // either way the emitted text is unchanged.
+  let lastKeyIndent = -1;
+  let lastKeyHadValue = false;
+
   lines.forEach((line, index) => {
     // `key:` for YAML, `key =` for TOML. Anything else (list items, nested
     // maps, folded continuation lines) passes through untouched.
     const keyed = /^([ \t]*)([A-Za-z0-9_.-]+)([ \t]*[:=])(.*)$/.exec(line);
-    if (keyed) {
-      const [, indent, key, delimiter, rest] = keyed;
-      if (indent) children.push({ type: 'text', value: indent });
+    const indent = /^[ \t]*/.exec(line)?.[0].length ?? 0;
+    const isContinuation = lastKeyHadValue && indent > lastKeyIndent;
+    if (keyed && !isContinuation) {
+      const [, leading, key, delimiter, rest] = keyed;
+      lastKeyIndent = indent;
+      lastKeyHadValue = rest.trim().length > 0;
+      if (leading) children.push({ type: 'text', value: leading });
       children.push({
         type: 'element',
         tagName: 'span',

--- a/src/markdown/pipeline.ts
+++ b/src/markdown/pipeline.ts
@@ -160,10 +160,15 @@ function frontmatterHandler(_state: unknown, node: { value: string }): Element |
   };
 }
 
-function buildProcessor(filePath?: string) {
-  return unified()
-    .use(remarkParse)
-    .use(remarkFrontmatter, ['yaml', 'toml'])
+function buildProcessor(filePath?: string, allowFrontmatter = true) {
+  const processor = unified().use(remarkParse);
+  // Frontmatter is defined as being at offset 0 of the DOCUMENT. A caller
+  // rendering a fragment (the diff overlay renders one segment at a time) has
+  // a string whose offset 0 is somewhere in the middle of the file, so leaving
+  // this on invents a frontmatter block out of any `---` that happens to start
+  // a segment.
+  if (allowFrontmatter) processor.use(remarkFrontmatter, ['yaml', 'toml']);
+  return processor
     .use(remarkGfm)
     .use(remarkRehype, {
       allowDangerousHtml: true,
@@ -176,7 +181,21 @@ function buildProcessor(filePath?: string) {
     .use(rehypeStringify);
 }
 
-export function renderMarkdown(markdown: string, filePath?: string): string {
-  const file = buildProcessor(filePath).processSync(markdown);
+export interface RenderOptions {
+  /**
+   * Whether the string being rendered is a whole document. Fragments (a diff
+   * segment, say) must pass false: frontmatter is an offset-0 construct and a
+   * fragment's offset 0 is not the document's.
+   */
+  allowFrontmatter?: boolean;
+}
+
+export function renderMarkdown(
+  markdown: string,
+  filePath?: string,
+  options: RenderOptions = {},
+): string {
+  const { allowFrontmatter = true } = options;
+  const file = buildProcessor(filePath, allowFrontmatter).processSync(markdown);
   return String(file);
 }


### PR DESCRIPTION
Follow-ups from a review pass over this session's five merged PRs (#24-#28), base `25246e8`. Ten review loops plus a closing pass; eleven commits, each self-contained.

Merging with a merge commit rather than a squash is deliberate: several of these are non-obvious one-line changes whose reasoning only exists in the commit message, and `git blame` should keep it.

## What was actually broken on main

Four of these fix defects that shipped:

| | |
|---|---|
| **Silent comment loss** | A fence line inside frontmatter (a YAML block scalar holding a code sample) mis-paired every later fence, so a comment on ordinary body prose was written to disk and then parsed back as zero comments, marker text stranded in the file. The base branch mis-paired too, but wrote the marker *into* the YAML: loud. Adding frontmatter relocation converted a visible corruption into a silent one, which is why this counts as a regression rather than inherited debt. |
| **Diff overlay misrepresenting documents** | `RenderedDiffView` renders one segment at a time, and frontmatter is an offset-0 construct, so a `---` that merely started a segment rendered as a frontmatter box over content that was never frontmatter. In the other direction, editing one field split the real block across segments, where the closing `---` turned the last field into a Setext heading and vanished. Flipping an ADR's `status` triggers the second one. |
| **Contrast** | The frontmatter block shipped at `--theme-text-muted` on `--theme-bg-secondary`: 2.18:1 on Solarized, failing AA on six of eight themes and under the 3:1 floor on three. The prose counters had already been moved off muted for exactly this reason. |
| **Navigation contradicting the rail** | `cleanOffset` is the marker's position, and relocated markers all park on the same offset, so N/P and the rail's own prev/next walked two frontmatter comments bottom-up while the rail stacked their cards top-down. |

Plus: the mermaid tie-break dropped legitimate diagram comments whose label also appeared in frontmatter; an unclosed `<!--` left the rest of a document unprotected; the raw view and the renderer disagreed about what frontmatter is (TOML, CRLF); folded continuation lines containing a colon were styled as keys; the UI saved a failed insert as a success; a raw NUL byte in a string literal made `MarkdownViewer.tsx` read as binary to grep.

## Three of these fix the review pass's own work

Worth flagging rather than burying. Loop 3 fixed a Critical introduced by loop 2. Loop 10 found that two earlier fixes contradicted each other, and that three guards the pass had written were not guarding: a per-theme contrast test that asserted on the intended colour *by name* and so stayed green when the colour was reverted; a diff-overlay test that restated the component's branching instead of calling it; and an untested failed-insert path. The closing pass then found two more assertions too narrow to catch the branch they named.

## Deliberately not done

- **Unclosed fenced code blocks are still unprotected.** Pre-existing, reproduces identically on `25246e8`, and protecting them changes which markers `collectCommentRegions` parses in already-malformed documents. It wants the parse-derived model below, not another regex.
- **Deriving container ranges from remark's parse instead of regexes**, with a fixed-point resolve replacing three ordered mutations over a shared offset. This was the review's highest-value finding and it is a rewrite of the module the UI, the MCP routes and the CLI all sit on. Recorded rather than executed.
- Three findings were refuted by reproduction and left alone: no-context agent comments "collapsing" (they resolve to the same occurrence, so sharing a highlight is correct), `moveComment` "dropping" contexts (it recomputes them), and the mermaid tie-break tests being vacuous (they do fail under the real regression).

## Verification

1580 unit tests, full Playwright suite 318 passed, `tsc -b` and eslint clean, `eval:dry` valid.

Every fix has a regression test proven to fail without it, reverted through `git stash` or `git checkout HEAD --` rather than by editing the source back, after an early hand-rolled revert silently missed and produced a green test that proved nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tof5nvvxJVHNRrYQViAvV2
