### PR TITLE
feat: touch and pen selection support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -432,16 +432,31 @@ headings, bold, links, tables, and list structure.
 Selections made by touch or pen route through a pending flow instead of the
 mouseup path (`useSelection.ts`): touch selection never fires `mouseup`, and
 native selection-handle drags emit no pointer events the page can see, so
-nothing auto-opens — a timer cannot distinguish "paused to think" from "done
-adjusting". While a touch/pen selection exists, a fixed **Comment** button
-(`data-testid="pending-selection-commit"`, bottom-right) is the explicit
-commit signal; tapping it promotes the pending `SelectionInfo` snapshot to the
-active selection, which opens the pill/form as usual. The modality is decided
-per gesture via the last `pointerdown`'s `pointerType` (not per device), so
-hybrid devices get mouse-immediate and touch-deferred behavior side by side.
-The commit works from the stored snapshot, so it survives the tap collapsing
-the native selection. `selectionchange` is debounced 150ms purely to coalesce
-handle-drag event streams; it gates nothing user-visible.
+nothing auto-opens; a timer cannot distinguish "paused to think" from "done
+adjusting". The modality is decided per gesture via the last `pointerdown`'s
+`pointerType` (not per device), so hybrid devices get mouse-immediate and
+touch-deferred behavior side by side.
+
+There is one comment surface for both modalities. `App.tsx` renders a single
+`CommentForm` for `selection ?? pendingSelection`, so a touch selection shows
+the same collapsed pill (Comment plus the quick templates) that a mouse
+selection does. `CommentForm`'s `handleExpand` and `handlePillTemplate` both
+call `onLock` first, and `onLock` commits the pending selection, so engaging
+with the pill by any route promotes it. That is what keeps the two modalities
+identical by construction rather than by two components kept in sync: an
+earlier revision had a separate touch-only button, which drifted into a
+different affordance (no templates) and cost touch users an extra tap.
+
+The commit reads the stored `SelectionInfo` snapshot, so it survives the tap
+collapsing the native selection. `selectionchange` is debounced 150ms purely to
+coalesce handle-drag event streams; it gates nothing user-visible. The pill's
+scroll-follow coalesces into one measurement per animation frame, because touch
+scrolling outpaces the compositor and measuring per event reads as jitter.
+
+Known gap (#35): the anchor drag handles (`DragHandles.tsx`,
+`useDragHandles.ts`) are still mouse-only. They react to a tap because iOS
+synthesises a `mousedown`, but a touch drag emits no `mousemove`, so they cannot
+be moved on a tablet.
 
 ### Comments rail
 The single comment surface for the rendered view: a fixed-width column at the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,6 +428,20 @@ browser's own range, so a plain Cmd/Ctrl+C would copy nothing. The document-leve
 
 Both flavors go on the clipboard, so pasting into a rich-text editor keeps
 headings, bold, links, tables, and list structure.
+#### Touch and pen selections
+Selections made by touch or pen route through a pending flow instead of the
+mouseup path (`useSelection.ts`): touch selection never fires `mouseup`, and
+native selection-handle drags emit no pointer events the page can see, so
+nothing auto-opens — a timer cannot distinguish "paused to think" from "done
+adjusting". While a touch/pen selection exists, a fixed **Comment** button
+(`data-testid="pending-selection-commit"`, bottom-right) is the explicit
+commit signal; tapping it promotes the pending `SelectionInfo` snapshot to the
+active selection, which opens the pill/form as usual. The modality is decided
+per gesture via the last `pointerdown`'s `pointerType` (not per device), so
+hybrid devices get mouse-immediate and touch-deferred behavior side by side.
+The commit works from the stored snapshot, so it survives the tap collapsing
+the native selection. `selectionchange` is debounced 150ms purely to coalesce
+handle-drag event streams; it gates nothing user-visible.
 
 ### Comments rail
 The single comment surface for the rendered view: a fixed-width column at the

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ This makes feedback:
 - Two-way agent review over MCP: agents request your review, review your docs, and ask anchored questions
 - Threaded replies and optional `open` / `resolved` review states
 - Adjustable anchors with drag handles
+- Touch and pen commenting: select with the native handles, then tap the floating **Comment** button when done (nothing pops up while you adjust)
 - Rendered, raw, and diff views
 - Hand-off prompt copying for one or multiple files
 
@@ -222,6 +223,7 @@ This makes feedback:
 - **macOS**: supported
 - **Linux**: supported; system file picker requires `zenity`
 - **Windows**: supported; system file picker uses PowerShell
+- **Touch browsers** (iPad Safari and similar): supported for reviewing and commenting; selections made by touch or pen use the floating **Comment** button flow
 
 ## Permissions
 

--- a/e2e/mermaid-fullscreen.spec.ts
+++ b/e2e/mermaid-fullscreen.spec.ts
@@ -361,3 +361,44 @@ test('toolbar comment-panel button toggles the side panel', async ({ page }) => 
     .click();
   await expect(page.locator('[aria-label="Diagram comments"]')).toBeVisible();
 });
+
+// ---------------------------------------------------------------------------
+// Touch/pen commenting inside the modal
+//
+// useSelection routes every touch and pen gesture into `pendingSelection`, so a
+// consumer reading only `selection` loses touch commenting silently and
+// entirely. This modal is the second consumer of that hook and was missed when
+// the pending flow landed, which contradicted the parity AGENTS.md claims for
+// this surface. Regression guard.
+// ---------------------------------------------------------------------------
+test('touch selection inside the fullscreen modal shows the comment pill', async ({ page }) => {
+  await openMermaidFixture(page);
+  await openFullscreenModal(page);
+
+  await page.evaluate(() => {
+    const inner = document.querySelector('.mermaid-fullscreen-canvas-inner')!;
+    inner.dispatchEvent(new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }));
+    const textEl = [...document.querySelectorAll('.mermaid-fullscreen-canvas-inner svg text')].find(
+      (t) => (t.textContent || '').trim().length > 3,
+    );
+    if (!textEl) throw new Error('no SVG text in the fullscreen canvas');
+    const walker = document.createTreeWalker(textEl, NodeFilter.SHOW_TEXT);
+    const tn = walker.nextNode() as Text | null;
+    if (!tn) throw new Error('no text node');
+    const range = document.createRange();
+    range.setStart(tn, 0);
+    range.setEnd(tn, Math.min(3, (tn.textContent || '').length));
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+    // No mouseup: a touch gesture never fires one.
+  });
+
+  const pill = page.getByTestId('pending-selection-commit');
+  await expect(pill).toBeVisible({ timeout: 5_000 });
+  // Collapsed, not auto-expanded, so the native handles stay adjustable.
+  await expect(page.locator('[data-comment-form] textarea')).toHaveCount(0);
+
+  await pill.click();
+  await expect(page.locator('[data-comment-form] textarea')).toBeVisible({ timeout: 5_000 });
+});

