### PR TITLE
feat: reverse-proxy fronting, plus the hardening it needed first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,30 @@ highlighting, orphan detection, and agent handoff are unaffected.
 - `GET /api/browse?dir=` — browse directory structure (files + folders)
 - `GET /api/asset?path=` — serve image assets (PNG, JPG, SVG, etc.)
 - `GET /api/watch?path=` — SSE stream of external file changes
-- `GET /api/pick-file` — native file picker (macOS/Linux/Windows)
-- `GET /api/pick-folder` — native folder picker
+- `POST /api/pick-file` — native file picker (macOS/Linux/Windows)
+- `POST /api/pick-folder` — native folder picker
+
+These two are POST despite reading like reads. They spawn a native OS dialog and
+persist a new trusted root once the user picks, so they must sit behind the
+`application/json` Content-Type guard, which a cross-site page cannot satisfy
+without a CORS preflight. As GETs they were reachable from any markup that can
+emit a URL, including an `<img>` in a reviewed markdown document, which the
+renderer passes through verbatim when the URL carries a scheme.
+
+Any new route that lets a caller direct a change must use POST or PUT, because
+those are exactly the two verbs the Content-Type guard checks (`server/index.ts`,
+the middleware after the Fetch Metadata one). `PUT /api/file` and
+`PUT /api/preferences` are the existing PUTs and are covered. A route added on
+DELETE or PATCH would NOT be covered, so extend the guard's method list before
+reaching for one. Do not rely on the `Sec-Fetch-Site` check instead: it fails
+open for clients that send no Fetch Metadata.
+
+One existing GET does write: `GET /api/file` calls `sweepStrandedAskMarkers`,
+which can rewrite the file to clear an `expectsReply` flag whose review session
+has already closed. That stays a GET deliberately. It is idempotent self-healing
+triggered by server-side session state, the caller cannot direct what it writes,
+and it only ever removes a stale flag. The rule above is about writes a caller
+chooses, not about every byte that can reach disk during a request.
 
 **Review sessions**
 - `POST /api/review-sessions` — create a session (`{ filePaths, enableResolve?, origin?: 'user' | 'agent', clientId? }`). `origin` defaults to `'user'`; the `mdr_review` MCP tool passes `'agent'` to enable agent-specific banner states and GC behavior. `clientId` is an opaque caller identity (the MCP client sends a process-scoped UUID) that scopes dedupe: two different agents on the same files get distinct sessions, while the same agent batching successive calls reuses its own.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,32 @@ file(s)" result instead of an error.
 
 Security defaults in `server/index.ts`: path validation against allowed roots, localhost-only CORS, 10 MB body limit.
 
+**Host allowlist and reverse-proxy fronting** — a Host-header check closes DNS
+rebinding by rejecting any hostname that is not loopback. `CreateAppOptions.allowedHosts`,
+defaulting from the comma-separated `MD_REDLINE_ALLOWED_HOSTS`, adds extra names
+so the loopback-bound server can sit behind a trusted proxy (`tailscale serve`,
+nginx, Caddy). Both the header and the allowlist entries are normalized through
+the exported `normalizeHostname`, so the two sides cannot drift apart. It strips
+a scheme, a protocol-relative `//`, any path, query or fragment, userinfo, a
+port, IPv6 brackets and trailing dots, then lowercases. That list is deliberately
+generous: an operator pastes whatever `tailscale serve status` or the address bar
+gave them, and every form that silently fails to match is a support ticket whose
+symptom (all proxied requests 400) points nowhere near the typo. Entries that
+normalize to nothing are dropped with a warning. Non-ASCII hostnames must be
+written in punycode, since that is what a browser puts in the Host header. A Host
+header that is present but empty is checked and fails closed. The bind address is
+never affected.
+
+There is no authentication anywhere in the server, so setting `allowedHosts`
+moves the trust boundary from this machine to whatever can reach the proxy.
+Two consequences worth keeping in mind when adding routes: `trustedRoots` is
+stripped from `PUT /api/preferences` because persisted roots hydrate into
+`allowedRoots` on the next launch (accepting it let a client grant itself a
+directory and read it back after a restart), and every route that lets a caller
+direct a change must use POST or PUT, the two verbs the `application/json` guard
+checks. See the README section "Reaching md-redline from another device" for the
+operator-facing version.
+
 **Ports and loopback discipline** — the API server binds IPv4 loopback only
 (`127.0.0.1`), default port 6373 ("MDR" on a phone keypad; overridable via
 `MD_REDLINE_PORT`), scanning up to 10 ports from there if taken. The Vite dev

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ All of these environment variables are optional.
 | `MD_REDLINE_VITE_PORT` | `5188` | Port for the Vite dev client (development only). |
 | `MD_REDLINE_HOME` | your OS home directory | Base directory for md-redline's preferences file (`.md-redline.json`, which stores trusted roots and the update-check cache). |
 | `MD_REDLINE_REGISTRY_URL` | public npm registry | Registry base URL used for the background update check. |
+| `MDR_ALLOWED_HOSTS` | unset | Comma-separated extra hostnames accepted by the Host-header check, for fronting the loopback-bound server with a trusted reverse proxy (for example `tailscale serve`, nginx, or Caddy). Only list hostnames you control; the server still binds to `127.0.0.1` only. |
 | `NO_UPDATE_NOTIFIER` or `CI` | unset | If either is present (any value, including empty), the background update check is disabled. |
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -242,8 +242,74 @@ All of these environment variables are optional.
 | `MD_REDLINE_VITE_PORT` | `5188` | Port for the Vite dev client (development only). |
 | `MD_REDLINE_HOME` | your OS home directory | Base directory for md-redline's preferences file (`.md-redline.json`, which stores trusted roots and the update-check cache). |
 | `MD_REDLINE_REGISTRY_URL` | public npm registry | Registry base URL used for the background update check. |
-| `MDR_ALLOWED_HOSTS` | unset | Comma-separated extra hostnames accepted by the Host-header check, for fronting the loopback-bound server with a trusted reverse proxy (for example `tailscale serve`, nginx, or Caddy). Only list hostnames you control; the server still binds to `127.0.0.1` only. |
+| `MD_REDLINE_ALLOWED_HOSTS` | unset | Comma-separated extra hostnames accepted by the Host-header check, so the loopback-bound server can sit behind a trusted reverse proxy. Read [Reaching md-redline from another device](#reaching-md-redline-from-another-device) before setting it. |
 | `NO_UPDATE_NOTIFIER` or `CI` | unset | If either is present (any value, including empty), the background update check is disabled. |
+
+### Reaching md-redline from another device
+
+md-redline binds to `127.0.0.1` and has **no authentication of any kind**. That is
+safe today because only your own machine can reach it.
+
+`MD_REDLINE_ALLOWED_HOSTS` exists so you can put a reverse proxy in front of it
+(`tailscale serve`, nginx, Caddy) and review from a tablet. Setting it does not
+change the bind address, so the proxy still has to run on the same machine. What
+it does change is the security boundary: it moves from "my machine" to "anything
+that can reach the proxy".
+
+Whatever can reach the proxy gets unauthenticated access to:
+
+- Reading and writing any markdown file under your trusted roots (`GET` and `PUT /api/file`)
+- Listing and browsing directories under those roots (`GET /api/browse`, `GET /api/files`)
+- Reading any image under those roots (`GET /api/asset`)
+- Learning where those roots are, plus every file you recently opened, as absolute
+  paths (`GET /api/preferences`)
+- Changing your stored author name, theme, recent files and settings (`PUT /api/preferences`)
+- Opening native file and folder pickers **on your machine** (`POST /api/pick-file`, `POST /api/pick-folder`)
+- Revealing files in Finder or Explorer **on your machine** (`POST /api/reveal`)
+- Reading and answering agent review sessions (`/api/review-sessions/*`), watching
+  files for changes (`GET /api/watch`), and shutting the server down (`POST /api/shutdown`)
+
+So if you set this:
+
+- Prefer `tailscale serve`, which is reachable only from devices on your own
+  tailnet. Do **not** use `tailscale funnel`, which publishes to the open internet.
+- With nginx or Caddy, terminate TLS and put authentication in front of md-redline
+  yourself. It will not do it for you.
+- Only list hostnames you actually control. The DNS-rebinding defense still holds
+  for everything else, because an attacker's rebinding domain never matches a
+  hostname you listed explicitly.
+
+Two practical notes on the proxy itself:
+
+- **Whether you need this variable at all depends on your proxy.** `tailscale serve`
+  and Caddy preserve the original `Host`, so you must list the public hostname.
+  nginx's default `proxy_set_header Host $proxy_host` rewrites it to `127.0.0.1:6373`,
+  which already passes, so you only need the variable if you forward the original
+  host (`proxy_set_header Host $host`).
+- **Turn off response buffering for `/api/watch`.** Live file updates arrive over
+  Server-Sent Events. md-redline sends `X-Accel-Buffering: no`, which nginx honours;
+  if your proxy ignores it, disable buffering for that path or edits will not appear
+  until a buffer fills.
+
+Serve it over HTTPS if you can. The clipboard API that the hand-off prompt copy
+relies on only works in a secure context, so over plain HTTP that button fails on
+the tablet you set this up for.
+
+Every endpoint that changes something is a `POST` or a `PUT` requiring a JSON
+content type, which a web page cannot send to another origin without the browser
+asking this server for permission first. That is what stops a page you visit, or
+a link in a chat message, or an image embedded in a markdown file you are
+reviewing, from quietly triggering an endpoint here. md-redline additionally
+rejects requests a browser labels cross-site, but only as a second layer: clients
+that send no such metadata, like the CLI and the MCP server, are deliberately
+unaffected by it.
+
+What a reachable client **cannot** do is widen its own filesystem access. Trusted
+roots grow only when you pick a file or folder in the native dialog
+(`/api/pick-file`, `/api/pick-folder`). A bulk `PUT /api/preferences` cannot write
+`trustedRoots`, and `/api/grant-access` only re-checks a path against the roots
+you already approved rather than adding new ones. So the set of readable
+directories is whatever you approved locally and nothing more.
 
 ## Troubleshooting
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -59,6 +59,11 @@ async function requestJson(appInstance: AppInstance, path: string, init?: Reques
   };
 }
 
+// The pickers are POST: they spawn a native OS dialog and persist a trusted
+// root on selection, so they sit behind the application/json guard that a
+// cross-site page cannot satisfy without a preflight.
+const PICK: RequestInit = { method: 'POST', headers: { 'content-type': 'application/json' } };
+
 // Preference writes (addTrustedRoot, writePreferences) are fire-and-forget:
 // the request returns before the write lands on disk. Polling for the file to
 // exist and satisfy `predicate` replaces fixed sleeps that raced the write on
@@ -1008,7 +1013,7 @@ describe('/api/pick-file', () => {
       execFileImpl,
     });
 
-    const { response, body } = await requestJson(windowsApp, '/api/pick-file');
+    const { response, body } = await requestJson(windowsApp, '/api/pick-file', PICK);
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ path: 'C:\\docs\\spec.md' });
@@ -1031,7 +1036,7 @@ describe('/api/pick-file', () => {
       execFileImpl,
     });
 
-    const { response, body } = await requestJson(pickApp, '/api/pick-file');
+    const { response, body } = await requestJson(pickApp, '/api/pick-file', PICK);
     expect(response.status).toBe(200);
     expect(body.path).toBe(externalFile);
 