--- a/e2e/touch-selection.spec.ts
+++ b/e2e/touch-selection.spec.ts
@@ -62,52 +62,76 @@ async function selectTextViaPointer(page: Page, text: string, pointerType: strin
 }
 
 test.describe('Touch selection', () => {
-  test('touch selection shows the commit button instead of auto-opening the form', async ({
-    page,
-  }) => {
+  // The comment surface is one pill for both modalities. What distinguishes
+  // "not opened yet" from "opened" is expansion (the textarea), not the pill's
+  // presence, so these assert against the textarea rather than the pill's
+  // container.
+  const pill = (page: Page) => page.getByTestId('pending-selection-commit');
+  const textarea = (page: Page) => page.locator('[data-comment-form] textarea');
+
+  test('touch selection shows the pill without expanding it', async ({ page }) => {
     await openFixture(page);
     await selectTextViaPointer(page, 'valid credentials', 'touch');
 
-    const commit = page.getByTestId('pending-selection-commit');
-    await expect(commit).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+    await expect(textarea(page)).toHaveCount(0);
   });
 
-  test('adjusting the selection keeps the form closed and the button up', async ({ page }) => {
+  test('adjusting the selection keeps it collapsed and the pill up', async ({ page }) => {
     await openFixture(page);
     await selectTextViaPointer(page, 'valid credentials', 'touch');
-    const commit = page.getByTestId('pending-selection-commit');
-    await expect(commit).toBeVisible({ timeout: 5000 });
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
 
     // Simulate handle adjustment: re-select a wider region, still no mouseup.
     await selectTextViaPointer(page, 'valid credentials to access', 'touch');
-    await expect(commit).toBeVisible();
-    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+    await expect(pill(page)).toBeVisible();
+    await expect(textarea(page)).toHaveCount(0);
   });
 
-  test('tapping the commit button opens the comment flow on the selection', async ({ page }) => {
+  test('tapping Comment commits the pending selection and opens the field', async ({ page }) => {
     await openFixture(page);
     await selectTextViaPointer(page, 'valid credentials', 'touch');
-    const commit = page.getByTestId('pending-selection-commit');
-    await expect(commit).toBeVisible({ timeout: 5000 });
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
 
-    await commit.click();
-    await expect(page.locator('[data-comment-form]')).toBeVisible({ timeout: 5000 });
-    await expect(commit).toHaveCount(0);
+    await pill(page).click();
+    await expect(textarea(page)).toBeVisible({ timeout: 5000 });
+    // The pill's Comment button is replaced by the expanded form.
+    await expect(pill(page)).toHaveCount(0);
+  });
+
+  // Touch used to get a bare Comment button with no templates while mouse got
+  // the full pill. Asserts the actual labels and that tapping one prefills the
+  // composer: an earlier version of this test counted buttons, which the
+  // always-present overflow control satisfied even with zero templates
+  // rendered, so it passed through the exact regression it names.
+  test('the quick templates are available on touch, same as mouse', async ({ page }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'touch');
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+
+    const agreed = page.locator('[data-comment-form] button', { hasText: /^Agreed$/ });
+    await expect(agreed).toBeVisible();
+    await expect(
+      page.locator('[data-comment-form] button', { hasText: /^Rewrite this$/ }),
+    ).toBeVisible();
+
+    // Tapping a template commits the pending selection and prefills the form.
+    await agreed.click();
+    await expect(textarea(page)).toBeVisible({ timeout: 5000 });
+    await expect(textarea(page)).toHaveValue(/Agreed with this/);
   });
 
   test('pen selections use the pending flow too', async ({ page }) => {
     await openFixture(page);
     await selectTextViaPointer(page, 'valid credentials', 'pen');
-    await expect(page.getByTestId('pending-selection-commit')).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+    await expect(textarea(page)).toHaveCount(0);
   });
 
-  test('collapsing the selection hides the commit button', async ({ page }) => {
+  test('collapsing the selection hides the pill', async ({ page }) => {
     await openFixture(page);
     await selectTextViaPointer(page, 'valid credentials', 'touch');
-    const commit = page.getByTestId('pending-selection-commit');
-    await expect(commit).toBeVisible({ timeout: 5000 });
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
 
     await page.evaluate(() => {
       document.body.dispatchEvent(
@@ -115,12 +139,50 @@ test.describe('Touch selection', () => {
       );
       window.getSelection()?.removeAllRanges();
     });
-    await expect(commit).toHaveCount(0, { timeout: 5000 });
+    await expect(pill(page)).toHaveCount(0, { timeout: 5000 });
   });
 
-  test('mouse selection still opens the form immediately with no commit button', async ({
+  // Quick comment skips the pill and opens the form straight away. That is
+  // right for mouse, where mouseup means the selection is final, and wrong for
+  // touch, where the user may still be dragging the native handles. Regression
+  // guard: onLock commits the pending selection, and a mount-time onLock under
+  // quick comment used to fire it immediately.
+  test('quick comment does not auto-open the form on a pending touch selection', async ({
     page,
   }) => {
+    const home = resolve(__dirname, '..', '.playwright-home');
+    const prefs = resolve(home, '.md-redline.json');
+    mkdirSync(home, { recursive: true });
+    writeFileSync(prefs, JSON.stringify({ settings: { quickComment: true } }));
+    try {
+      await openFixture(page);
+      await selectTextViaPointer(page, 'valid credentials', 'touch');
+      await expect(pill(page)).toBeVisible({ timeout: 5000 });
+      await expect(textarea(page)).toHaveCount(0);
+
+      // Committing from the pill then honours quick comment as usual.
+      await pill(page).click();
+      await expect(textarea(page)).toBeVisible({ timeout: 5000 });
+    } finally {
+      rmSync(prefs, { force: true });
+    }
+  });
+
+  // An iPad with a keyboard attached is the flagship setup for this feature, so
+  // Cmd+Enter has to work on a touch selection. It used to no-op: the shortcut
+  // gated on a ref that mirrored the committed selection only, and a touch
+  // selection is pending until the user commits it.
+  test('Cmd+Enter opens the form on a pending touch selection', async ({ page }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'touch');
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+    await expect(textarea(page)).toHaveCount(0);
+
+    await page.keyboard.press('ControlOrMeta+Enter');
+    await expect(textarea(page)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('mouse selection still opens the pill on mouseup, unchanged', async ({ page }) => {
     await openFixture(page);
     await selectTextViaPointer(page, 'valid credentials', 'mouse');
     // Mouse flow: fire the mouseup that ends a drag-select.
@@ -135,7 +197,91 @@ test.describe('Touch selection', () => {
         }),
       );
     });
-    await expect(page.locator('[data-comment-form]')).toBeVisible({ timeout: 5000 });
-    await expect(page.getByTestId('pending-selection-commit')).toHaveCount(0);
+    // Mouse reaches the same pill, collapsed, without going through the
+    // pending flow at all.
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+    await expect(textarea(page)).toHaveCount(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Real touch events.
+//
+// Everything above drives synthetic PointerEvents and Playwright mouse clicks,
+// which is the only way to model a native handle drag (the OS owns it). But it
+// means the three onTouchEnd + preventDefault handlers on the pill had no
+// coverage at all: they exist because on touch the synthesized mousedown
+// arrives after the selection has already collapsed, and deleting them left the
+// suite green. These tests tap through page.touchscreen, which dispatches real
+// touchstart/touchend.
+// ---------------------------------------------------------------------------
+test.describe('Touch selection (real touch events)', () => {
+  test.use({ hasTouch: true });
+
+  const pill = (page: Page) => page.getByTestId('pending-selection-commit');
+  const textarea = (page: Page) => page.locator('[data-comment-form] textarea');
+
+  /** Real touch tap at an element's centre. */
+  async function tap(page: Page, locator: ReturnType<Page['locator']>) {
+    const box = await locator.boundingBox();
+    if (!box) throw new Error('element has no bounding box');
+    await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2);
+  }
+
+  async function touchSelect(page: Page, text: string) {
+    // A real tap first, so lastPointerType comes from a genuine touch
+    // pointerdown rather than a synthesized one.
+    const prose = page.locator('.prose');
+    await tap(page, prose);
+    await page.evaluate((needle) => {
+      const root = document.querySelector('.prose')!;
+      const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+      let n: Node | null;
+      while ((n = walker.nextNode())) {
+        const i = (n.textContent || '').indexOf(needle);
+        if (i >= 0) {
+          const r = document.createRange();
+          r.setStart(n, i);
+          r.setEnd(n, i + needle.length);
+          const s = getSelection()!;
+          s.removeAllRanges();
+          s.addRange(r);
+          return;
+        }
+      }
+      throw new Error(`"${needle}" not found`);
+    }, text);
+  }
+
+  test('a real tap on Comment opens the form', async ({ page }) => {
+    await openFixture(page);
+    await touchSelect(page, 'valid credentials');
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+
+    await tap(page, pill(page));
+    await expect(textarea(page)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('a real tap on a quick template prefills the form', async ({ page }) => {
+    await openFixture(page);
+    await touchSelect(page, 'valid credentials');
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+
+    await tap(page, page.locator('[data-comment-form] button', { hasText: /^Agreed$/ }));
+    await expect(textarea(page)).toBeVisible({ timeout: 5000 });
+    await expect(textarea(page)).toHaveValue(/Agreed with this/);
+  });
+
+  test('a real tap on the overflow control opens it once, not twice', async ({ page }) => {
+    await openFixture(page);
+    await touchSelect(page, 'valid credentials');
+    await expect(pill(page)).toBeVisible({ timeout: 5000 });
+
+    // handlePillOverflow toggles. If preventDefault fails to suppress the
+    // synthesized click, it fires twice and the menu closes again immediately.
+    await tap(page, page.locator('[data-comment-form] button', { hasText: '⋯' }));
+    await expect(
+      page.locator('[data-comment-form] button', { hasText: /^Add detail$/ }),
+    ).toBeVisible({ timeout: 5000 });
   });
 });

--- a/e2e/touch-selection.spec.ts
+++ b/e2e/touch-selection.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type Page } from '@playwright/test';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { TEST_DOC_BASELINE } from './helpers/fixture-baselines';
+import { resetTestAppState } from './helpers/test-state';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const TEMP_FIXTURE_DIR = resolve(__dirname, '..', 'node_modules', '.md-redline-e2e');
+let fixtureDir = '';
+let fixturePath = '';
+
+test.beforeEach(async ({ page }, testInfo) => {
+  mkdirSync(TEMP_FIXTURE_DIR, { recursive: true });
+  fixtureDir = resolve(
+    TEMP_FIXTURE_DIR,
+    `touch-selection-${process.pid}-${testInfo.retry}-${Date.now()}`,
+  );
+  mkdirSync(fixtureDir, { recursive: true });
+  fixturePath = resolve(fixtureDir, 'test-doc.md');
+  writeFileSync(fixturePath, TEST_DOC_BASELINE);
+  await resetTestAppState(page);
+});
+
+test.afterEach(async () => {
+  if (fixtureDir) rmSync(fixtureDir, { recursive: true, force: true });
+});
+
+async function openFixture(page: Page) {
+  await page.goto(`/?file=${fixturePath}`);
+  await page.locator('.prose').waitFor({ timeout: 10_000 });
+}
+
+// Create a DOM selection the way a touch gesture leaves it: a pointerdown
+// with pointerType 'touch' followed by a programmatic range selection and NO
+// mouseup — native touch selection never fires one. The browser fires
+// selectionchange itself when the range is added.
+async function selectTextViaPointer(page: Page, text: string, pointerType: string) {
+  await page.evaluate(
+    ({ targetText, pt }) => {
+      const prose = document.querySelector('.prose') || document.body;
+      prose.dispatchEvent(new PointerEvent('pointerdown', { pointerType: pt, bubbles: true }));
+      const walker = document.createTreeWalker(prose, NodeFilter.SHOW_TEXT);
+      let node: Text | null;
+      while ((node = walker.nextNode() as Text | null)) {
+        const idx = node.textContent?.indexOf(targetText) ?? -1;
+        if (idx >= 0) {
+          const range = document.createRange();
+          range.setStart(node, idx);
+          range.setEnd(node, idx + targetText.length);
+          const sel = window.getSelection()!;
+          sel.removeAllRanges();
+          sel.addRange(range);
+          node.parentElement?.scrollIntoView({ block: 'nearest' });
+          return;
+        }
+      }
+      throw new Error(`Text "${targetText}" not found in rendered markdown`);
+    },
+    { targetText: text, pt: pointerType },
+  );
+}
+
+test.describe('Touch selection', () => {
+  test('touch selection shows the commit button instead of auto-opening the form', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'touch');
+
+    const commit = page.getByTestId('pending-selection-commit');
+    await expect(commit).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+  });
+
+  test('adjusting the selection keeps the form closed and the button up', async ({ page }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'touch');
+    const commit = page.getByTestId('pending-selection-commit');
+    await expect(commit).toBeVisible({ timeout: 5000 });
+
+    // Simulate handle adjustment: re-select a wider region, still no mouseup.
+    await selectTextViaPointer(page, 'valid credentials to access', 'touch');
+    await expect(commit).toBeVisible();
+    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+  });
+
+  test('tapping the commit button opens the comment flow on the selection', async ({ page }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'touch');
+    const commit = page.getByTestId('pending-selection-commit');
+    await expect(commit).toBeVisible({ timeout: 5000 });
+
+    await commit.click();
+    await expect(page.locator('[data-comment-form]')).toBeVisible({ timeout: 5000 });
+    await expect(commit).toHaveCount(0);
+  });
+
+  test('pen selections use the pending flow too', async ({ page }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'pen');
+    await expect(page.getByTestId('pending-selection-commit')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+  });
+
+  test('collapsing the selection hides the commit button', async ({ page }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'touch');
+    const commit = page.getByTestId('pending-selection-commit');
+    await expect(commit).toBeVisible({ timeout: 5000 });
+
+    await page.evaluate(() => {
+      document.body.dispatchEvent(
+        new PointerEvent('pointerdown', { pointerType: 'touch', bubbles: true }),
+      );
+      window.getSelection()?.removeAllRanges();
+    });
+    await expect(commit).toHaveCount(0, { timeout: 5000 });
+  });
+
+  test('mouse selection still opens the form immediately with no commit button', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await selectTextViaPointer(page, 'valid credentials', 'mouse');
+    // Mouse flow: fire the mouseup that ends a drag-select.
+    await page.evaluate(() => {
+      const sel = window.getSelection()!;
+      const rect = sel.getRangeAt(0).getBoundingClientRect();
+      sel.anchorNode?.parentElement?.dispatchEvent(
+        new MouseEvent('mouseup', {
+          bubbles: true,
+          clientX: rect.left + rect.width / 2,
+          clientY: rect.top + rect.height / 2,
+        }),
+      );
+    });
+    await expect(page.locator('[data-comment-form]')).toBeVisible({ timeout: 5000 });
+    await expect(page.getByTestId('pending-selection-commit')).toHaveCount(0);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ import {
   stripInlineFormatting,
 } from './lib/comment-parser';
 import { getEffectiveStatus } from './types';
+import type { SelectionInfo } from './types';
 import { MarkdownViewer, type MarkdownViewerHandle } from './components/MarkdownViewer';
 import { TableOfContents } from './components/TableOfContents';
 import { CommentPopover } from './components/CommentPopover';
@@ -570,8 +571,9 @@ export default function App() {
     );
   }, []);
 
-  const { selection, pendingSelection, clearSelection, lockSelection, commitPendingSelection } =
-    useSelection(containerRef as RefObject<HTMLElement | null>);
+  const { selection, commentSelection, isPending, clearSelection, lockSelection } = useSelection(
+    containerRef as RefObject<HTMLElement | null>,
+  );
   const requestCommentFocus = useCallback(
     (commentId: string, origin: 'creation' | 'jump' = 'jump') =>
       setRequestedCommentFocus({ commentId, token: Date.now(), origin }),
@@ -1593,9 +1595,20 @@ export default function App() {
     onAnchorChange: handleAnchorChange,
   });
 
-  // Stable ref for selection to use in keyboard handler without re-creating it
+  // Stable ref for selection to use in keyboard handler without re-creating it.
+  // Committed selections ONLY. The copy handler depends on that: it overrides
+  // the native copy because the viewer paints its own highlight and clears the
+  // browser's range, which happens on commit. While a selection is merely
+  // pending the native range is still live, so copy must stay native.
   const selectionRef = useRef(selection);
   selectionRef.current = selection;
+
+  // For entry points that START commenting, a pending touch selection counts.
+  // Gating those on selectionRef made Cmd+Enter, Cmd+Shift+M and the context
+  // menu silently do nothing after a touch or pen selection, which is the
+  // normal case on an iPad with a keyboard attached.
+  const commentableSelectionRef = useRef<SelectionInfo | null>(commentSelection);
+  commentableSelectionRef.current = commentSelection;
 
   // Context menu handlers
   const {
@@ -1617,7 +1630,7 @@ export default function App() {
     handleAddComment,
     setActiveCommentId,
     ensureCommentSurface,
-    selectionRef,
+    selectionRef: commentableSelectionRef,
     lockSelection,
     setAutoExpandForm,
     triggerEdit,
@@ -1719,7 +1732,13 @@ export default function App() {
       }
 
       // Cmd+Enter : Expand comment form when text is selected (Feature 3)
-      if (mod && e.key === 'Enter' && !isInput && selectionRef.current && viewMode === 'rendered') {
+      if (
+        mod &&
+        e.key === 'Enter' &&
+        !isInput &&
+        commentableSelectionRef.current &&
+        viewMode === 'rendered'
+      ) {
         e.preventDefault();
         lockSelection();
         setAutoExpandForm(true);
@@ -1729,7 +1748,7 @@ export default function App() {
       // Cmd+Shift+M : Start commenting on selection
       if (mod && e.shiftKey && e.key.toLowerCase() === 'm') {
         e.preventDefault();
-        if (selectionRef.current) {
+        if (commentableSelectionRef.current) {
           lockSelection();
         }
         return;
@@ -2826,30 +2845,20 @@ export default function App() {
             </div>
           </div>
 
-          {/* Touch/pen: the selection is held as pending while the native
-            handles are adjusted; this button is the explicit "done selecting"
-            signal. touchend commits from the stored SelectionInfo snapshot,
-            so it works even if the tap collapses the native selection. */}
-          {pendingSelection && !selection && viewMode === 'rendered' && (
-            <button
-              type="button"
-              data-preserve-selection
-              data-testid="pending-selection-commit"
-              onTouchEnd={(e) => {
-                e.preventDefault();
-                commitPendingSelection();
-              }}
-              onClick={commitPendingSelection}
-              className="fixed bottom-6 right-6 z-50 rounded-full bg-primary px-5 py-3 text-sm font-medium text-on-primary shadow-lg"
-            >
-              Comment
-            </button>
-          )}
-
-          {/* Floating comment form (disabled in raw/diff view) */}
-          {selection && viewMode === 'rendered' && (
+          {/* Floating comment form (disabled in raw/diff view).
+            One form serves both states. A mouse selection arrives already
+            committed; a touch or pen selection arrives as `pendingSelection`,
+            because touch fires no mouseup and the native handles emit nothing
+            the page can see. Rendering the same pill for both is what keeps
+            the two modalities identical: the collapsed pill and its quick
+            templates are the affordance in either case.
+            Both handleExpand and handlePillTemplate call onLock first, so
+            committing there means any engagement with the pill promotes the
+            pending selection, whichever button the user reaches for. */}
+          {commentSelection && viewMode === 'rendered' && (
             <CommentForm
-              selection={selection}
+              selection={commentSelection}
+              isPending={isPending}
               autoExpand={autoExpandForm}
               onSubmit={(anchor, text, ctxBefore, ctxAfter, hintOffset) => {
                 handleAddComment(anchor, text, ctxBefore, ctxAfter, hintOffset);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -570,9 +570,8 @@ export default function App() {
     );
   }, []);
 
-  const { selection, clearSelection, lockSelection } = useSelection(
-    containerRef as RefObject<HTMLElement | null>,
-  );
+  const { selection, pendingSelection, clearSelection, lockSelection, commitPendingSelection } =
+    useSelection(containerRef as RefObject<HTMLElement | null>);
   const requestCommentFocus = useCallback(
     (commentId: string, origin: 'creation' | 'jump' = 'jump') =>
       setRequestedCommentFocus({ commentId, token: Date.now(), origin }),
@@ -2826,6 +2825,26 @@ export default function App() {
               </div>
             </div>
           </div>
+
+          {/* Touch/pen: the selection is held as pending while the native
+            handles are adjusted; this button is the explicit "done selecting"
+            signal. touchend commits from the stored SelectionInfo snapshot,
+            so it works even if the tap collapses the native selection. */}
+          {pendingSelection && !selection && viewMode === 'rendered' && (
+            <button
+              type="button"
+              data-preserve-selection
+              data-testid="pending-selection-commit"
+              onTouchEnd={(e) => {
+                e.preventDefault();
+                commitPendingSelection();
+              }}
+              onClick={commitPendingSelection}
+              className="fixed bottom-6 right-6 z-50 rounded-full bg-primary px-5 py-3 text-sm font-medium text-on-primary shadow-lg"
+            >
+              Comment
+            </button>
+          )}
 
           {/* Floating comment form (disabled in raw/diff view) */}
           {selection && viewMode === 'rendered' && (

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -6,6 +6,12 @@ import { getPrimaryModifierLabel } from '../lib/platform';
 
 interface Props {
   selection: SelectionInfo;
+  /** True while this is an uncommitted touch/pen selection the user may still
+   * be adjusting with the native handles. Such a selection must never start
+   * expanded: quick comment skips the pill for mouse, where the selection is
+   * already final on mouseup, but on touch that would swallow the adjustment
+   * step the pending flow exists for. */
+  isPending?: boolean;
   autoExpand?: boolean;
   onSubmit: (
     anchor: string,
@@ -18,12 +24,19 @@ interface Props {
   onLock: () => void;
 }
 
-export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock }: Props) {
+export function CommentForm({
+  selection,
+  isPending,
+  autoExpand,
+  onSubmit,
+  onCancel,
+  onLock,
+}: Props) {
   const { settings } = useSettings();
   const TEMPLATES = settings.templates;
   const COMMENT_MAX_LENGTH = settings.commentMaxLength;
   const modLabel = getPrimaryModifierLabel();
-  const [isExpanded, setIsExpanded] = useState(!!settings.quickComment);
+  const [isExpanded, setIsExpanded] = useState(!!settings.quickComment && !isPending);
   const [text, setText] = useState('');
   // True while a template prefill sits untouched; Escape then clears the
   // prefill instead of closing the form.
@@ -57,17 +70,23 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
     }
   }, [isExpanded]);
 
-  // Auto-expand when triggered by keyboard shortcut
+  // Auto-expand when triggered by keyboard shortcut. Guarded on isPending for
+  // the same reason as the quick-comment effect below: onLock commits, and a
+  // pending selection must stay collapsed and adjustable until the user says
+  // otherwise.
   useEffect(() => {
-    if (autoExpand && !isExpanded) {
+    if (autoExpand && !isExpanded && !isPending) {
       onLock();
       setIsExpanded(true);
     }
-  }, [autoExpand, isExpanded, onLock]);
+  }, [autoExpand, isExpanded, isPending, onLock]);
 
-  // Quick comment: lock selection on mount when starting expanded
+  // Quick comment: lock selection on mount when starting expanded. Skipped
+  // while pending, both because there is nothing to lock yet and because
+  // onLock commits the pending selection, which would auto-open the form on
+  // touch.
   useEffect(() => {
-    if (settings.quickComment) {
+    if (settings.quickComment && !isPending) {
       onLock();
     }
     // Only run on mount — quickComment won't change mid-lifecycle of this instance
@@ -114,7 +133,13 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
   // to it.
   useEffect(() => {
     if (isExpanded) return;
-    const remeasure = () => {
+    // Coalesce into one measurement per frame. Touch scrolling fires scroll
+    // events faster than the compositor paints, and measuring on every one of
+    // them lands the repositioned pill a frame out of step with the text it is
+    // tracking, which reads as jitter on a tablet.
+    let frame = 0;
+    const measure = () => {
+      frame = 0;
       const sel = window.getSelection();
       if (sel && sel.rangeCount > 0 && !sel.isCollapsed) {
         const r = sel.getRangeAt(0).getBoundingClientRect();
@@ -139,9 +164,15 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
           : next,
       );
     };
+    const remeasure = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(measure);
+    };
     document.addEventListener('scroll', remeasure, { capture: true, passive: true });
-    return () =>
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
       document.removeEventListener('scroll', remeasure, { capture: true } as EventListenerOptions);
+    };
   }, [isExpanded, selection.rect]);
 
   useLayoutEffect(() => {
@@ -246,7 +277,10 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
   };
 
   const handlePillOverflow = () => {
-    onLock();
+    // Deliberately does NOT lock. onLock commits a pending touch selection, so
+    // peeking at the overflow menu used to freeze handle adjustment for good.
+    // The selection is safe without it: mouseup inside [data-comment-form]
+    // already bails, and the pill carries that attribute.
     setShowPillMenu((prev) => !prev);
   };
 
@@ -279,12 +313,25 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
         )}
         <div className="selection-pill-enter flex items-center gap-0.5 px-1.5 py-1 max-w-[calc(100vw-24px)] overflow-hidden bg-surface-raised border border-border rounded-full shadow-lg">
           <button
+            // Named for the touch flow: this is the button that promotes a
+            // pending touch/pen selection. A mouse selection is already
+            // committed by the time the pill renders, so the same button just
+            // expands. One control, one name, both modalities.
+            data-testid="pending-selection-commit"
             onMouseDown={(e) => e.preventDefault()} // Prevent stealing focus/clearing selection
+            onTouchEnd={(e) => {
+              // The tap that expands would otherwise collapse the native
+              // selection first. Commit reads a stored snapshot so it survives
+              // either way, but this keeps the highlight up while it opens.
+              e.preventDefault();
+              handleExpand();
+            }}
             onClick={handleExpand}
             className="flex items-center gap-1.5 pl-2.5 pr-2 py-1 rounded-full text-sm font-medium text-primary-text hover:bg-tint-primary transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring"
           >
             <svg
               className="w-3.5 h-3.5"
+              aria-hidden="true"
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
@@ -303,6 +350,13 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
             <button
               key={t.label}
               onMouseDown={(e) => e.preventDefault()}
+              // Same reason as the Comment button: on touch, mousedown is
+              // synthesised after the selection has already collapsed, so
+              // preventing it there is too late to keep the pending selection.
+              onTouchEnd={(e) => {
+                e.preventDefault();
+                handlePillTemplate(t.text);
+              }}
               onClick={() => handlePillTemplate(t.text)}
               className="px-2.5 py-1 rounded-full text-xs text-content-secondary hover:bg-tint transition-colors max-w-36 truncate focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-ring"
             >
@@ -312,6 +366,10 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
           {TEMPLATES.length > 2 && (
             <button
               onMouseDown={(e) => e.preventDefault()}
+              onTouchEnd={(e) => {
+                e.preventDefault();
+                handlePillOverflow();
+              }}
               onClick={handlePillOverflow}
               aria-label="More templates"
               aria-expanded={showPillMenu}
@@ -400,6 +458,7 @@ export function CommentForm({ selection, autoExpand, onSubmit, onCancel, onLock 
             >
               <svg
                 className="w-3.5 h-3.5"
+                aria-hidden="true"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"

--- a/src/components/MermaidFullscreenModal.tsx
+++ b/src/components/MermaidFullscreenModal.tsx
@@ -141,7 +141,8 @@ export function MermaidFullscreenModal({
       (root?.querySelector('.mermaid-fullscreen-canvas-inner') as HTMLElement | null) ?? null;
   }, [open, svgHtml]);
 
-  const { selection, clearSelection, lockSelection } = useSelection(canvasInnerRef);
+  const { commentSelection, isPending, clearSelection, lockSelection } =
+    useSelection(canvasInnerRef);
 
   // Modal stays mounted (returns null) when closed, which means useSelection
   // state survives across opens. Without this, closing while a CommentForm is
@@ -175,7 +176,7 @@ export function MermaidFullscreenModal({
         // composer/useSelection's own Esc handling (which clears the
         // selection / cancels the form). Closing the whole modal here would
         // drop the in-progress draft.
-        if (inEditable || selection) return;
+        if (inEditable || commentSelection) return;
         e.stopPropagation();
         onClose();
         return;
@@ -213,7 +214,7 @@ export function MermaidFullscreenModal({
   }, [
     open,
     onClose,
-    selection,
+    commentSelection,
     settings.mermaidFullscreenPanelCollapsed,
     updateMermaidFullscreenPanelCollapsed,
   ]);
@@ -514,9 +515,10 @@ export function MermaidFullscreenModal({
         </div>
       </div>
 
-      {selection && (
+      {commentSelection && (
         <CommentForm
-          selection={selection}
+          selection={commentSelection}
+          isPending={isPending}
           onSubmit={(anchor, text, ctxBefore, ctxAfter, hintOffset) => {
             onAddComment(anchor, text, ctxBefore, ctxAfter, hintOffset);
             clearSelection();

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -25,6 +25,7 @@ import {
   detectMissingAnchors,
   orderCommentsByAnchor,
 } from '../lib/comment-parser';
+import { randomId } from '../lib/random-id';
 import { getEffectiveStatus } from '../types';
 import { renderMarkdown } from '../markdown/pipeline';
 import type { MarkdownViewerHandle } from '../components/MarkdownViewer';
@@ -195,7 +196,7 @@ export function useComments(params: UseCommentsParams) {
       contextAfter?: string,
       hintOffset?: number,
     ) => {
-      const newCommentId = crypto.randomUUID();
+      const newCommentId = randomId();
       const newRaw = insertComment(
         rawMarkdownRef.current ?? '',
         anchor,

--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+
+import { useSelection } from './useSelection';
+import type { SelectionInfo } from '../types';
+
+vi.mock('../lib/selection-resolver', () => ({
+  resolveSelection: vi.fn(),
+}));
+
+import { resolveSelection } from '../lib/selection-resolver';
+
+const mockResolve = vi.mocked(resolveSelection);
+
+const INFO: SelectionInfo = {
+  text: 'selected text',
+  rect: new DOMRect(0, 0, 10, 10),
+  contextBefore: '',
+  contextAfter: '',
+  offset: 0,
+};
+
+let result: { current: ReturnType<typeof useSelection> };
+const hook = () => result.current;
+
+function pointerDown(pointerType: string) {
+  const e = new Event('pointerdown');
+  Object.defineProperty(e, 'pointerType', { value: pointerType });
+  act(() => {
+    document.dispatchEvent(e);
+  });
+}
+
+function mouseUp() {
+  act(() => {
+    document.dispatchEvent(new Event('mouseup'));
+  });
+}
+
+function selectionChange() {
+  act(() => {
+    document.dispatchEvent(new Event('selectionchange'));
+    vi.advanceTimersByTime(200);
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockResolve.mockReturnValue(INFO);
+  // Stable ref object, like the useRef the app passes — a fresh object per
+  // render would re-run the hook's listener effect and reset gesture state.
+  const containerRef = { current: document.body };
+  ({ result } = renderHook(() => useSelection(containerRef)));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('useSelection modality routing', () => {
+  it('opens the selection immediately on mouseup for mouse gestures', () => {
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection).toEqual(INFO);
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  it('does not open on mouseup when the gesture was touch', () => {
+    pointerDown('touch');
+    mouseUp();
+    expect(hook().selection).toBeNull();
+  });
+
+  it('captures touch selections as pending instead of opening', () => {
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().selection).toBeNull();
+    expect(hook().pendingSelection).toEqual(INFO);
+  });
+
+  it('captures pen selections as pending', () => {
+    pointerDown('pen');
+    selectionChange();
+    expect(hook().pendingSelection).toEqual(INFO);
+  });
+
+  it('ignores selectionchange for mouse gestures', () => {
+    pointerDown('mouse');
+    selectionChange();
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  it('promotes pending to selection on commit', () => {
+    pointerDown('touch');
+    selectionChange();
+    act(() => hook().commitPendingSelection());
+    expect(hook().selection).toEqual(INFO);
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  it('commit is a no-op without a pending selection', () => {
+    act(() => hook().commitPendingSelection());
+    expect(hook().selection).toBeNull();
+  });
+
+  it('stops capturing pending while a selection is committed', () => {
+    pointerDown('touch');
+    selectionChange();
+    act(() => hook().commitPendingSelection());
+    mockResolve.mockReturnValue({ ...INFO, text: 'other' });
+    selectionChange();
+    expect(hook().pendingSelection).toBeNull();
+    expect(hook().selection).toEqual(INFO);
+  });
+
+  it('re-arms the pending flow after clearSelection', () => {
+    pointerDown('touch');
+    selectionChange();
+    act(() => hook().commitPendingSelection());
+    act(() => hook().clearSelection());
+    selectionChange();
+    expect(hook().pendingSelection).toEqual(INFO);
+  });
+
+  it('clears pending when the selection collapses', () => {
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().pendingSelection).toEqual(INFO);
+    mockResolve.mockReturnValue(null);
+    selectionChange();
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  it('Escape clears both pending and committed selections', () => {
+    pointerDown('touch');
+    selectionChange();
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keyup', { key: 'Escape' }));
+    });
+    expect(hook().pendingSelection).toBeNull();
+    expect(hook().selection).toBeNull();
+  });
+
+  it('does not capture pending while locked', () => {
+    act(() => hook().lockSelection());
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  it('debounces the selectionchange stream during handle drags', () => {
+    pointerDown('touch');
+    act(() => {
+      for (let i = 0; i < 5; i++) {
+        document.dispatchEvent(new Event('selectionchange'));
+        vi.advanceTimersByTime(50);
+      }
+    });
+    expect(mockResolve).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mockResolve).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -106,14 +106,36 @@ describe('useSelection modality routing', () => {
     expect(hook().selection).toBeNull();
   });
 
-  it('stops capturing pending while a selection is committed', () => {
+  // Originally asserted on commitPendingSelection alone. The app only reaches
+  // that through lockSelection, which also locks, and an unlocked committed
+  // selection deliberately no longer blocks capture (see the supersede test
+  // below), so this now drives the path the app actually takes.
+  it('stops capturing pending while a selection is locked', () => {
     pointerDown('touch');
     selectionChange();
-    act(() => hook().commitPendingSelection());
+    act(() => hook().lockSelection());
     mockResolve.mockReturnValue({ ...INFO, text: 'other' });
     selectionChange();
     expect(hook().pendingSelection).toBeNull();
     expect(hook().selection).toEqual(INFO);
+  });
+
+  // A pill showing for an unlocked mouse selection must not swallow a touch
+  // selection made elsewhere. Gating capture on "anything committed" dropped
+  // those silently and left the stale pill over the old text, while the mouse
+  // path always overrode, so the two modalities disagreed.
+  it('a touch selection supersedes an unlocked mouse selection', () => {
+    mockResolve.mockReturnValue({ ...INFO, text: 'MOUSE-A' });
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection?.text).toBe('MOUSE-A');
+
+    mockResolve.mockReturnValue({ ...INFO, text: 'TOUCH-B' });
+    pointerDown('touch');
+    selectionChange();
+
+    expect(hook().pendingSelection?.text).toBe('TOUCH-B');
+    expect(hook().selection).toBeNull();
   });
 
   it('re-arms the pending flow after clearSelection', () => {
@@ -142,6 +164,169 @@ describe('useSelection modality routing', () => {
     });
     expect(hook().pendingSelection).toBeNull();
     expect(hook().selection).toBeNull();
+  });
+
+  // A mouse gesture supersedes any pending touch selection. Without that,
+  // onLock (which fires on every pill interaction) would resurrect the stale
+  // touch selection and anchor the comment to the wrong text.
+  it('a mouse selection clears a pending touch selection', () => {
+    mockResolve.mockReturnValue({ ...INFO, text: 'TOUCH-A' });
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().pendingSelection?.text).toBe('TOUCH-A');
+
+    mockResolve.mockReturnValue({ ...INFO, text: 'MOUSE-B' });
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection?.text).toBe('MOUSE-B');
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  it('committing after a mouse selection does not resurrect the touch one', () => {
+    mockResolve.mockReturnValue({ ...INFO, text: 'TOUCH-A' });
+    pointerDown('touch');
+    selectionChange();
+
+    mockResolve.mockReturnValue({ ...INFO, text: 'MOUSE-B' });
+    pointerDown('mouse');
+    mouseUp();
+
+    act(() => hook().commitPendingSelection());
+    expect(hook().selection?.text).toBe('MOUSE-B');
+  });
+
+  it('a mouse selection that collapses also drops the pending pill', () => {
+    mockResolve.mockReturnValue({ ...INFO, text: 'TOUCH-A' });
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().pendingSelection?.text).toBe('TOUCH-A');
+
+    mockResolve.mockReturnValue(null);
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection).toBeNull();
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  // Tapping the pill collapses the native selection. If the debounce then
+  // resolves null it drops the pending selection and the commit that follows
+  // finds nothing, so the tap silently does nothing. Guarded on where the
+  // gesture started rather than on winning a race against the timer.
+  it('a gesture starting inside the pill does not clear the pending selection', () => {
+    mockResolve.mockReturnValue(INFO);
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().pendingSelection).toEqual(INFO);
+
+    // The pill carries data-preserve-selection.
+    const pillEl = document.createElement('div');
+    pillEl.setAttribute('data-preserve-selection', '');
+    document.body.appendChild(pillEl);
+    const e = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(e, 'pointerType', { value: 'touch' });
+    Object.defineProperty(e, 'target', { value: pillEl });
+    act(() => {
+      document.dispatchEvent(e);
+    });
+
+    // The tap collapsed the selection.
+    mockResolve.mockReturnValue(null);
+    selectionChange();
+
+    expect(hook().pendingSelection).toEqual(INFO);
+    act(() => hook().commitPendingSelection());
+    expect(hook().selection).toEqual(INFO);
+    pillEl.remove();
+  });
+
+  it('a commit landing inside the debounce window does not resurrect pending', () => {
+    mockResolve.mockReturnValue(INFO);
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().pendingSelection).toEqual(INFO);
+
+    // The tap collapses the selection, which schedules a second timer while
+    // nothing is committed yet, so the pre-check does not bail.
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+    // Then the click lands and commits.
+    act(() => {
+      hook().commitPendingSelection();
+    });
+    expect(hook().selection).toEqual(INFO);
+
+    // That in-flight timer must not write pendingSelection back.
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(hook().pendingSelection).toBeNull();
+    expect(hook().selection).toEqual(INFO);
+  });
+
+  // A debounce timer must only ever apply to the gesture that armed it. Without
+  // that, a touch selectionchange could arm a timer, a mouse drag could commit
+  // inside the 150ms window, and the stale timer would then destroy the fresh
+  // mouse selection.
+  it('a stale timer cannot destroy a selection committed after it was armed', () => {
+    mockResolve.mockReturnValue({ ...INFO, text: 'MOUSE-A' });
+    pointerDown('mouse');
+    mouseUp();
+
+    mockResolve.mockReturnValue({ ...INFO, text: 'TOUCH-B' });
+    pointerDown('touch');
+    act(() => {
+      document.dispatchEvent(new Event('selectionchange'));
+    });
+
+    mockResolve.mockReturnValue({ ...INFO, text: 'MOUSE-C' });
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection?.text).toBe('MOUSE-C');
+
+    mockResolve.mockReturnValue(null);
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(hook().selection?.text).toBe('MOUSE-C');
+    expect(hook().pendingSelection).toBeNull();
+  });
+
+  // The preserved-target guard exists to stop the tap that engages the pill from
+  // erasing pending when it collapses the selection. It must not veto a real
+  // adjustment: native handle drags emit no pointerdown, so the flag survives
+  // that tap indefinitely.
+  it('handle adjustments still land after a tap on a preserved element', () => {
+    mockResolve.mockReturnValue({ ...INFO, text: 'TOUCH-A' });
+    pointerDown('touch');
+    selectionChange();
+    expect(hook().pendingSelection?.text).toBe('TOUCH-A');
+
+    const el = document.createElement('span');
+    el.setAttribute('data-preserve-selection', '');
+    document.body.appendChild(el);
+    const e = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(e, 'pointerType', { value: 'touch' });
+    Object.defineProperty(e, 'target', { value: el });
+    act(() => {
+      document.dispatchEvent(e);
+    });
+
+    mockResolve.mockReturnValue({ ...INFO, text: 'TOUCH-A-WIDER' });
+    selectionChange();
+    expect(hook().pendingSelection?.text).toBe('TOUCH-A-WIDER');
+
+    // But a collapse right after that tap still leaves pending intact.
+    mockResolve.mockReturnValue(null);
+    const e2 = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(e2, 'pointerType', { value: 'touch' });
+    Object.defineProperty(e2, 'target', { value: el });
+    act(() => {
+      document.dispatchEvent(e2);
+    });
+    selectionChange();
+    expect(hook().pendingSelection?.text).toBe('TOUCH-A-WIDER');
+    el.remove();
   });
 
   it('does not capture pending while locked', () => {

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -13,30 +13,70 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
   const [pendingSelection, setPendingSelection] = useState<SelectionInfo | null>(null);
   const lockedRef = useRef(false);
   const pendingRef = useRef<SelectionInfo | null>(null);
+  // Mirrors `selection` for the event handlers, which run outside React's
+  // render cycle and cannot read the state variable. Written synchronously by
+  // commitSelection rather than by a passive effect: an effect lags a render,
+  // and a selectionchange timer scheduled in that window used to be able to
+  // leave both states non-null.
   const hasSelectionRef = useRef(false);
+  // Bumped by every state write and every new pointerdown. A debounce timer
+  // captures it when armed and bails if it changed, so a timer can only ever
+  // apply to the gesture that armed it. Native handle drags emit no pointer
+  // events and write nothing, so they leave it alone and their adjustments land.
+  // This replaces a per-event "was something committed before this gesture"
+  // snapshot, which could not distinguish a superseding gesture from the drag it
+  // was meant to allow and so let a stale timer destroy a fresh mouse selection.
+  const epochRef = useRef(0);
 
-  useEffect(() => {
-    hasSelectionRef.current = selection !== null;
-  }, [selection]);
+  // `selection` and `pendingSelection` are mutually exclusive by construction.
+  // These two functions are the ONLY writers, and each clears the other, which
+  // is what stops a stale pending selection from outliving the gesture that
+  // produced it. Add a third writer and that guarantee is gone.
+  //
+  // capturePending: a fresh touch gesture supersedes an unlocked committed
+  // selection exactly as a fresh mouse drag does.
+  const capturePending = useCallback((info: SelectionInfo | null) => {
+    epochRef.current += 1;
+    hasSelectionRef.current = false;
+    setSelection(null);
+    pendingRef.current = info;
+    setPendingSelection(info);
+  }, []);
 
-  const lockSelection = useCallback(() => {
-    lockedRef.current = true;
+  // commitSelection: promotes to committed, or clears everything when passed null.
+  const commitSelection = useCallback((info: SelectionInfo | null) => {
+    epochRef.current += 1;
+    pendingRef.current = null;
+    setPendingSelection(null);
+    hasSelectionRef.current = info !== null;
+    setSelection(info);
   }, []);
 
   const clearSelection = useCallback(() => {
     lockedRef.current = false;
-    pendingRef.current = null;
-    setPendingSelection(null);
-    setSelection(null);
+    commitSelection(null);
     window.getSelection()?.removeAllRanges();
-  }, []);
+  }, [commitSelection]);
 
   const commitPendingSelection = useCallback(() => {
-    if (!pendingRef.current) return;
-    setSelection(pendingRef.current);
-    pendingRef.current = null;
-    setPendingSelection(null);
-  }, []);
+    // No-op once something is already committed. onLock fires this on every
+    // pill interaction, including for a selection that arrived by mouse, and
+    // without this guard a touch selection left pending from an earlier
+    // gesture would silently replace it and anchor the comment to the wrong
+    // text.
+    if (hasSelectionRef.current || !pendingRef.current) return;
+    commitSelection(pendingRef.current);
+  }, [commitSelection]);
+
+  // Composed on purpose. Every consumer that locks a selection is starting a
+  // comment on it, which means a pending touch selection has to be promoted
+  // first. Offering a lock-only variant alongside is what let a second consumer
+  // wire `onLock={lockSelection}` and silently lose touch commenting entirely,
+  // so this hook does not expose one. Stable, because commitPendingSelection is.
+  const lockSelection = useCallback(() => {
+    commitPendingSelection();
+    lockedRef.current = true;
+  }, [commitPendingSelection]);
 
   useEffect(() => {
     // The pointerType of the most recent pointerdown decides which flow
@@ -45,8 +85,17 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
     // gesture (not per device) so hybrid devices — touchscreen laptops,
     // tablets with trackpads — get the right behavior for each interaction.
     let lastPointerType = 'mouse';
+    // Whether the gesture in progress started inside something that must not
+    // lose the selection: the pill, the comment form, a drag handle.
+    let pointerInPreserved = false;
     const handlePointerDown = (e: PointerEvent) => {
+      // A new gesture invalidates any timer armed by the previous one.
+      epochRef.current += 1;
       if (e.pointerType) lastPointerType = e.pointerType;
+      pointerInPreserved =
+        (e.target as Element)?.closest?.(
+          '[data-comment-form], [data-drag-handle], [data-preserve-selection]',
+        ) != null;
     };
 
     const handleMouseUp = (e: MouseEvent) => {
@@ -59,15 +108,15 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
       if (!containerRef.current) return;
 
       const info = resolveSelection(containerRef.current);
-      setSelection(info);
+      // Also clears any pending touch selection: the mouse gesture supersedes
+      // it, whether it resolved to something or collapsed to nothing.
+      commitSelection(info);
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         lockedRef.current = false;
-        pendingRef.current = null;
-        setPendingSelection(null);
-        setSelection(null);
+        commitSelection(null);
         window.getSelection()?.removeAllRanges();
       }
     };
@@ -79,7 +128,13 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
     let selectionDebounce: ReturnType<typeof setTimeout> | undefined;
     const handleSelectionChange = () => {
       if (lastPointerType === 'mouse') return;
-      if (lockedRef.current || hasSelectionRef.current) return;
+      // Only a LOCKED selection blocks capture. An unlocked committed selection
+      // is just a pill showing, and a new touch gesture supersedes it the same
+      // way a new mouse drag does. Gating on hasSelectionRef here dropped every
+      // touch selection made while a mouse pill was up, silently, with the stale
+      // pill left floating over the old text.
+      if (lockedRef.current) return;
+      const armedEpoch = epochRef.current;
       if (document.body.classList.contains('anchor-dragging')) return;
       if (!containerRef.current) return;
       clearTimeout(selectionDebounce);
@@ -90,9 +145,25 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
           anchorEl?.closest?.('[data-comment-form], [data-drag-handle], [data-preserve-selection]')
         )
           return;
-        const info = resolveSelection(containerRef.current!);
-        pendingRef.current = info;
-        setPendingSelection(info);
+        // Re-read the ref inside the timer: the guard above ran 150ms ago and
+        // the container can unmount in between (tab close, view switch), which
+        // a non-null assertion here would turn into a throw in a stray timeout.
+        const container = containerRef.current;
+        if (!container) return;
+        // Re-check inside the callback, not only before scheduling: a commit or
+        // a lock landing during the 150ms window would otherwise let this write
+        // pendingSelection while a selection is already committed.
+        if (lockedRef.current) return;
+        // Anything that wrote state or started a new gesture since this timer
+        // was armed supersedes it.
+        if (epochRef.current !== armedEpoch) return;
+        const info = resolveSelection(container);
+        // The tap that engages the pill collapses the native selection. Dropping
+        // pending then would leave the commit nothing to promote. But this must
+        // not veto a real adjustment: handle drags emit no pointerdown, so the
+        // flag is still set from that tap long after it mattered.
+        if (info === null && pointerInPreserved) return;
+        capturePending(info);
       }, 150);
     };
 
@@ -107,7 +178,18 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
       document.removeEventListener('selectionchange', handleSelectionChange);
       clearTimeout(selectionDebounce);
     };
-  }, [containerRef]);
+  }, [containerRef, commitSelection, capturePending]);
 
-  return { selection, pendingSelection, clearSelection, lockSelection, commitPendingSelection };
+  return {
+    selection,
+    pendingSelection,
+    // The derived pair every consumer needs. Hand-rolling these at each call
+    // site is how the Mermaid fullscreen modal ended up reading `selection`
+    // alone and losing touch commenting without any error.
+    commentSelection: selection ?? pendingSelection,
+    isPending: !selection && pendingSelection !== null,
+    clearSelection,
+    lockSelection,
+    commitPendingSelection,
+  };
 }

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -4,7 +4,20 @@ import type { SelectionInfo } from '../types';
 
 export function useSelection(containerRef: React.RefObject<HTMLElement | null>) {
   const [selection, setSelection] = useState<SelectionInfo | null>(null);
+  // Selections made by touch or pen are captured here instead of opening the
+  // comment form directly. Native selection-handle drags happen in browser
+  // chrome and emit no pointer events the page can see, so no timer can
+  // distinguish "paused to think" from "done adjusting" — the form opens only
+  // when the user commits explicitly (the floating Comment button). Mouse
+  // selections keep the immediate-open behavior.
+  const [pendingSelection, setPendingSelection] = useState<SelectionInfo | null>(null);
   const lockedRef = useRef(false);
+  const pendingRef = useRef<SelectionInfo | null>(null);
+  const hasSelectionRef = useRef(false);
+
+  useEffect(() => {
+    hasSelectionRef.current = selection !== null;
+  }, [selection]);
 
   const lockSelection = useCallback(() => {
     lockedRef.current = true;
@@ -12,12 +25,32 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
 
   const clearSelection = useCallback(() => {
     lockedRef.current = false;
+    pendingRef.current = null;
+    setPendingSelection(null);
     setSelection(null);
     window.getSelection()?.removeAllRanges();
   }, []);
 
+  const commitPendingSelection = useCallback(() => {
+    if (!pendingRef.current) return;
+    setSelection(pendingRef.current);
+    pendingRef.current = null;
+    setPendingSelection(null);
+  }, []);
+
   useEffect(() => {
+    // The pointerType of the most recent pointerdown decides which flow
+    // handles the resulting selection: 'mouse' opens the form on mouseup as
+    // before; 'touch' and 'pen' route through the pending flow. Tracked per
+    // gesture (not per device) so hybrid devices — touchscreen laptops,
+    // tablets with trackpads — get the right behavior for each interaction.
+    let lastPointerType = 'mouse';
+    const handlePointerDown = (e: PointerEvent) => {
+      if (e.pointerType) lastPointerType = e.pointerType;
+    };
+
     const handleMouseUp = (e: MouseEvent) => {
+      if (lastPointerType !== 'mouse') return;
       if (lockedRef.current) return;
       if ((e.target as Element)?.closest?.('[data-comment-form]')) return;
       if ((e.target as Element)?.closest?.('[data-drag-handle]')) return;
@@ -32,18 +65,49 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
     const handleKeyUp = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
         lockedRef.current = false;
+        pendingRef.current = null;
+        setPendingSelection(null);
         setSelection(null);
         window.getSelection()?.removeAllRanges();
       }
     };
 
+    // Touch/pen selection never fires mouseup, so watch selectionchange. The
+    // short debounce only coalesces the event stream during a handle drag —
+    // it does not gate the UI, since the pending selection just enables the
+    // commit button rather than opening anything.
+    let selectionDebounce: ReturnType<typeof setTimeout> | undefined;
+    const handleSelectionChange = () => {
+      if (lastPointerType === 'mouse') return;
+      if (lockedRef.current || hasSelectionRef.current) return;
+      if (document.body.classList.contains('anchor-dragging')) return;
+      if (!containerRef.current) return;
+      clearTimeout(selectionDebounce);
+      selectionDebounce = setTimeout(() => {
+        const anchorNode = window.getSelection()?.anchorNode;
+        const anchorEl = anchorNode instanceof Element ? anchorNode : anchorNode?.parentElement;
+        if (
+          anchorEl?.closest?.('[data-comment-form], [data-drag-handle], [data-preserve-selection]')
+        )
+          return;
+        const info = resolveSelection(containerRef.current!);
+        pendingRef.current = info;
+        setPendingSelection(info);
+      }, 150);
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown);
     document.addEventListener('mouseup', handleMouseUp);
     document.addEventListener('keyup', handleKeyUp);
+    document.addEventListener('selectionchange', handleSelectionChange);
     return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
       document.removeEventListener('mouseup', handleMouseUp);
       document.removeEventListener('keyup', handleKeyUp);
+      document.removeEventListener('selectionchange', handleSelectionChange);
+      clearTimeout(selectionDebounce);
     };
   }, [containerRef]);
 
-  return { selection, clearSelection, lockSelection };
+  return { selection, pendingSelection, clearSelection, lockSelection, commitPendingSelection };
 }

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -1,4 +1,5 @@
 import { getEffectiveStatus, type MdComment, type ParseResult, type CommentReply } from '../types';
+import { randomId } from './random-id';
 
 // Match <!-- @comment{...JSON...} --> — use dotall flag so JSON with
 // newlines in string values is matched correctly.
@@ -534,7 +535,7 @@ export function insertComment(
   contextBefore?: string,
   contextAfter?: string,
   hintOffset?: number,
-  commentId: string = crypto.randomUUID(),
+  commentId: string = randomId(),
   extras?: InsertCommentExtras,
 ): string {
   const comment: MdComment = {
@@ -891,7 +892,7 @@ export function addReply(
   author: string = 'User',
 ): string {
   const reply: CommentReply = {
-    id: crypto.randomUUID(),
+    id: randomId(),
     text,
     author,
     timestamp: new Date().toISOString(),

--- a/src/lib/random-id.test.ts
+++ b/src/lib/random-id.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { randomId } from './random-id';
+
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('randomId', () => {
+  it('uses crypto.randomUUID when it exists', () => {
+    const spy = vi.spyOn(crypto, 'randomUUID');
+    expect(randomId()).toMatch(V4);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  // The whole reason this helper exists. crypto.randomUUID is secure-context
+  // only, so it is undefined when the app is served over plain HTTP from
+  // anything but localhost, which is how md-redline is reached from a tablet on
+  // the LAN. Neither node nor jsdom reproduces that, so without this test the
+  // fallback branch never executes in CI and a later simplification could break
+  // comment creation on that path while staying green.
+  describe('without crypto.randomUUID (non-secure context)', () => {
+    // `delete crypto.randomUUID` does not work: it is non-configurable in
+    // Node's webcrypto. Stubbing the global with an object that simply lacks it
+    // is what a non-secure context actually looks like to the helper.
+    const withoutRandomUUID = <T>(fn: () => T): T => {
+      const realGetRandomValues = crypto.getRandomValues.bind(crypto);
+      vi.stubGlobal('crypto', {
+        getRandomValues: (b: Uint8Array) => realGetRandomValues(b),
+      });
+      try {
+        return fn();
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    };
+
+    it('still returns a well-formed v4', () => {
+      withoutRandomUUID(() => {
+        expect(crypto.randomUUID).toBeUndefined();
+        expect(randomId()).toMatch(V4);
+      });
+    });
+
+    it('sets the version and variant bits, not just the shape', () => {
+      withoutRandomUUID(() => {
+        // getRandomValues returning all zeroes isolates the bit math from
+        // entropy: version must be 4 and the variant nibble must be 8.
+        vi.stubGlobal('crypto', {
+          getRandomValues: (b: Uint8Array) => {
+            b.fill(0);
+            return b;
+          },
+        });
+        expect(randomId()).toBe('00000000-0000-4000-8000-000000000000');
+      });
+    });
+
+    it('does not repeat across many draws', () => {
+      withoutRandomUUID(() => {
+        const ids = new Set(Array.from({ length: 5000 }, () => randomId()));
+        expect(ids.size).toBe(5000);
+      });
+    });
+  });
+});

--- a/src/lib/random-id.ts
+++ b/src/lib/random-id.ts
@@ -1,0 +1,29 @@
+/**
+ * A UUID v4 that works outside a secure context.
+ *
+ * `crypto.randomUUID` is secure-context only, so it is undefined when the app
+ * is served over plain HTTP from anything other than localhost. That is exactly
+ * what happens when you reach md-redline from another device on the LAN, and
+ * the failure is bad: creating a comment threw a TypeError mid-save, so the
+ * comment silently never appeared.
+ *
+ * `crypto.getRandomValues` carries no such restriction, so the fallback is a
+ * real v4 from the same entropy source rather than a downgrade to Math.random.
+ * Both paths require `crypto` itself, which every browser this app supports has
+ * regardless of secure context; only `randomUUID` and `subtle` are gated.
+ */
+// Byte-to-hex table, built once rather than per call.
+const HEX = Array.from({ length: 256 }, (_, i) => (i + 0x100).toString(16).slice(1));
+
+export function randomId(): string {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  // Set the version (4) and variant (10xx) bits.
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const b = Array.from(bytes, (v) => HEX[v]);
+  return `${b[0]}${b[1]}${b[2]}${b[3]}-${b[4]}${b[5]}-${b[6]}${b[7]}-${b[8]}${b[9]}-${b[10]}${b[11]}${b[12]}${b[13]}${b[14]}${b[15]}`;
+}


### PR DESCRIPTION
Closes #16. Supersedes #18: @JesseLeresche's commit is preserved here unchanged as
the first of three, with two follow-up commits from me on top.

### What

Touch selection never fires `mouseup`, so the comment flow was unreachable from a
tablet. Selections made by touch or pen are captured as *pending* while the user
adjusts them with the native handles, and engaging the comment pill promotes the
stored `SelectionInfo` snapshot to the active selection. Mouse behaviour is
unchanged.

The design reasoning is Jesse's and it is the right call. Two things he ruled out
with on-device evidence, both of which I would have tried first:

- `selectionchange` plus a settle timer races the user. Native handle drags emit
  no page-visible pointer events, so no timeout distinguishes "paused to think"
  from "done adjusting" (he tried 350ms and 900ms on an iPad; both interrupt).
- Gating on `matchMedia('(pointer: coarse)')` breaks hybrids. Modality is decided
  per gesture from the last `pointerdown`'s `pointerType` instead, so a
  touchscreen laptop gets mouse-immediate and touch-deferred behaviour side by
  side.

### One pill, both modalities

His commit gave touch its own affordance: a Comment button fixed bottom-right.
Testing on an iPad Pro turned up two problems. It overlapped `Toast`
(`bottom-12 right-4`) and sat under `UpdateNotice` (`bottom-24 right-4`), all
three at `z-50` with stacking decided by DOM order. More importantly it was a
second, poorer affordance: mouse users got the collapsed pill with Comment plus
quick templates, touch users got a bare button and then had to tap Comment again
on the pill that appeared after committing. Two taps to reach a field a mouse
reaches in one click, and the quick templates were unreachable by touch entirely.

There is now one surface. `App.tsx` renders a single `CommentForm` for
`selection ?? pendingSelection`, and since `handleExpand` and `handlePillTemplate`
both call `onLock` first, `lockSelection` promotes the pending selection. Touch
and mouse are identical by construction rather than by keeping two components in
sync. The pill's scroll-follow also coalesces into one measurement per animation
frame, which fixes jitter on touch and helps the mouse pill too.

### Found by testing on a real device

- **`crypto.randomUUID` is secure-context only**, so it is undefined whenever the
  app is served over plain HTTP from anything but localhost. Reaching md-redline
  from another device on the LAN is exactly that case, and the failure was silent
  and total: creating a comment threw partway through the save, so the comment
  never appeared and no error surfaced. Not touch-specific; the mouse path failed
  identically. Now falls back to `crypto.getRandomValues`, which carries no such
  restriction.
- **Quick comment auto-opened the form** on a pending touch selection, removing
  the adjustment step the whole feature exists to provide.

### Found by review

Ten review-loop fixes are squashed into the second commit. The ones worth knowing
about:

- **A wrong-anchor bug.** `commitPendingSelection` overwrote a live mouse
  selection with a stale pending touch one, so the comment attached to the wrong
  text. Reachable on any hybrid device. Fixed by making two writers the only
  writers, each clearing the other.
- **Touch commenting was dead in the Mermaid fullscreen modal**, which is a second
  `useSelection` consumer nobody had audited. It read `selection` only, so every
  touch gesture produced a pending selection nothing rendered. That contradicted
  the commenting parity AGENTS.md claims for that surface.
- **Three of five comment entry points silently no-opped on touch.** Cmd+Enter,
  Cmd+Shift+M and the context menu all gated on a ref mirroring the committed
  selection only. An iPad with a keyboard attached is the flagship setup here.
- **The touch suite dispatched no touch events.** Every gesture was a synthetic
  `PointerEvent` and every tap a mouse click, so the `onTouchEnd` handlers had
  zero coverage and survived deletion. Added a `hasTouch` block driving
  `page.touchscreen`. That in turn showed `preventDefault` on `touchend` was a
  race against the 150ms debounce, now replaced by a gesture epoch that does not
  depend on timing.
- **One of my own tests was vacuous.** "Quick templates available on touch"
  counted buttons excluding Comment, and the always-present overflow control
  satisfied it with zero templates rendered, which is the exact regression it
  named. Mutation-tested, rewritten to assert the labels and the prefill.

`useSelection` now returns `commentSelection`, `isPending` and a composed
`lockSelection`, so a third consumer cannot repeat the Mermaid mistake by wiring
`onLock={lockSelection}` and losing touch silently. There is no lock-only variant
to reach for, because no caller wants one.

### Known gaps, deliberately not in scope

- **The anchor drag handles are still mouse-only** (`DragHandles.tsx`,
  `useDragHandles.ts`). They react to a tap because iOS synthesises a
  `mousedown`, but a touch drag emits no `mousemove`, so they cannot be moved on
  a tablet. Re-anchoring an existing comment is a different feature from creating
  one, and a 472-line drag state machine deserves its own PR and tests. Filed as
  #35 and documented as a known gap in AGENTS.md.
- **`useSelection`'s state should collapse to one value.** Three of its five
  invariants hold by construction and two by convention, and every bug above was
  one of the convention ones. Filed separately: rewriting it touches the mouse
  path every existing user depends on, to benefit a feature only tablet users
  reach, so it does not belong in this PR. Filed as #34.

### Testing

1605 unit tests, 331 e2e, lint, format and `tsc -b` clean. Every regression test
was verified to fail without its fix by reverting through git rather than by hand.
Live-verified on an iPad Pro M2 running current iPadOS: long-press select, adjust
the native handles, commit, type, save, Apple Pencil Scribble into the composer,
and scroll with a selection pending.