@@ -1057,6 +1062,7 @@ describe('/api/pick-file', () => {
     const { response } = await requestJson(
       pickApp,
       `/api/pick-file?defaultPath=${encodeURIComponent(targetPath)}`,
+      PICK,
     );
     expect(response.status).toBe(200);
     expect(calls).toHaveLength(1);
@@ -1080,7 +1086,11 @@ describe('/api/pick-file', () => {
     });
 
     const trickyPath = '/tmp/has "quote" and \\back/file.md';
-    await requestJson(pickApp, `/api/pick-file?defaultPath=${encodeURIComponent(trickyPath)}`);
+    await requestJson(
+      pickApp,
+      `/api/pick-file?defaultPath=${encodeURIComponent(trickyPath)}`,
+      PICK,
+    );
     expect(calls).toHaveLength(1);
     const argsJoined = calls[0].args.join(' ');
     // Quotes should be backslash-escaped, backslashes doubled.
@@ -1102,7 +1112,7 @@ describe('/api/pick-file', () => {
       execFileImpl,
     });
 
-    await requestJson(pickApp, '/api/pick-file');
+    await requestJson(pickApp, '/api/pick-file', PICK);
     expect(calls).toHaveLength(1);
     const argsJoined = calls[0].args.join(' ');
     expect(argsJoined).not.toContain('default location');
@@ -1128,7 +1138,7 @@ describe('/api/pick-folder', () => {
       execFileImpl,
     });
 
-    const { response, body } = await requestJson(pickApp, '/api/pick-folder');
+    const { response, body } = await requestJson(pickApp, '/api/pick-folder', PICK);
     expect(response.status).toBe(200);
     expect(body.path).toBe(realPicked);
 
@@ -1156,6 +1166,7 @@ describe('/api/pick-folder', () => {
     const { response } = await requestJson(
       pickApp,
       `/api/pick-folder?defaultPath=${encodeURIComponent(targetPath)}`,
+      PICK,
     );
     expect(response.status).toBe(200);
     expect(calls).toHaveLength(1);
@@ -1180,7 +1191,7 @@ describe('/api/pick-folder', () => {
       execFileImpl,
     });
 
-    const { response, body } = await requestJson(pickApp, '/api/pick-folder');
+    const { response, body } = await requestJson(pickApp, '/api/pick-folder', PICK);
     expect(response.status).toBe(400);
     expect(body.error).toMatch(/not a directory/);
 
@@ -1227,6 +1238,118 @@ describe('Host header allowlist (DNS rebinding defense)', () => {
       headers: { Host: '[::1]:3001' },
     });
     expect(r.status).toBe(200);
+  });
+});
+
+describe('cross-site API requests (Fetch Metadata guard)', () => {
+  // Runs before routing, so a cross-site request is rejected whatever its
+  // method or target. Asserting 403 rather than the 404 this path would
+  // otherwise return is what makes the middleware load-bearing here.
+  it('rejects a cross-site request before it reaches a route', async () => {
+    const r = await app.request(`http://localhost/api/pick-folder`, {
+      headers: { 'sec-fetch-site': 'cross-site' },
+    });
+    expect(r.status).toBe(403);
+    expect(await r.json()).toEqual({ error: 'Cross-site requests are not allowed' });
+  });
+
+  it('rejects same-site as well as cross-site', async () => {
+    const r = await app.request(`http://localhost/api/config`, {
+      headers: { 'sec-fetch-site': 'same-site' },
+    });
+    expect(r.status).toBe(403);
+  });
+
+  it('allows the app own same-origin requests', async () => {
+    const r = await app.request(`http://localhost/api/config`, {
+      headers: { 'sec-fetch-site': 'same-origin' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it('allows direct navigation (sec-fetch-site: none)', async () => {
+    const r = await app.request(`http://localhost/api/config`, {
+      headers: { 'sec-fetch-site': 'none' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it('allows non-browser callers that send no Fetch Metadata at all', async () => {
+    const r = await app.request(`http://localhost/api/config`);
+    expect(r.status).toBe(200);
+  });
+
+  it('still allows the image requests the markdown renderer emits for /api/asset', async () => {
+    const r = await app.request(
+      `http://localhost/api/asset?path=${encodeURIComponent(join(docsDir, 'nope.png'))}`,
+      { headers: { 'sec-fetch-site': 'same-origin', 'sec-fetch-dest': 'image' } },
+    );
+    // The file does not exist, so this 404s. The point is that a legitimately
+    // embedded image is NOT blocked.
+    expect(r.status).not.toBe(403);
+  });
+});
+
+describe('routes with side effects are not reachable by embedding a URL', () => {
+  // The documents this app renders are untrusted input, and a markdown file can
+  // contain `![](http://127.0.0.1:6373/api/pick-folder)`. A URL with a scheme is
+  // "external" to the renderer so it survives verbatim, and the resulting <img>
+  // request is honestly same-origin, which no origin heuristic can distinguish.
+  // What actually stops it is that a browser cannot issue a POST with a JSON
+  // content type from a markup embed or a navigation.
+  it('the native file picker cannot be reached by a GET', async () => {
+    const r = await app.request(`http://localhost/api/pick-file`);
+    expect(r.status).toBe(404);
+  });
+
+  it('the native folder picker cannot be reached by a GET', async () => {
+    const r = await app.request(`http://localhost/api/pick-folder`);
+    expect(r.status).toBe(404);
+  });
+
+  it('a form-style POST without a JSON content type is rejected', async () => {
+    // The only cross-origin POST a page can send without a preflight.
+    const r = await app.request(`http://localhost/api/pick-folder`, {
+      method: 'POST',
+      headers: { 'content-type': 'text/plain' },
+    });
+    expect(r.status).toBe(415);
+  });
+});
+
+describe('PUT /api/preferences cannot widen filesystem access', () => {
+  it('ignores a client-supplied trustedRoots, so access cannot escalate across a restart', async () => {
+    const home = await realpath(await mkdtemp(join(tmpdir(), 'mdr-prefs-escalate-home-')));
+    const projectRoot = await realpath(await mkdtemp(join(tmpdir(), 'mdr-prefs-escalate-cwd-')));
+    const outsideDir = await realpath(await mkdtemp(join(tmpdir(), 'mdr-prefs-escalate-out-')));
+    const outsideFile = join(outsideDir, 'private.md');
+    await writeFile(outsideFile, '# Private\n', 'utf8');
+
+    const first = createApp({ cwd: projectRoot, homeDir: home });
+
+    // Baseline: the file sits outside every trusted root.
+    const before = await first.request(`/api/file?path=${encodeURIComponent(outsideFile)}`);
+    expect(before.status).toBe(403);
+
+    // A client tries to grant itself the directory via a bulk preferences write.
+    const write = await first.request('/api/preferences', {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ trustedRoots: [outsideDir], author: 'someone' }),
+    });
+    expect(write.status).toBe(200);
+    // The rest of the patch still applies; only trustedRoots is dropped.
+    expect((await write.json()).author).toBe('someone');
+
+    // Restarting is what would have activated a poisoned root, since
+    // allowedRoots hydrates from persisted trustedRoots on launch.
+    const second = createApp({ cwd: projectRoot, homeDir: home });
+    const after = await second.request(`/api/file?path=${encodeURIComponent(outsideFile)}`);
+    expect(after.status).toBe(403);
+
+    await rm(home, { recursive: true, force: true });
+    await rm(projectRoot, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
   });
 });
 

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1239,6 +1239,78 @@ describe('Host header allowlist (DNS rebinding defense)', () => {
     });
     expect(r.status).toBe(200);
   });
+
+  it('allows extra hostnames listed in allowedHosts (reverse-proxy fronting)', async () => {
+    const proxiedApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      allowedHosts: ['mac.tail1234.ts.net'],
+    });
+    const r1 = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'mac.tail1234.ts.net' },
+    });
+    expect(r1.status).toBe(200);
+    // Case-insensitive, port stripped like the loopback names
+    const r2 = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'MAC.Tail1234.TS.NET:8443' },
+    });
+    expect(r2.status).toBe(200);
+  });
+
+  it('still rejects unlisted hostnames when allowedHosts is set', async () => {
+    const proxiedApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      allowedHosts: ['mac.tail1234.ts.net'],
+    });
+    const r = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'attacker.example.com' },
+    });
+    expect(r.status).toBe(400);
+    expect(await r.json()).toEqual({ error: 'Invalid Host header' });
+  });
+
+  it('reads allowedHosts from MDR_ALLOWED_HOSTS when the option is absent', async () => {
+    vi.stubEnv('MDR_ALLOWED_HOSTS', 'proxy.example.internal, other.host ');
+    try {
+      const envApp = createApp({ cwd: cwdRoot, homeDir: fakeHome });
+      const r1 = await envApp.request(`http://localhost/api/config`, {
+        headers: { Host: 'proxy.example.internal' },
+      });
+      expect(r1.status).toBe(200);
+      const r2 = await envApp.request(`http://localhost/api/config`, {
+        headers: { Host: 'other.host:9000' },
+      });
+      expect(r2.status).toBe(200);
+      const r3 = await envApp.request(`http://localhost/api/config`, {
+        headers: { Host: 'attacker.example.com' },
+      });
+      expect(r3.status).toBe(400);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('an explicit allowedHosts option overrides the env var', async () => {
+    vi.stubEnv('MDR_ALLOWED_HOSTS', 'env.example.internal');
+    try {
+      const optionApp = createApp({
+        cwd: cwdRoot,
+        homeDir: fakeHome,
+        allowedHosts: ['option.example.internal'],
+      });
+      const r1 = await optionApp.request(`http://localhost/api/config`, {
+        headers: { Host: 'option.example.internal' },
+      });
+      expect(r1.status).toBe(200);
+      const r2 = await optionApp.request(`http://localhost/api/config`, {
+        headers: { Host: 'env.example.internal' },
+      });
+      expect(r2.status).toBe(400);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
 });
 
 describe('cross-site API requests (Fetch Metadata guard)', () => {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -6,6 +6,7 @@ import {
   createApp,
   createAppFull,
   isPathInsideRoot,
+  normalizeHostname,
   removePortFileIfOwned,
   type CreateAppOptions,
 } from './index';
@@ -1199,6 +1200,42 @@ describe('/api/pick-folder', () => {
   });
 });
 
+describe('normalizeHostname', () => {
+  // Both the Host header and the allowlist entries go through this, so the
+  // table is the contract for what an operator is allowed to paste.
+  it.each([
+    ['mac.tail1234.ts.net', 'mac.tail1234.ts.net'],
+    ['MAC.Tail1234.TS.NET', 'mac.tail1234.ts.net'],
+    ['mac.tail1234.ts.net:8443', 'mac.tail1234.ts.net'],
+    ['https://mac.tail1234.ts.net', 'mac.tail1234.ts.net'],
+    ['https://mac.tail1234.ts.net/', 'mac.tail1234.ts.net'],
+    ['https://mac.tail1234.ts.net/review?x=1#f', 'mac.tail1234.ts.net'],
+    ['//mac.tail1234.ts.net/', 'mac.tail1234.ts.net'],
+    ['https://user:pw@mac.tail1234.ts.net/', 'mac.tail1234.ts.net'],
+    ['user@mac.tail1234.ts.net', 'mac.tail1234.ts.net'],
+    ['mac.tail1234.ts.net.', 'mac.tail1234.ts.net'],
+    ['mac.tail1234.ts.net..', 'mac.tail1234.ts.net'],
+    ['  mac.tail1234.ts.net  ', 'mac.tail1234.ts.net'],
+    ['[fd7a:115c:a1e0::1]', 'fd7a:115c:a1e0::1'],
+    ['[fd7a:115c:a1e0::1]:6373', 'fd7a:115c:a1e0::1'],
+    ['localhost', 'localhost'],
+    ['127.0.0.1:3001', '127.0.0.1'],
+    ['', ''],
+    ['https://', ''],
+  ])('normalizes %s to %s', (input, expected) => {
+    expect(normalizeHostname(input)).toBe(expected);
+  });
+
+  // A path segment must never be able to carry a different name into the
+  // comparison, in either direction.
+  it('does not let a path or userinfo smuggle in another hostname', () => {
+    expect(normalizeHostname('https://evil.example/mac.tail1234.ts.net')).toBe('evil.example');
+    expect(normalizeHostname('https://evil.example@mac.tail1234.ts.net')).toBe(
+      'mac.tail1234.ts.net',
+    );
+  });
+});
+
 describe('Host header allowlist (DNS rebinding defense)', () => {
   it('rejects requests with a non-loopback Host header', async () => {
     const response = await app.request(`http://localhost/api/config`, {
@@ -1270,8 +1307,8 @@ describe('Host header allowlist (DNS rebinding defense)', () => {
     expect(await r.json()).toEqual({ error: 'Invalid Host header' });
   });
 
-  it('reads allowedHosts from MDR_ALLOWED_HOSTS when the option is absent', async () => {
-    vi.stubEnv('MDR_ALLOWED_HOSTS', 'proxy.example.internal, other.host ');
+  it('reads allowedHosts from MD_REDLINE_ALLOWED_HOSTS when the option is absent', async () => {
+    vi.stubEnv('MD_REDLINE_ALLOWED_HOSTS', 'proxy.example.internal, other.host ');
     try {
       const envApp = createApp({ cwd: cwdRoot, homeDir: fakeHome });
       const r1 = await envApp.request(`http://localhost/api/config`, {
@@ -1292,7 +1329,7 @@ describe('Host header allowlist (DNS rebinding defense)', () => {
   });
 
   it('an explicit allowedHosts option overrides the env var', async () => {
-    vi.stubEnv('MDR_ALLOWED_HOSTS', 'env.example.internal');
+    vi.stubEnv('MD_REDLINE_ALLOWED_HOSTS', 'env.example.internal');
     try {
       const optionApp = createApp({
         cwd: cwdRoot,
@@ -1307,6 +1344,96 @@ describe('Host header allowlist (DNS rebinding defense)', () => {
         headers: { Host: 'env.example.internal' },
       });
       expect(r2.status).toBe(400);
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('matches an allowlist entry that carries a port, as copied from a proxy config', async () => {
+    const proxiedApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      allowedHosts: ['mac.tail1234.ts.net:8443'],
+    });
+    const r = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'mac.tail1234.ts.net' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it('treats a trailing-dot FQDN as the same name on both sides', async () => {
+    const proxiedApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      allowedHosts: ['mac.tail1234.ts.net.'],
+    });
+    const r1 = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'mac.tail1234.ts.net.' },
+    });
+    expect(r1.status).toBe(200);
+    const r2 = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'mac.tail1234.ts.net' },
+    });
+    expect(r2.status).toBe(200);
+  });
+
+  it('accepts a bracketed IPv6 allowlist entry', async () => {
+    const proxiedApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      allowedHosts: ['[fd7a:115c:a1e0::1]'],
+    });
+    const r = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: '[fd7a:115c:a1e0::1]:6373' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it('matches the loopback names case-insensitively', async () => {
+    const r = await app.request(`http://localhost/api/config`, {
+      headers: { Host: 'LOCALHOST:6373' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  // `tailscale serve status` and the browser address bar both hand you a URL
+  // with a trailing slash, so that is the form an operator actually pastes.
+  it.each([
+    'https://mac.tail1234.ts.net',
+    'https://mac.tail1234.ts.net/',
+    'https://mac.tail1234.ts.net/review',
+    'https://mac.tail1234.ts.net:8443/',
+    'mac.tail1234.ts.net/',
+    'mac.tail1234.ts.net?x=1',
+    'mac.tail1234.ts.net#frag',
+  ])('accepts an allowlist entry written as %s', async (entry) => {
+    const proxiedApp = createApp({
+      cwd: cwdRoot,
+      homeDir: fakeHome,
+      allowedHosts: [entry],
+    });
+    const r = await proxiedApp.request(`http://localhost/api/config`, {
+      headers: { Host: 'mac.tail1234.ts.net' },
+    });
+    expect(r.status).toBe(200);
+  });
+
+  it('rejects a Host header that is present but empty, rather than skipping the check', async () => {
+    const r = await app.request(`http://localhost/api/config`, {
+      headers: { Host: '' },
+    });
+    expect(r.status).toBe(400);
+    expect(await r.json()).toEqual({ error: 'Invalid Host header' });
+  });
+
+  it('an empty MD_REDLINE_ALLOWED_HOSTS still rejects every non-loopback host', async () => {
+    vi.stubEnv('MD_REDLINE_ALLOWED_HOSTS', '');
+    try {
+      const envApp = createApp({ cwd: cwdRoot, homeDir: fakeHome });
+      const r = await envApp.request(`http://localhost/api/config`, {
+        headers: { Host: 'attacker.example.com' },
+      });
+      expect(r.status).toBe(400);
     } finally {
       vi.unstubAllEnvs();
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -186,6 +186,27 @@ export function createAppFull(options: CreateAppOptions = {}) {
     }
     await next();
   });
+  // Reject cross-site API requests using the browser's own Fetch Metadata.
+  // Defence in depth only, and deliberately shallow: it rejects what a browser
+  // itself labels cross-site, which costs nothing and catches casual embedding.
+  //
+  // It is NOT what protects the state-changing routes. This check fails open
+  // when the headers are absent, and the clients that send nothing include curl,
+  // the CLI, the MCP server, and Safari before 16.4. Anything that actually
+  // mutates state is a POST guarded by the application/json requirement below,
+  // which a cross-site page cannot satisfy without a preflight. Do not add route
+  // exceptions here or push more of the security burden onto it; make the route
+  // a POST instead.
+  //
+  // Scoped to /api/* so a cross-site link to the app itself still opens. The
+  // Vite dev proxy forwards the browser's own value.
+  app.use('/api/*', async (c, next) => {
+    const site = c.req.header('sec-fetch-site');
+    if (site && site !== 'same-origin' && site !== 'none') {
+      return c.json({ error: 'Cross-site requests are not allowed' }, 403);
+    }
+    await next();
+  });
   // Enforce application/json Content-Type on POST/PUT to block CSRF via text/plain forms
   app.use('*', async (c, next) => {
     if (c.req.method === 'POST' || c.req.method === 'PUT') {
@@ -644,6 +665,15 @@ export function createAppFull(options: CreateAppOptions = {}) {
     }
     // updateCheck is the server-owned registry cache; clients cannot write it.
     delete body.updateCheck;
+    // trustedRoots is the filesystem access boundary and is only ever widened
+    // through an explicit local consent flow (/api/pick-file, /api/pick-folder,
+    // /api/grant-access). A bulk preferences write must never touch it: the
+    // persisted value hydrates straight into allowedRoots on the next launch,
+    // so accepting it here would let any client that can reach this endpoint
+    // grant itself arbitrary roots and read them back after a restart. Whether
+    // anything other than this machine can reach the endpoint is a property of
+    // how the server is deployed, not something this handler should rely on.
+    delete body.trustedRoots;
     try {
       const merged = await writePreferences(homeDir, body);
       return c.json(merged);
@@ -912,7 +942,7 @@ export function createAppFull(options: CreateAppOptions = {}) {
     }
   });
 
-  app.get('/api/pick-file', async (c) => {
+  app.post('/api/pick-file', async (c) => {
     const defaultPath = c.req.query('defaultPath') ?? '';
     try {
       const path = await new Promise<string>((promiseResolve, reject) => {
@@ -1009,7 +1039,7 @@ export function createAppFull(options: CreateAppOptions = {}) {
     }
   });
 
-  app.get('/api/pick-folder', async (c) => {
+  app.post('/api/pick-folder', async (c) => {
     const defaultPath = c.req.query('defaultPath') ?? '';
     try {
       const path = await new Promise<string>((promiseResolve, reject) => {

--- a/server/index.ts
+++ b/server/index.ts
@@ -68,6 +68,13 @@ export interface CreateAppOptions {
   getLatestVersion?: () => string | null;
   /** Whether the asynchronous update check has not settled yet. */
   isUpdateCheckPending?: () => boolean;
+  /** Extra hostnames accepted by the Host-header allowlist, for fronting the
+   * loopback-bound server with a trusted reverse proxy (`tailscale serve`,
+   * nginx, Caddy). Defaults to the comma-separated MDR_ALLOWED_HOSTS env var.
+   * Loopback names are always allowed; the DNS-rebinding defense is
+   * preserved because an attacker's rebinding domain never matches an
+   * explicitly listed hostname. */
+  allowedHosts?: string[];
 }
 
 function canonicalize(p: string): string {
@@ -130,6 +137,11 @@ export function createAppFull(options: CreateAppOptions = {}) {
   const getLatestVersion = options.getLatestVersion;
   const isUpdateCheckPending = options.isUpdateCheckPending;
   const caseInsensitivePaths = platformName === 'win32';
+  const extraAllowedHosts = (
+    options.allowedHosts ?? (process.env.MDR_ALLOWED_HOSTS ?? '').split(',')
+  )
+    .map((h) => h.trim().toLowerCase())
+    .filter(Boolean);
 
   const app = new Hono();
   // Allow CORS only from Vite dev server ports (default 5188-5197, or custom via env)
@@ -180,7 +192,12 @@ export function createAppFull(options: CreateAppOptions = {}) {
     if (host) {
       // Strip an optional port. IPv6 hosts arrive as `[::1]:3001`.
       const hostname = host.startsWith('[') ? host.slice(1, host.indexOf(']')) : host.split(':')[0];
-      if (hostname !== 'localhost' && hostname !== '127.0.0.1' && hostname !== '::1') {
+      if (
+        hostname !== 'localhost' &&
+        hostname !== '127.0.0.1' &&
+        hostname !== '::1' &&
+        !extraAllowedHosts.includes(hostname.toLowerCase())
+      ) {
         return c.json({ error: 'Invalid Host header' }, 400);
       }
     }

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,10 +70,20 @@ export interface CreateAppOptions {
   isUpdateCheckPending?: () => boolean;
   /** Extra hostnames accepted by the Host-header allowlist, for fronting the
    * loopback-bound server with a trusted reverse proxy (`tailscale serve`,
-   * nginx, Caddy). Defaults to the comma-separated MDR_ALLOWED_HOSTS env var.
-   * Loopback names are always allowed; the DNS-rebinding defense is
+   * nginx, Caddy). Defaults to the comma-separated MD_REDLINE_ALLOWED_HOSTS env var.
+   * Entries are normalized like the Host header itself, so a port, a bracketed
+   * IPv6 literal, or a trailing dot on an entry is fine.
+   *
+   * Loopback names are always allowed, and the DNS-rebinding defense is
    * preserved because an attacker's rebinding domain never matches an
-   * explicitly listed hostname. */
+   * explicitly listed hostname. Setting this does NOT change the bind address.
+   *
+   * SECURITY: this server has no authentication of any kind. Setting this moves
+   * the trust boundary from "this machine" to "anything that can reach the
+   * proxy", which then has unauthenticated read/write over every markdown file
+   * under the trusted roots and can trigger native dialogs on the host. Put
+   * authentication in front of it yourself. See the README section "Reaching
+   * md-redline from another device". */
   allowedHosts?: string[];
 }
 
@@ -110,6 +120,53 @@ function expandHomePath(inputPath: string, homeDir: string): string {
   return inputPath;
 }
 
+/**
+ * Reduce a Host header value, or an allowlist entry, to a bare comparable
+ * hostname: strip an optional port, unwrap a bracketed IPv6 literal, drop the
+ * trailing dot of an absolute FQDN, and lowercase.
+ *
+ * Both sides of the Host allowlist check go through this, which is the point.
+ * The loopback names used to be compared case-sensitively against a value that
+ * kept its original case, so `Host: LOCALHOST` was rejected; and allowlist
+ * entries were only trimmed and lowercased, so an entry copied verbatim out of
+ * a proxy config (`mac.tail1234.ts.net:8443`) silently never matched. Running
+ * both through one function is what makes the comparison actually uniform.
+ */
+export function normalizeHostname(value: string): string {
+  // Accept a whole URL, because that is what an operator has in hand: the
+  // browser address bar and `tailscale serve status` both give you
+  // `https://mac.tail1234.ts.net/`. Strip the scheme, then everything from the
+  // first path, query or fragment delimiter, so the trailing slash does not
+  // survive into the comparison and silently never match.
+  //
+  // Truncating at `/` is safe on the Host-header side too. This check exists
+  // only to stop browser-driven DNS rebinding, and a browser builds Host from
+  // the URL authority, which cannot contain a path. A non-browser client could
+  // send anything, but it could equally send `Host: localhost`, so there is
+  // nothing here for it to bypass.
+  let host = value
+    .trim()
+    .replace(/^[a-z][a-z0-9+.-]*:\/\//i, '')
+    .replace(/^\/\//, '');
+  // Cut the path, query and fragment before anything else, so an `@` or `:`
+  // appearing later in a URL cannot be mistaken for userinfo or a port.
+  host = host.split(/[/?#]/)[0];
+  // Drop userinfo. `user:pass@host` is a legal authority, and without this a
+  // pasted credentialed URL allowlists the username instead of the host, which
+  // fails in both directions at once. Browsers already strip userinfo before
+  // building the Host header, so doing the same here just matches them.
+  const at = host.lastIndexOf('@');
+  if (at !== -1) host = host.slice(at + 1);
+  if (host.startsWith('[')) {
+    // Bracketed IPv6 literal, e.g. `[::1]:3001`.
+    const close = host.indexOf(']');
+    host = close === -1 ? host.slice(1) : host.slice(1, close);
+  } else {
+    host = host.split(':')[0];
+  }
+  return host.replace(/\.+$/, '').toLowerCase();
+}
+
 function sseFrame(event: string, data: string): Uint8Array {
   const lines = data.split('\n');
   const frame = `event: ${event}\n${lines.map((l) => `data: ${l}`).join('\n')}\n\n`;
@@ -137,11 +194,16 @@ export function createAppFull(options: CreateAppOptions = {}) {
   const getLatestVersion = options.getLatestVersion;
   const isUpdateCheckPending = options.isUpdateCheckPending;
   const caseInsensitivePaths = platformName === 'win32';
-  const extraAllowedHosts = (
-    options.allowedHosts ?? (process.env.MDR_ALLOWED_HOSTS ?? '').split(',')
-  )
-    .map((h) => h.trim().toLowerCase())
-    .filter(Boolean);
+  const rawAllowedHosts =
+    options.allowedHosts ?? (process.env.MD_REDLINE_ALLOWED_HOSTS ?? '').split(',');
+  const extraAllowedHosts = rawAllowedHosts.map(normalizeHostname).filter(Boolean);
+  // An entry that normalizes to nothing would otherwise vanish in silence, and
+  // the symptom (every proxied request 400s) points nowhere near the typo.
+  for (const entry of rawAllowedHosts) {
+    if (entry.trim() && !normalizeHostname(entry)) {
+      console.warn(`[md-redline] ignoring unparseable allowed host: ${JSON.stringify(entry)}`);
+    }
+  }
 
   const app = new Hono();
   // Allow CORS only from Vite dev server ports (default 5188-5197, or custom via env)
@@ -189,14 +251,16 @@ export function createAppFull(options: CreateAppOptions = {}) {
     // browser, which always sets Host. Allow it through. The threat model
     // here is browser-driven DNS rebinding; an in-process caller already
     // has full code execution and there's nothing to defend against.
-    if (host) {
-      // Strip an optional port. IPv6 hosts arrive as `[::1]:3001`.
-      const hostname = host.startsWith('[') ? host.slice(1, host.indexOf(']')) : host.split(':')[0];
+    // Note the `!== undefined`: a header that is present but EMPTY must still
+    // be checked (and will fail closed), where a truthy test would skip the
+    // allowlist entirely. Only a genuinely absent Host takes the exemption.
+    if (host !== undefined) {
+      const hostname = normalizeHostname(host);
       if (
         hostname !== 'localhost' &&
         hostname !== '127.0.0.1' &&
         hostname !== '::1' &&
-        !extraAllowedHosts.includes(hostname.toLowerCase())
+        !extraAllowedHosts.includes(hostname)
       ) {
         return c.json({ error: 'Invalid Host header' }, 400);
       }
@@ -1320,6 +1384,10 @@ export function createAppFull(options: CreateAppOptions = {}) {
         'Content-Type': 'text/event-stream',
         'Cache-Control': 'no-cache',
         Connection: 'keep-alive',
+        // nginx buffers proxied responses by default, which holds SSE frames
+        // until the buffer fills and makes live file updates look broken
+        // behind a reverse proxy. Ignored by proxies that do not need it.
+        'X-Accel-Buffering': 'no',
       },
     });
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -233,7 +233,13 @@ export default function App() {
         const url = hint
           ? `/api/pick-folder?defaultPath=${encodeURIComponent(hint)}`
           : '/api/pick-folder';
-        const res = await fetch(url);
+        // POST, not GET: this spawns a native dialog and persists a trusted
+        // root on selection, so it must sit behind the application/json guard
+        // that a cross-site page cannot satisfy without a preflight.
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+        });
         const data = (await res.json()) as { path?: string; cancelled?: boolean };
         if (!res.ok || data.cancelled || !data.path) {
           // Cancelled, failed, or returned no path. Leave the existing error

--- a/src/components/FileOpener.tsx
+++ b/src/components/FileOpener.tsx
@@ -85,7 +85,11 @@ export function FileOpener({
 
   const handleSystemPicker = useCallback(async () => {
     try {
-      const res = await fetch('/api/pick-file');
+      // POST, not GET: see the note on the pick-folder call in App.tsx.
+      const res = await fetch('/api/pick-file', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      });
       const data = await readJsonResponse<PickFileResponse>(res);
       if (!res.ok || !data) {
         throw new Error(getApiErrorMessage(res, data, 'Failed to open system file picker'));

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -311,7 +311,10 @@ export function useComments(params: UseCommentsParams) {
             `Copied agent instructions for ${fileCount} file${fileCount !== 1 ? 's' : ''}. Now tracking changes.`,
             'success',
           ),
-        () => showToast("Couldn't copy to clipboard. Try from localhost.", 'error'),
+        // The clipboard API needs a secure context. "Try from localhost" was
+        // wrong advice for anyone reaching md-redline through a proxy, which
+        // MD_REDLINE_ALLOWED_HOSTS now makes a supported setup.
+        () => showToast("Couldn't copy to clipboard. Needs https:// or localhost.", 'error'),
       );
     },
     [commentCounts, showToast, enableResolve],


### PR DESCRIPTION
Closes #17. Supersedes #19: @JesseLeresche's commit is preserved here unchanged,
with follow-ups from me on top.

Two of the three commits are security fixes that turned up while reviewing this.
They are independent of the feature and reachable on a plain loopback server
today, so read that section even if you skip the rest.

### The feature

`allowedHosts` on `CreateAppOptions`, defaulting from a comma-separated
`MD_REDLINE_ALLOWED_HOSTS`, so the loopback-bound server can sit behind a trusted
reverse proxy (`tailscale serve`, nginx, Caddy) and be reviewed from a tablet.
Listed hostnames pass the Host-header check, everything else still gets the 400.
The bind address is untouched and the default is exactly the current loopback
trio, so nothing changes for anyone who doesn't opt in.

### The hardening

**A markdown file under review could pop a native dialog.** `/api/pick-file` and
`/api/pick-folder` spawn an OS dialog and persist a new trusted root once you
pick. They were GETs, so anything that can emit a URL could fire them, including
an `<img>` in a document you opened to review:

```markdown
![](http://127.0.0.1:6373/api/pick-folder)
```

A URL carrying a scheme is "external" to the renderer, so it passes through
verbatim. Opening that file pops "Allow md-redline to access this folder" on the
machine running mdr. The request is genuinely same-origin, so no origin heuristic
can separate it from the app's own calls. Verified in Chrome: on main it spawns
two real dialogs, and after this change it spawns none and both requests 404.

Reviewing documents that other people and agents wrote is the entire product, so
this needed a structural answer rather than another header check. Both routes are
now POST and sit behind the existing `application/json` requirement, which a
browser cannot satisfy from markup or a navigation without a preflight.

**`PUT /api/preferences` could widen filesystem access.** It accepted a
client-supplied `trustedRoots`, and persisted roots hydrate into `allowedRoots`
on the next launch, so a caller could grant itself a directory, wait for a
restart, and read it back. Reproduced end to end: a file that 403s before the
write returns 200 with its contents afterwards. The field is now stripped.

Both were reachable before this feature existed. They matter more with a proxy in
front, which is why they land here rather than after.

### Follow-ups on Jesse's commit

1. **Renamed the env var** from `MDR_ALLOWED_HOSTS` to
   `MD_REDLINE_ALLOWED_HOSTS`, matching `MD_REDLINE_PORT`, `MD_REDLINE_HOME`,
   `MD_REDLINE_VITE_PORT` and `MD_REDLINE_REGISTRY_URL`. Env names are API once
   released.
2. **One normalizer for both sides.** Entries were only trimmed and lowercased
   while the header was port-stripped and bracket-unwrapped, so an entry copied
   out of a proxy config with its port on it never matched, and failed closed
   with no diagnostic. Loopback names were also compared case-sensitively, so
   `Host: LOCALHOST` was rejected. Both sides now run through `normalizeHostname`,
   which strips a scheme, a path, a query, a fragment, userinfo, a port, IPv6
   brackets and trailing dots. The path case matters most: `tailscale serve
   status` hands you `https://host/`, and a surviving trailing slash is exactly
   the silent never-matches failure this is meant to remove.
3. **A present-but-empty Host** is now checked and fails closed, where a truthy
   test skipped the allowlist entirely.
4. **`X-Accel-Buffering: no` on the SSE stream**, since nginx buffers proxied
   responses by default and would otherwise hold live file updates.
5. **Documented the real exposure.** The Host check was never the security
   boundary, the loopback bind was, and this option exists precisely to let
   something else reach the server. There is no authentication anywhere, so the
   README now names what a reachable client gets (including the recon value of
   `GET /api/preferences`), says which proxies need the variable at all, and
   calls out `tailscale serve` against `funnel`.
6. **Fixed a clipboard toast** that told users to "try from localhost" when the
   real requirement is a secure context. That was exactly wrong advice for the
   proxied tablet this feature is for.

Also adds a `Sec-Fetch-Site` check on `/api/*` as defence in depth, with a
comment saying plainly that it is not load bearing: it fails open when the
headers are absent, and curl, the CLI, the MCP server and Safari before 16.4 all
send nothing. The POST requirement is what actually holds.

### Testing

1626 unit tests, 318 e2e, lint and `tsc -b` clean. Every new regression test was
checked to fail without its fix. The picker paths were live-verified in a real
browser on macOS: the attack, the legitimate picker flow, and cancellation.
