### PR TITLE
fix: resolve the API port and home directory once, treating a blank value as unset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,62 @@ direct a change must use POST or PUT, the two verbs the `application/json` guard
 checks. See the README section "Reaching md-redline from another device" for the
 operator-facing version.
 
+**Environment variables** that a user sets use the `MD_REDLINE_` prefix. New
+user-facing variables take the prefix.
+
+Two aliases predate the convention and still work, because both shipped and are
+documented in the README's config table: `MDR_BROWSER` for `MD_REDLINE_BROWSER`,
+and a bare `PORT` for `MD_REDLINE_PORT`. Do not remove either without a major. In
+both pairs the prefixed name wins, but only if it is non-EMPTY. Blank counts as
+unset everywhere, because a plain `??` keeps an empty string and an empty string
+is rarely harmless: `MD_REDLINE_PORT=""` used to beat a working `PORT` and reach
+`Number.parseInt('')`, and the resulting NaN aborted startup with "No available
+port found (tried NaN-NaN)"; an empty `MD_REDLINE_HOME` resolved
+`.md-redline.json` against the current working directory, so trusted roots were
+written wherever the user launched from and never persisted.
+
+One resolver per variable, imported by every reader: **more than one place reads
+the same variable, and the readers have to agree.** `vite.config.ts` resolves the
+API port to aim its dev proxy, `server/index.ts` resolves it to decide what to
+bind, `bin/md-redline` resolves it to seed the fallback scan that finds a running
+server, and `server/update-check.ts` resolves the home directory independently of
+`server/index.ts` (the update checker is constructed with no `homeDir` option, so
+that read is live in production).
+
+Three inline copies is what that replaced, and they did disagree. `PORT=7100`, the
+alias the README documents, bound the server and aimed the proxy at 7100 while the
+CLI scanned from 6373, because the CLI's copy read only the prefixed name; the CLI
+could then find the server through the port file or not at all. A blank
+`MD_REDLINE_PORT` aborted the server with "No available port found (tried
+NaN-NaN)" and killed `npm run dev` with `ERR_SOCKET_BAD_PORT`, while the CLI
+quietly fell back to 6373. Only a malformed value like `7100nonsense` was
+consistent, and only because all three truncated it the same way; all three now
+reject it. Add a resolver and import it; never inline a second copy.
+
+The port resolvers live in `bin/ports.js`, not in `server/env.ts`, and that
+location is deliberate. `bin/md-redline` reads the API port too, to seed the
+fallback scan that locates a running server when the port file is missing or
+stale, and it is a dependency-free CLI with no build step, so it can only import
+plain JavaScript. `bin/` is also what package.json ships next to `dist/`, so the
+module is present in an npm install. `server/env.ts` re-exports it, esbuild inlines
+it into `dist/server.js`, and `vite.config.ts` reaches it through `server/env.ts`.
+Three readers, one function. Types come from the hand-written `bin/ports.d.ts`,
+not from a compiler flag: `bin/version-compare.js` has been shared between the CLI
+and `server/update-check.ts` the same way since before this module existed, and
+`allowJs` would have typed every future `bin/` import as unchecked `any`.
+
+`MD_REDLINE_REGISTRY_URL` and `MD_REDLINE_BASE_URL` keep a plain `??` by choice:
+both are development or background-only, and a blank value fails visibly at the
+first fetch rather than quietly doing the wrong thing. `NO_UPDATE_NOTIFIER` and
+`CI` are presence-checked on purpose, per ecosystem convention, where an empty
+value counts as set.
+
+Two further sets are deliberately outside the rule. `MD_REDLINE_INTERNAL_BROWSER_*` are
+set by `bin/md-redline` and expanded by the Windows `cmd` it spawns, never read
+through `process.env`, so a `process.env` grep will not find them: they are an
+argument-passing mechanism rather than configuration. `RELEASE_SKIP_CI_CHECK` and
+`RELEASE_SKIP_CLAUDE` are local to `scripts/release.mjs`.
+
 **Ports and loopback discipline** — the API server binds IPv4 loopback only
 (`127.0.0.1`), default port 6373 ("MDR" on a phone keypad; overridable via
 `MD_REDLINE_PORT`), scanning up to 10 ports from there if taken. The Vite dev
@@ -228,7 +284,7 @@ fast-path lookup and removes it on exit only if it still owns the recorded port
 
 **Browser launcher** — the CLI opens the resolved URL in the OS default
 browser: `open` (macOS), `xdg-open` (Linux), `cmd /c start` (Windows). Set
-`MDR_BROWSER` to override with an explicit command that is spawned with the URL
+`MD_REDLINE_BROWSER` to override with an explicit command that is spawned with the URL
 as its argument. Every launch goes through `spawnDetached`, which on Windows
 must pass `detached: true` (opt-in per call) so the child outlives the CLI's
 near-immediate exit; without it the launcher is torn down before it runs. The
@@ -236,7 +292,11 @@ long-lived server deliberately stays non-detached, since a detached child gets
 its own console window on Windows that `windowsHide` cannot suppress under
 `shell: true`. The undocumented `mdr __open <url>` subcommand runs only the
 launcher and exits; the browser-open regression test
-(`bin/open-launch-cli.test.ts`) drives it with `MDR_BROWSER` pointed at a stub.
+(`bin/open-launch-cli.test.ts`) drives it with `MD_REDLINE_BROWSER` pointed at a stub.
+The undocumented `mdr __port` prints the API port the CLI resolved and exits, which
+is the only way to observe it: that value only seeds the fallback scan inside
+`findServerPort`, and `--stop` would kill whatever it found. The same test file uses
+it to prove the CLI agrees with the server and `vite.config.ts`.
 
 **CLI stale-server upgrade**: on every plain `mdr` invocation,
 `ensureServerRunning()` in `bin/md-redline` asks the running server for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+# Contributing to md-redline
+
+Thanks for taking the time. This file covers the things you cannot infer from the
+code, so you do not lose an afternoon to them.
+
+`AGENTS.md` is the full reference for architecture, the comment format, the API,
+keyboard shortcuts and everything else. It is long because it is a reference, not
+a starting point. Read this first, and reach for `AGENTS.md` when you need the
+detail on whatever you are actually touching.
+
+## Setup
+
+Node 20 or newer.
+
+```bash
+npm install
+npm run dev        # server + Vite client + MCP bundle watcher
+```
+
+`npm run dev` serves the app at `http://localhost:5188` with the API on `6373`.
+
+## Before you push
+
+`npm run format && npm test`, then `npm run test:e2e` if you touched anything a
+browser sees. That is the common case; `.github/workflows/ci.yml` is the authority
+on what actually gates a merge, and it is short enough to read.
+
+The one thing worth knowing without reading it: unit tests run on ubuntu, windows
+and macos, while everything else runs on Linux only. If you touch process
+spawning, path handling or the browser launcher, that matrix is where you will
+find out you were wrong, and a green run on your own machine says little about the
+other two.
+
+### Four things that will waste your time otherwise
+
+**Formatting gates everything else.** `format:check` runs before lint, so an
+unformatted file fails the build before a single test runs. `npm run format` fixes
+it. Markdown is excluded on purpose: this file and the README are hand-wrapped.
+
+The exception that will bite you: the format globs match by extension, and
+`bin/md-redline` has none, so the main CLI entrypoint is neither formatted nor
+checked. Leave its hand-formatting alone. Running `prettier --write bin/md-redline`
+reflows the entire file and buries your actual change in a hundred lines of noise.
+
+**`npm run test:unit` needs a current `dist/`.** The MCP stdio tests spawn
+`bin/md-redline mcp`, which runs the built bundle. Against a stale `dist/` they
+skip themselves rather than fail, so a green summary can hide them entirely. Watch
+the skip count. `npm test` runs `build && test:unit` for exactly this reason; if
+`mcp-stdio-subprocess` behaves oddly, rebuild before you debug.
+
+**`npx tsc --noEmit` at the repo root checks nothing.** The root `tsconfig.json`
+is solution-style (references only), so it exits clean having verified nothing at
+all. Use `npx tsc -b`, which is what `npm run build` runs.
+
+**Rebasing after a formatting change is much easier in one specific order.** Run
+`npm run format` on your branch and commit that *before* rebasing onto main. Both
+sides then hold identical formatting and the whitespace conflicts mostly vanish,
+leaving only genuine overlap to resolve.
+
+## Testing expectations
+
+New logic paths need tests. Two lessons from recent work, both learned the
+expensive way:
+
+**A regression test must fail without its fix.** Revert the fix, watch the test
+go red for the stated reason, then restore. Revert with git (`git stash push --
+<file>`) rather than editing the source back by hand: a hand-edit that misses on
+whitespace produces a green test that proves nothing.
+
+**Touch behaviour cannot be tested with synthetic events.** A suite that
+dispatches `PointerEvent` objects and calls `.click()` will pass with the touch
+handlers deleted. `e2e/touch-selection.spec.ts` has the working pattern: a
+`test.use({ hasTouch: true })` block driving `page.touchscreen`.
+
+The e2e suite drives a real Chromium and is serialized with one retry, so it is
+slow and a single flake costs a full re-run. Run the specs covering your change
+while you work, and the whole suite before pushing.
+
+## Docs
+
+`AGENTS.md` is the single source of truth for codebase documentation. If your
+change adds a route, a setting, a keyboard shortcut, a theme or a command-palette
+entry, update `AGENTS.md` in the same commit. Do not add a parallel doc; do not
+put codebase docs in `CLAUDE.md`.
+
+The README is user-facing. Update it when you change something a user configures
+or interacts with.
+
+## Conventions
+
+- User-facing environment variables use the `MD_REDLINE_` prefix, a blank value
+  counts as unset, and anything read from more than one place gets one shared
+  resolver rather than a second inline copy. `AGENTS.md` has the rule, where the
+  resolvers live and why, the grandfathered aliases and the exceptions.
+- Any route that lets a caller change something must be a `POST` or a `PUT`, the
+  two verbs the `application/json` guard checks. A state-changing `GET` is
+  reachable from an `<img>` tag in a markdown document the app renders, which is
+  untrusted input. `AGENTS.md` has the detail.
+- Comments explain why, not what. The repo leans toward fewer, longer comments
+  that capture a decision or a non-obvious constraint.
+
+## Opening a PR
+
+Describe what changed and why, and say what you verified. If you tested on real
+hardware, say which device and OS: several bugs in this codebase were only ever
+reproducible on a real iPad, and that context is worth more than a green CI run.
+
+Small PRs land faster. If you find an unrelated problem on the way, file it
+separately rather than folding it in.

--- a/README.md
+++ b/README.md
@@ -239,8 +239,8 @@ All of these environment variables are optional.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
-| `MDR_BROWSER` | OS default browser | Command used to open the review URL. Set it to a specific browser binary (for example `MDR_BROWSER=firefox`); it is spawned with the URL as its argument. |
-| `MD_REDLINE_PORT` (or `PORT`) | `6373` | Port for the API server. It scans up to 10 ports upward from here if that one is taken. |
+| `MD_REDLINE_BROWSER` | OS default browser | Command used to open the review URL. Set it to a specific browser binary (for example `MD_REDLINE_BROWSER=firefox`); it is spawned with the URL as its argument. The older `MDR_BROWSER` still works: it is used whenever this one is unset or blank. |
+| `MD_REDLINE_PORT` (or `PORT`) | `6373` | Port for the API server. It scans up to 10 ports upward from here if that one is taken. `MD_REDLINE_PORT` wins when both are set; a blank one defers to `PORT`. |
 | `MD_REDLINE_VITE_PORT` | `5188` | Port for the Vite dev client (development only). |
 | `MD_REDLINE_HOME` | your OS home directory | Base directory for md-redline's preferences file (`.md-redline.json`, which stores trusted roots and the update-check cache). |
 | `MD_REDLINE_REGISTRY_URL` | public npm registry | Registry base URL used for the background update check. |
@@ -252,66 +252,65 @@ All of these environment variables are optional.
 md-redline binds to `127.0.0.1` and has **no authentication of any kind**. That is
 safe today because only your own machine can reach it.
 
-`MD_REDLINE_ALLOWED_HOSTS` exists so you can put a reverse proxy in front of it
-(`tailscale serve`, nginx, Caddy) and review from a tablet. Setting it does not
-change the bind address, so the proxy still has to run on the same machine. What
-it does change is the security boundary: it moves from "my machine" to "anything
-that can reach the proxy".
+`MD_REDLINE_ALLOWED_HOSTS` lets you put a reverse proxy in front of it
+(`tailscale serve`, nginx, Caddy) and review from a tablet. It does not change the
+bind address, so the proxy still runs on the same machine. It does change the
+security boundary, from "my machine" to "anything that can reach the proxy".
 
-Whatever can reach the proxy gets unauthenticated access to:
+Whatever reaches the proxy can read and write every markdown file under your
+trusted roots, browse those directories, see their absolute paths and your recent
+files, open native file pickers and reveal files in Finder **on your machine**,
+answer agent review sessions, and shut the server down. There is no login.
 
-- Reading and writing any markdown file under your trusted roots (`GET` and `PUT /api/file`)
-- Listing and browsing directories under those roots (`GET /api/browse`, `GET /api/files`)
-- Reading any image under those roots (`GET /api/asset`)
-- Learning where those roots are, plus every file you recently opened, as absolute
-  paths (`GET /api/preferences`)
-- Changing your stored author name, theme, recent files and settings (`PUT /api/preferences`)
-- Opening native file and folder pickers **on your machine** (`POST /api/pick-file`, `POST /api/pick-folder`)
-- Revealing files in Finder or Explorer **on your machine** (`POST /api/reveal`)
-- Reading and answering agent review sessions (`/api/review-sessions/*`), watching
-  files for changes (`GET /api/watch`), and shutting the server down (`POST /api/shutdown`)
+So if you set it:
 
-So if you set this:
-
-- Prefer `tailscale serve`, which is reachable only from devices on your own
-  tailnet. Do **not** use `tailscale funnel`, which publishes to the open internet.
+- Prefer `tailscale serve`, reachable only from your own tailnet. Do **not** use
+  `tailscale funnel`, which publishes to the open internet.
 - With nginx or Caddy, terminate TLS and put authentication in front of md-redline
   yourself. It will not do it for you.
 - Only list hostnames you actually control. The DNS-rebinding defense still holds
   for everything else, because an attacker's rebinding domain never matches a
   hostname you listed explicitly.
+- Serve it over HTTPS if you can. The clipboard API the hand-off prompt copy needs
+  only works in a secure context, so over plain HTTP that button fails on the very
+  tablet you set this up for.
 
-Two practical notes on the proxy itself:
+A reachable client **cannot** widen its own filesystem access: trusted roots grow
+only when you pick a file or folder in the native dialog, so the readable set
+stays whatever you approved locally.
 
-- **Whether you need this variable at all depends on your proxy.** `tailscale serve`
-  and Caddy preserve the original `Host`, so you must list the public hostname.
-  nginx's default `proxy_set_header Host $proxy_host` rewrites it to `127.0.0.1:6373`,
-  which already passes, so you only need the variable if you forward the original
-  host (`proxy_set_header Host $host`).
-- **Turn off response buffering for `/api/watch`.** Live file updates arrive over
-  Server-Sent Events. md-redline sends `X-Accel-Buffering: no`, which nginx honours;
-  if your proxy ignores it, disable buffering for that path or edits will not appear
-  until a buffer fills.
+<details>
+<summary>Proxy configuration details and how the request checks work</summary>
 
-Serve it over HTTPS if you can. The clipboard API that the hand-off prompt copy
-relies on only works in a secure context, so over plain HTTP that button fails on
-the tablet you set this up for.
+**Whether you need the variable at all depends on your proxy.** `tailscale serve`
+and Caddy preserve the original `Host`, so you must list the public hostname.
+nginx's default `proxy_set_header Host $proxy_host` rewrites it to
+`127.0.0.1:6373`, which already passes, so you only need the variable if you
+forward the original host (`proxy_set_header Host $host`).
 
-Every endpoint that changes something is a `POST` or a `PUT` requiring a JSON
-content type, which a web page cannot send to another origin without the browser
-asking this server for permission first. That is what stops a page you visit, or
-a link in a chat message, or an image embedded in a markdown file you are
-reviewing, from quietly triggering an endpoint here. md-redline additionally
-rejects requests a browser labels cross-site, but only as a second layer: clients
-that send no such metadata, like the CLI and the MCP server, are deliberately
-unaffected by it.
+**Turn off response buffering for `/api/watch`.** Live file updates arrive over
+Server-Sent Events. md-redline sends `X-Accel-Buffering: no`, which nginx honours;
+if your proxy ignores it, disable buffering for that path or edits will not appear
+until a buffer fills.
 
-What a reachable client **cannot** do is widen its own filesystem access. Trusted
-roots grow only when you pick a file or folder in the native dialog
-(`/api/pick-file`, `/api/pick-folder`). A bulk `PUT /api/preferences` cannot write
-`trustedRoots`, and `/api/grant-access` only re-checks a path against the roots
-you already approved rather than adding new ones. So the set of readable
-directories is whatever you approved locally and nothing more.
+**Why a hostile page cannot drive these endpoints.** Every endpoint that changes
+something is a `POST` or a `PUT` requiring a JSON content type, which a web page
+cannot send to another origin without the browser asking this server for
+permission first. That is what stops a page you visit, a link in a chat message,
+or an image embedded in a markdown file you are reviewing from quietly triggering
+an endpoint here. md-redline additionally rejects requests a browser labels
+cross-site, but only as a second layer: clients that send no such metadata, like
+the CLI and the MCP server, are deliberately unaffected.
+
+**The full surface**, if you want to audit it: `GET`/`PUT /api/file`,
+`GET /api/browse`, `GET /api/files`, `GET /api/asset`, `GET`/`PUT /api/preferences`,
+`GET /api/config`, `GET /api/version`, `GET /api/platform`,
+`POST /api/pick-file`, `POST /api/pick-folder`, `POST /api/reveal`,
+`GET /api/watch`, `POST /api/shutdown`, and `/api/review-sessions/*`.
+`POST /api/grant-access` only re-checks a path against roots you already approved
+rather than adding new ones.
+
+</details>
 
 ## Troubleshooting
 

--- a/bin/cli-browser-stub.ts
+++ b/bin/cli-browser-stub.ts
@@ -3,7 +3,7 @@ import { join } from 'path';
 
 /**
  * Writes a platform-appropriate executable stub that stands in for a real
- * browser when the CLI is driven under test via the MDR_BROWSER override. The
+ * browser when the CLI is driven under test via the MD_REDLINE_BROWSER override. The
  * CLI spawns it with the URL as its sole argument.
  *
  * With `markerPath`, the stub writes its URL argument there as its first action,

--- a/bin/md-redline
+++ b/bin/md-redline
@@ -9,6 +9,7 @@ import process from 'process';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 import { createRequire } from 'module';
+import { resolveApiPort } from './ports.js';
 
 import { checkServer, gracefulShutdown, killPort } from './server-control.js';
 import { buildWindowsCommand } from './spawn-command.js';
@@ -21,14 +22,13 @@ const APP_DIR = resolve(__dirname, '..');
 const require = createRequire(import.meta.url);
 const { version: CLI_VERSION } = require(join(APP_DIR, 'package.json'));
 const DIST_SERVER = join(APP_DIR, 'dist', 'server.js');
-// 6373 ("MDR" on a phone keypad) keeps mdr out of the 3000-3010 range that
-// Next.js/Nest/CRA stacks contend for. The server reads the same env var,
-// so an override stays consistent across CLI and server.
-const DEFAULT_SERVER_PORT = Number.parseInt(process.env.MD_REDLINE_PORT ?? '', 10) || 6373;
-// Pre-0.7 servers bound 3001+. Scanning the old range lets this CLI find a
-// still-running old server, so the version-upgrade path can stop it and
-// `mdr --stop` keeps working across the port migration. Safe to drop once
-// no pre-6373 servers can plausibly be running.
+const DEFAULT_SERVER_PORT = resolveApiPort();
+// Pre-0.7 servers bound 3001+. 0.7.0 (2026-07-18) moved the default to 6373, and
+// 0.6.0 shipped four days before it, so a machine that has not rebooted since can
+// still have one running. Scanning the old range lets the stale-server upgrade path
+// find that server and stop it, and keeps `mdr --stop` working across the
+// migration. Drop this at 0.8.0 or after 2026-11-01, whichever is later: these are
+// local servers, so one reboot cycle clears every one of them.
 const LEGACY_SERVER_PORT = 3001;
 const DEFAULT_CLIENT_PORT = 5188;
 const MAX_PORT_SCAN = 10;
@@ -722,6 +722,17 @@ async function main() {
     // detached-teardown race — and honors MD_REDLINE_BROWSER like every other path.
     const target = process.argv[3];
     if (target) await openInBrowser(target);
+    return;
+  }
+
+  if (process.argv[2] === '__port') {
+    // Internal, undocumented seam, same idea as __open above: print the API port
+    // this CLI resolved and exit, without booting or contacting anything. The port
+    // is otherwise unobservable from outside, because it only seeds the fallback
+    // scan inside findServerPort, and the one command that would reveal it
+    // (--stop) kills whatever it finds. Lets a test prove the CLI, the server and
+    // vite.config all answer with the same port for the same environment.
+    console.log(DEFAULT_SERVER_PORT);
     return;
   }
 

--- a/bin/md-redline
+++ b/bin/md-redline
@@ -171,12 +171,23 @@ function spawnDetached(command, args, options = {}) {
   });
 }
 
+// Named once each, then referenced through these constants everywhere below.
+// Each name appears in two unrelated syntaxes: an env key Node sets, and a %VAR%
+// placeholder inside a string cmd.exe expands. A rename that updates one syntax
+// but not the other spawns `start "" ""`, which silently opens Explorer instead
+// of the browser. Sourcing both spellings from one identifier makes that
+// mismatch unreachable, which matters because no test can catch it: a faithful
+// ComSpec stub is impossible (Node refuses to spawn .cmd/.bat without a shell,
+// and only real cmd.exe expands %VAR%), so the only check is a human on Windows.
+const BROWSER_COMMAND_VAR = 'MD_REDLINE_INTERNAL_BROWSER_COMMAND';
+const BROWSER_URL_VAR = 'MD_REDLINE_INTERNAL_BROWSER_URL';
+
 function spawnWindowsBrowser(command, url, { shellCommand = false } = {}) {
   return new Promise((resolveSpawn, rejectSpawn) => {
     const env = {
       ...process.env,
-      MDR_INTERNAL_BROWSER_COMMAND: command,
-      MDR_INTERNAL_BROWSER_URL: url,
+      [BROWSER_COMMAND_VAR]: command,
+      [BROWSER_URL_VAR]: url,
     };
     const child = shellCommand
       ? spawn(process.env.ComSpec ?? 'cmd.exe', [
@@ -188,7 +199,7 @@ function spawnWindowsBrowser(command, url, { shellCommand = false } = {}) {
           // with windowsVerbatimArguments so Node does not backslash-escape the
           // inner quotes (\") — cmd reads those literally and the command name
           // becomes unrecognized.
-          '""%MDR_INTERNAL_BROWSER_COMMAND%" "%MDR_INTERNAL_BROWSER_URL%""',
+          `""%${BROWSER_COMMAND_VAR}%" "%${BROWSER_URL_VAR}%""`,
         ], {
           cwd: APP_DIR,
           detached: true,
@@ -224,12 +235,12 @@ function openWithWindowsShell(url) {
       '/d',
       '/s',
       '/c',
-      '"start "" "%MDR_INTERNAL_BROWSER_URL%""',
+      `"start "" "%${BROWSER_URL_VAR}%""`,
     ], {
       cwd: APP_DIR,
       detached: true,
       stdio: 'ignore',
-      env: { ...process.env, MDR_INTERNAL_BROWSER_URL: url },
+      env: { ...process.env, [BROWSER_URL_VAR]: url },
       windowsHide: true,
       windowsVerbatimArguments: true,
     });
@@ -412,10 +423,21 @@ async function buildUrl(file, dir) {
 }
 
 async function openInBrowser(url) {
-  // MDR_BROWSER overrides the launcher with an explicit command that receives
-  // the URL as its argument (e.g. a specific browser binary). Spawned detached
-  // so it survives this process exiting, same as the platform defaults below.
-  const override = process.env.MDR_BROWSER?.trim();
+  // MD_REDLINE_BROWSER overrides the launcher with an explicit command that
+  // receives the URL as its argument (e.g. a specific browser binary). Spawned
+  // detached so it survives this process exiting, same as the platform defaults
+  // below.
+  //
+  // MDR_BROWSER is the original name, kept as a fallback because it shipped and
+  // is documented. Every other variable uses the MD_REDLINE_ prefix, so the new
+  // name is the one to reach for; this one can go at a major.
+  // First non-EMPTY wins, not first non-undefined: `??` alone would let
+  // MD_REDLINE_BROWSER="" discard a working MDR_BROWSER and fall through to the OS
+  // default. ports.js documents why blank has to count as unset everywhere.
+  const override =
+    [process.env.MD_REDLINE_BROWSER, process.env.MDR_BROWSER]
+      .map((v) => v?.trim())
+      .find((v) => v) ?? '';
   if (override) {
     if (process.platform === 'win32') {
       const needsShell = /\.(?:cmd|bat)$/i.test(override);
@@ -697,7 +719,7 @@ async function main() {
     // Internal, undocumented seam: launch the browser for a URL and exit
     // immediately, without booting a server. Lets the browser-open regression
     // test drive openInBrowser() in isolation — the worst case for the Windows
-    // detached-teardown race — and honors MDR_BROWSER like every other path.
+    // detached-teardown race — and honors MD_REDLINE_BROWSER like every other path.
     const target = process.argv[3];
     if (target) await openInBrowser(target);
     return;

--- a/bin/open-launch-cli.test.ts
+++ b/bin/open-launch-cli.test.ts
@@ -1,21 +1,36 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawn } from 'child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { delimiter, join } from 'path';
 
 import { createBrowserStub } from './cli-browser-stub.js';
 
 // Regression test for the browser launcher. The CLI's internal `__open <url>`
 // seam runs openInBrowser() and exits immediately — the exact shape of the bug
 // where, on Windows, `cmd /c start` was torn down before it could launch the
-// browser because the CLI unref'd and exited within milliseconds. MDR_BROWSER
-// points the launcher at a stub that records that it ran; if the launcher does
+// browser because the CLI unref'd and exited within milliseconds.
+// MD_REDLINE_BROWSER points the launcher at a stub that records that it ran; if the launcher does
 // not survive the CLI exiting (the pre-fix behavior) the marker never appears
 // and this fails. Deterministic and headless on every OS, so it guards the
 // spawn path in CI without needing a real browser or a desktop session.
 
 const BIN = join(__dirname, 'md-redline');
+
+// Both browser variables blanked, then whatever the test sets on top. Spreading
+// process.env raw means a contributor who exports MD_REDLINE_BROWSER (the
+// README's own example) either fails these tests or, worse, has npm test spawn
+// their real browser. Empty string rather than delete, because the launcher takes
+// the first NON-EMPTY value, so blank reads as unset while ALSO keeping the
+// legacy-name test honest: under the old `??` resolution an empty new name
+// discarded a working legacy one, and blanking is what makes that go red.
+//
+// The cost is that both keys are always DEFINED here, so no test using cleanEnv()
+// alone exercises a genuinely unset variable. The last test in this file deletes
+// them for exactly that reason; do not fold it back into cleanEnv().
+function cleanEnv(overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv {
+  return { ...process.env, MD_REDLINE_BROWSER: '', MDR_BROWSER: '', ...overrides };
+}
 
 function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<number | null> {
   return new Promise((resolvePromise, reject) => {
@@ -32,6 +47,17 @@ async function waitForFile(path: string, timeoutMs: number): Promise<boolean> {
     await new Promise((r) => setTimeout(r, 50));
   }
   return existsSync(path);
+}
+
+// Shadows the platform's own opener on PATH so the no-override default path can
+// be driven without launching a real browser. Windows is deliberately not
+// supported: its default path is `cmd /c start` through ComSpec, which never
+// consults PATH, so that one branch stays verifiable only by hand on a real
+// desktop session.
+function createPathShadowStub(dir: string, markerPath: string): void {
+  const stub = join(dir, process.platform === 'darwin' ? 'open' : 'xdg-open');
+  writeFileSync(stub, `#!/bin/sh\nprintf %s "$1" > "${markerPath}"\n`);
+  chmodSync(stub, 0o755);
 }
 
 describe('mdr browser launcher (subprocess)', () => {
@@ -56,10 +82,7 @@ describe('mdr browser launcher (subprocess)', () => {
     const stub = createBrowserStub(dir, marker);
 
     const url = 'http://127.0.0.1:65535/probe?file=C%3A%5CUsers%5Cme%5Cspec.md';
-    const code = await runCli(['__open', url], {
-      ...process.env,
-      MDR_BROWSER: stub,
-    });
+    const code = await runCli(['__open', url], cleanEnv({ MD_REDLINE_BROWSER: stub }));
     expect(code).toBe(0);
 
     // The launcher is detached, so it writes the marker shortly AFTER the CLI
@@ -69,4 +92,89 @@ describe('mdr browser launcher (subprocess)', () => {
     expect(launched, 'browser stub never ran: the launcher did not survive CLI exit').toBe(true);
     expect(readFileSync(marker, 'utf8')).toBe(url);
   }, 15_000);
+
+  // MDR_BROWSER is the original name. It shipped and is documented, so it stays
+  // supported even though every other variable uses the MD_REDLINE_ prefix.
+  it('still honours the legacy MDR_BROWSER name', async () => {
+    const dir = freshTempDir();
+    const marker = join(dir, 'launched.txt');
+    const stub = createBrowserStub(dir, marker);
+
+    const url = 'http://127.0.0.1:65535/legacy';
+    const code = await runCli(['__open', url], cleanEnv({ MDR_BROWSER: stub }));
+    expect(code).toBe(0);
+    expect(await waitForFile(marker, 5000)).toBe(true);
+    expect(readFileSync(marker, 'utf8')).toBe(url);
+  }, 15_000);
+
+  // An empty or whitespace-only new name must not mask a working old one: `??`
+  // alone falls through on undefined and hands the empty string to the launcher.
+  it.each(['', '   '])(
+    'an empty MD_REDLINE_BROWSER (%j) falls back to MDR_BROWSER',
+    async (blank) => {
+      const dir = freshTempDir();
+      const marker = join(dir, 'launched.txt');
+      const stub = createBrowserStub(dir, marker);
+
+      const url = 'http://127.0.0.1:65535/blank';
+      const code = await runCli(
+        ['__open', url],
+        cleanEnv({ MD_REDLINE_BROWSER: blank, MDR_BROWSER: stub }),
+      );
+      expect(code).toBe(0);
+      expect(await waitForFile(marker, 5000)).toBe(true);
+      expect(readFileSync(marker, 'utf8')).toBe(url);
+    },
+    15_000,
+  );
+
+  // If both are set the new name wins, so a stale MDR_BROWSER in a shell profile
+  // cannot quietly override a deliberate MD_REDLINE_BROWSER.
+  it('prefers MD_REDLINE_BROWSER when both are set', async () => {
+    // Separate dirs: createBrowserStub writes a fixed filename, so two stubs in
+    // one dir would overwrite each other and both vars would point at the same
+    // script.
+    const wantedDir = freshTempDir();
+    const legacyDir = freshTempDir();
+    const wanted = join(wantedDir, 'wanted.txt');
+    const legacy = join(legacyDir, 'legacy.txt');
+    const wantedStub = createBrowserStub(wantedDir, wanted);
+    const legacyStub = createBrowserStub(legacyDir, legacy);
+
+    const url = 'http://127.0.0.1:65535/both';
+    const code = await runCli(
+      ['__open', url],
+      cleanEnv({ MD_REDLINE_BROWSER: wantedStub, MDR_BROWSER: legacyStub }),
+    );
+    expect(code).toBe(0);
+    expect(await waitForFile(wanted, 5000)).toBe(true);
+    expect(existsSync(legacy)).toBe(false);
+  }, 15_000);
+
+  // Neither variable set is the ordinary case, and it was the one case nothing
+  // covered. cleanEnv() defines both keys as empty strings, so a launcher that
+  // lost its optional chain (`v.trim()` for `v?.trim()`) threw a TypeError for
+  // every user who has set no browser at all while this suite stayed fully green.
+  // Deleting the keys instead of blanking them is the entire point here, and it
+  // covers the platform default branch as a bonus.
+  it.skipIf(process.platform === 'win32')(
+    'falls through to the platform opener when neither variable is set',
+    async () => {
+      const dir = freshTempDir();
+      const marker = join(dir, 'opened.txt');
+      createPathShadowStub(dir, marker);
+
+      const env = cleanEnv();
+      delete env.MD_REDLINE_BROWSER;
+      delete env.MDR_BROWSER;
+      env.PATH = `${dir}${delimiter}${process.env.PATH ?? ''}`;
+
+      const url = 'http://127.0.0.1:65535/default-path';
+      const code = await runCli(['__open', url], env);
+      expect(code).toBe(0);
+      expect(await waitForFile(marker, 5000)).toBe(true);
+      expect(readFileSync(marker, 'utf8')).toBe(url);
+    },
+    15_000,
+  );
 });

--- a/bin/open-launch-cli.test.ts
+++ b/bin/open-launch-cli.test.ts
@@ -178,3 +178,42 @@ describe('mdr browser launcher (subprocess)', () => {
     15_000,
   );
 });
+
+// The CLI is the third reader of the API port, and the one no unit test can reach:
+// the value seeds the fallback scan inside findServerPort, so it is invisible from
+// outside unless the CLI is asked. Without this, re-inlining an expression here
+// leaves the whole suite green while a documented `PORT=7100` sends the CLI
+// scanning from 6373 and the server binds 7100. The expected values come from
+// server/env.test.ts's table, which is the same function.
+describe('mdr resolves the API port the same way the server does', () => {
+  function runCliCapturingStdout(args: string[], env: NodeJS.ProcessEnv): Promise<string> {
+    return new Promise((resolvePromise, reject) => {
+      const child = spawn(process.execPath, [BIN, ...args], {
+        env,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+      let out = '';
+      child.stdout.on('data', (chunk) => {
+        out += String(chunk);
+      });
+      child.once('error', reject);
+      child.once('exit', () => resolvePromise(out.trim()));
+    });
+  }
+
+  it.each([
+    ['the prefixed name', { MD_REDLINE_PORT: '7100' }, '7100'],
+    ['the documented bare alias', { PORT: '7100' }, '7100'],
+    ['the prefixed name winning over the alias', { MD_REDLINE_PORT: '7100', PORT: '7200' }, '7100'],
+    ['a blank prefixed name deferring to the alias', { MD_REDLINE_PORT: '', PORT: '7100' }, '7100'],
+    ['a malformed value, not truncated to 7100', { MD_REDLINE_PORT: '7100nonsense' }, '6373'],
+    ['neither set', {}, '6373'],
+  ])(
+    'honours %s',
+    async (_label, overrides, expected) => {
+      const env = cleanEnv({ MD_REDLINE_PORT: '', PORT: '', ...overrides });
+      expect(await runCliCapturingStdout(['__port'], env)).toBe(expected);
+    },
+    15_000,
+  );
+});

--- a/bin/ports.d.ts
+++ b/bin/ports.d.ts
@@ -1,0 +1,7 @@
+export const FALLBACK_PORT: number;
+export function resolvePort(
+  env: Record<string, string | undefined>,
+  names: readonly string[],
+  fallback: number,
+): number;
+export function resolveApiPort(env?: Record<string, string | undefined>): number;

--- a/bin/ports.js
+++ b/bin/ports.js
@@ -1,0 +1,68 @@
+/**
+ * Port resolution, done once for every reader.
+ *
+ * This lives in `bin/` rather than `server/` for a packaging reason: `files` in
+ * package.json ships `bin/` and `dist/`, and the CLI needs this at runtime from an
+ * npm install. The server gets it bundled into `dist/server.js` by esbuild, and
+ * `vite.config.ts` imports it through `server/env.ts` to aim its dev proxy.
+ *
+ * It is plain JavaScript so `bin/md-redline` can import it directly, with types in
+ * the hand-written `bin/ports.d.ts` sibling rather than a compiler flag: that is how
+ * `bin/version-compare.js` is already shared between this CLI and
+ * `server/update-check.ts`. The CLI is dependency-free with no build step of its
+ * own, so a TypeScript module would have to be hand-copied into it, and a hand-copy
+ * is what this file exists to delete. The three readers used to disagree for real:
+ * `PORT=7100`, an alias the README documents, bound the server and aimed the dev
+ * proxy at 7100 while the CLI scanned from 6373, because the CLI's copy read only
+ * the prefixed name.
+ */
+
+/** 6373 spells "MDR" on a phone keypad, clear of the 3000-3010 range Next/Nest/CRA contend for. */
+export const FALLBACK_PORT = 6373;
+
+/**
+ * First non-EMPTY candidate wins, and it has to be a port a server could bind.
+ *
+ * Blank counts as unset. A plain `??` keeps an empty string, which is how
+ * `MD_REDLINE_PORT=""` used to beat a working `PORT` and reach
+ * `Number.parseInt('')`. The resulting NaN was not just a wrong port: the server's
+ * scan loop runs while `p < DEFAULT_PORT + MAX_PORT_ATTEMPTS`, false on the first
+ * comparison, so it tried no port at all and died with "No available port found
+ * (tried NaN-NaN)" while ignoring the port the user had set. An empty value is
+ * easy to produce by accident: `export MD_REDLINE_PORT="$SOME_UNSET_VAR"` in a
+ * profile, or a blank entry in a CI env block.
+ *
+ * A non-empty value that is not a usable port warns and defers to the next
+ * candidate rather than throwing. The server reads this while its module is still
+ * evaluating, before the startup chain that renders errors as one readable line,
+ * and a typo in a port should not brick a local tool.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @param {readonly string[]} names Candidates in priority order.
+ * @param {number} fallback Used when no candidate holds a usable port.
+ * @returns {number} A port between 1 and 65535.
+ */
+export function resolvePort(env, names, fallback) {
+  for (const name of names) {
+    const raw = env[name];
+    const value = raw?.trim();
+    if (!value) continue;
+    // Number, not parseInt: parseInt('7100nonsense') is 7100, which would start
+    // the server somewhere the user never asked for.
+    const port = Number(value);
+    if (Number.isInteger(port) && port >= 1 && port <= 65535) return port;
+    console.warn(`[md-redline] ${name}="${raw}" is not a valid port number; ignoring it.`);
+  }
+  return fallback;
+}
+
+/**
+ * The API server's port. `PORT` is a documented alias for `MD_REDLINE_PORT`, kept
+ * because it shipped; the prefixed name wins.
+ *
+ * @param {Record<string, string | undefined>} [env] Defaults to `process.env`.
+ * @returns {number} A port between 1 and 65535.
+ */
+export function resolveApiPort(env = process.env) {
+  return resolvePort(env, ['MD_REDLINE_PORT', 'PORT'], FALLBACK_PORT);
+}

--- a/bin/update-notice-cli.test.ts
+++ b/bin/update-notice-cli.test.ts
@@ -105,6 +105,10 @@ function closeStub(server: Server): Promise<void> {
 function buildEnv(stubPort: number, isolatedTmp: string, browserStub: string): NodeJS.ProcessEnv {
   return {
     ...process.env,
+    // Blank the legacy browser name: the launcher takes the first non-empty of
+    // MD_REDLINE_BROWSER then MDR_BROWSER, so an ambient MDR_BROWSER on a
+    // contributor's machine would otherwise be reachable from these tests.
+    MDR_BROWSER: '',
     // Isolates the port file the CLI reads/writes under tmpdir() so this run
     // never sees (or clobbers) a real md-redline.port from the dev box. TMPDIR
     // covers macOS/Linux; TEMP/TMP cover Windows, whose os.tmpdir() ignores it.
@@ -116,7 +120,7 @@ function buildEnv(stubPort: number, isolatedTmp: string, browserStub: string): N
     // No-op the browser launcher so the run never opens a real browser. Works
     // on every OS, unlike shadowing `open` on PATH (Windows launches via
     // `cmd /c start`, which PATH cannot intercept).
-    MDR_BROWSER: browserStub,
+    MD_REDLINE_BROWSER: browserStub,
   };
 }
 

--- a/scripts/simulate-agent-ask.ts
+++ b/scripts/simulate-agent-ask.ts
@@ -14,7 +14,7 @@
  */
 import { execSync } from 'child_process';
 
-const baseUrl = process.env.MDR_BASE_URL ?? 'http://localhost:5188';
+const baseUrl = process.env.MD_REDLINE_BASE_URL ?? 'http://localhost:5188';
 
 async function main() {
   const [filePath, anchor, text] = process.argv.slice(2);

--- a/scripts/simulate-agent-review.ts
+++ b/scripts/simulate-agent-review.ts
@@ -48,7 +48,7 @@ function parseArgs(argv: string[]): Options {
     files: [],
     mode: 'fire-and-forget',
     count: 3,
-    server: process.env.MDR_BASE_URL ?? 'http://localhost:5188',
+    server: process.env.MD_REDLINE_BASE_URL ?? 'http://localhost:5188',
     open: false,
   };
 
@@ -115,7 +115,7 @@ Options:
   --mode <mode>          fire-and-forget | wait | release  (default: fire-and-forget)
   --count <n>            Number of synthetic comments to generate (default: 3).
   --server <url>         mdr server base URL (default: http://localhost:5188).
-                         Also reads MDR_BASE_URL env var.
+                         Also reads MD_REDLINE_BASE_URL env var.
   --open                 Open the session URL in the system browser.
   --help, -h             Show this message.
 

--- a/server/env.test.ts
+++ b/server/env.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { homedir } from 'os';
+
+import {
+  FALLBACK_PORT,
+  FALLBACK_VITE_PORT,
+  resolveApiPort,
+  resolveHomeDir,
+  resolveVitePort,
+} from './env';
+
+describe('resolveApiPort', () => {
+  // The prefixed name and the bare alias are both documented in the README's
+  // config table, so this table is the contract for which one wins and for what
+  // counts as "set".
+  it.each([
+    ['neither set', {}, FALLBACK_PORT],
+    ['prefixed name only', { MD_REDLINE_PORT: '7100' }, 7100],
+    ['bare alias only', { PORT: '7100' }, 7100],
+    ['both set, prefixed wins', { MD_REDLINE_PORT: '7100', PORT: '7200' }, 7100],
+    ['surrounding whitespace tolerated', { MD_REDLINE_PORT: ' 7100 ' }, 7100],
+  ])('%s', (_label, env, expected) => {
+    expect(resolveApiPort(env)).toBe(expected);
+  });
+
+  // The regression this function exists for. An empty prefixed name used to beat
+  // a working alias and then parse to NaN, and because findAvailablePort loops
+  // while `p < DEFAULT_PORT + MAX_PORT_ATTEMPTS`, NaN meant it tried no port at
+  // all: startup died with "No available port found (tried NaN-NaN)" instead of
+  // listening on the port the user had set.
+  it.each(['', '   '])('an empty MD_REDLINE_PORT (%j) defers to PORT', (blank) => {
+    expect(resolveApiPort({ MD_REDLINE_PORT: blank, PORT: '7100' })).toBe(7100);
+  });
+
+  it('an empty MD_REDLINE_PORT with no alias falls back rather than becoming NaN', () => {
+    expect(resolveApiPort({ MD_REDLINE_PORT: '' })).toBe(FALLBACK_PORT);
+  });
+
+  // Warn and defer rather than throw: this runs during module evaluation, before
+  // the startup chain that turns errors into a readable one-line message.
+  it.each([
+    ['not a number', 'nonsense'],
+    ['trailing garbage, not silently truncated', '7100nonsense'],
+    ['zero', '0'],
+    ['negative', '-1'],
+    ['above the port range', '65536'],
+    ['fractional', '7100.5'],
+  ])('rejects %s and warns', (_label, value) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(resolveApiPort({ MD_REDLINE_PORT: value })).toBe(FALLBACK_PORT);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toContain('MD_REDLINE_PORT');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('defers from an invalid prefixed name to a valid alias', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(resolveApiPort({ MD_REDLINE_PORT: 'nonsense', PORT: '7100' })).toBe(7100);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+describe('resolveVitePort', () => {
+  it.each([
+    ['unset', {}, FALLBACK_VITE_PORT],
+    ['set', { MD_REDLINE_VITE_PORT: '5300' }, 5300],
+    ['blank', { MD_REDLINE_VITE_PORT: '' }, FALLBACK_VITE_PORT],
+    ['whitespace only', { MD_REDLINE_VITE_PORT: '   ' }, FALLBACK_VITE_PORT],
+  ])('%s', (_label, env, expected) => {
+    expect(resolveVitePort(env)).toBe(expected);
+  });
+
+  // Blank here used to reach Vite as `server.port: NaN`, which fails the dev
+  // server outright with ERR_SOCKET_BAD_PORT rather than degrading to a default.
+  it('rejects a malformed value and warns rather than yielding NaN', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(resolveVitePort({ MD_REDLINE_VITE_PORT: 'nonsense' })).toBe(FALLBACK_VITE_PORT);
+      expect(warn.mock.calls[0][0]).toContain('MD_REDLINE_VITE_PORT');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  // MD_REDLINE_PORT is the API server's variable. Reading it here would point the
+  // dev client at the API port.
+  it('ignores the API port variables', () => {
+    expect(resolveVitePort({ MD_REDLINE_PORT: '7100', PORT: '7200' })).toBe(FALLBACK_VITE_PORT);
+  });
+});
+
+describe('resolveHomeDir', () => {
+  // Blank is the case that matters. A plain `?? homedir()` kept the empty string,
+  // and an empty base directory sends `.md-redline.json` to the current working
+  // directory, so trusted roots and the update cache are written wherever the
+  // user launched from and quietly fail to persist.
+  it.each([
+    ['unset', {}],
+    ['empty', { MD_REDLINE_HOME: '' }],
+    ['whitespace only', { MD_REDLINE_HOME: '   ' }],
+  ])('falls back to the OS home directory when %s', (_label, env) => {
+    expect(resolveHomeDir(env)).toBe(homedir());
+  });
+
+  it('uses an explicit value', () => {
+    expect(resolveHomeDir({ MD_REDLINE_HOME: '/tmp/mdr-home' })).toBe('/tmp/mdr-home');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(resolveHomeDir({ MD_REDLINE_HOME: '  /tmp/mdr-home  ' })).toBe('/tmp/mdr-home');
+  });
+});
+
+// The claim this module exists for, asserted against the real Vite config instead
+// of by calling one function twice. Importing vite.config.ts fresh under a stubbed
+// environment is the only way to observe the value it computes at module scope, and
+// the hazard is concrete: while each reader had its own inline copy, a documented
+// PORT=7100 bound the server and aimed this proxy at 7100 while the CLI scanned
+// from 6373. Re-inline that expression in vite.config.ts and this goes red.
+describe('vite.config.ts aims its dev proxy at the port the server binds', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it.each([
+    { MD_REDLINE_PORT: '', PORT: '7100' },
+    { MD_REDLINE_PORT: '7100nonsense' },
+    { MD_REDLINE_PORT: '5300' },
+    {},
+  ])('agrees for %j', async (env) => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      vi.stubEnv('MD_REDLINE_PORT', env.MD_REDLINE_PORT ?? '');
+      vi.stubEnv('PORT', env.PORT ?? '');
+      vi.resetModules();
+      const config = (await import('../vite.config')).default as {
+        server: { proxy: Record<string, string> };
+      };
+      expect(config.server.proxy['/api']).toBe(`http://127.0.0.1:${resolveApiPort(env)}`);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,0 +1,35 @@
+import { homedir } from 'os';
+
+/**
+ * Server-side environment resolution. The port resolvers live in `bin/ports.js`,
+ * which explains why they are plain JavaScript and why every reader has to share
+ * them; they are re-exported here so server code has one import. Anything
+ * server-only stays in this file.
+ */
+
+export { FALLBACK_PORT, resolveApiPort } from '../bin/ports.js';
+import { resolvePort } from '../bin/ports.js';
+
+export const FALLBACK_VITE_PORT = 5188;
+
+/** Port for the Vite dev client. No alias: this one only ever had the prefixed name. */
+export function resolveVitePort(env: NodeJS.ProcessEnv = process.env): number {
+  return resolvePort(env, ['MD_REDLINE_VITE_PORT'], FALLBACK_VITE_PORT);
+}
+
+/**
+ * Resolves the base directory for md-redline's preferences file.
+ *
+ * Blank counts as unset here too. A plain `?? homedir()` kept an empty string,
+ * and an empty base directory is not an obvious failure: `.md-redline.json` then
+ * resolves against the current working directory, so trusted roots and the
+ * update-check cache get written wherever the user happened to launch from and
+ * silently fail to persist across launches.
+ *
+ * Both `server/index.ts` and `server/update-check.ts` read this independently.
+ * The update checker is constructed without a `homeDir` option, so its own read
+ * is live in production rather than a test-only fallback.
+ */
+export function resolveHomeDir(env: NodeJS.ProcessEnv = process.env): string {
+  return env.MD_REDLINE_HOME?.trim() || homedir();
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -7,7 +7,7 @@ import { promises as fsPromises } from 'fs';
 import { randomBytes } from 'crypto';
 import { watch, statSync, realpathSync, readFileSync, unlinkSync, type FSWatcher } from 'fs';
 import { join, extname, resolve, dirname } from 'path';
-import { homedir, platform, tmpdir } from 'os';
+import { platform, tmpdir } from 'os';
 import { execFile } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { createRequire } from 'module';
@@ -21,6 +21,7 @@ import { injectSvgDimensions } from './svg-dimensions';
 import { ReviewSessionStore, type PendingAsk } from './review-sessions';
 import { deliverInlineAskReplies, registerReviewSessionRoutes } from './routes/review-sessions';
 import { parseComments, removeComment, transformCommentMarkers } from '../src/lib/comment-parser';
+import { resolveApiPort, resolveHomeDir, resolveVitePort } from './env';
 import { createUpdateChecker, isUpdateCheckDisabled } from './update-check';
 
 const require = createRequire(import.meta.url);
@@ -186,7 +187,7 @@ const MAX_FILE_BYTES = 25 * 1024 * 1024;
 
 export function createAppFull(options: CreateAppOptions = {}) {
   const cwd = options.cwd ? resolve(options.cwd) : process.cwd();
-  const homeDir = options.homeDir ?? process.env.MD_REDLINE_HOME ?? homedir();
+  const homeDir = options.homeDir ?? resolveHomeDir();
   const initialArgRaw = options.initialArg ?? process.argv[2] ?? '';
   const initialArg = initialArgRaw ? resolve(cwd, initialArgRaw) : '';
   const platformName = options.platformName ?? platform();
@@ -207,7 +208,7 @@ export function createAppFull(options: CreateAppOptions = {}) {
 
   const app = new Hono();
   // Allow CORS only from Vite dev server ports (default 5188-5197, or custom via env)
-  const viteBasePort = Number.parseInt(process.env.MD_REDLINE_VITE_PORT ?? '5188', 10);
+  const viteBasePort = resolveVitePort();
   const allowedPorts = new Set<number>();
   for (let p = viteBasePort; p < viteBasePort + 10; p++) allowedPorts.add(p);
   // Also allow the default range if a custom port is configured
@@ -1533,10 +1534,7 @@ export const app = createApp({
   isUpdateCheckPending: updatesEnabled ? updateChecker.isPending : undefined,
 });
 
-// 6373 ("MDR" on a phone keypad) stays clear of the 3000-3010 range that
-// Next.js/Nest/CRA stacks contend for. Must match DEFAULT_SERVER_PORT in
-// bin/md-redline, which scans this range to find us.
-const DEFAULT_PORT = Number.parseInt(process.env.MD_REDLINE_PORT ?? process.env.PORT ?? '6373', 10);
+const DEFAULT_PORT = resolveApiPort();
 const MAX_PORT_ATTEMPTS = 10;
 const PORT_FILE = join(tmpdir(), 'md-redline.port');
 

--- a/server/update-check.ts
+++ b/server/update-check.ts
@@ -1,4 +1,4 @@
-import { homedir } from 'os';
+import { resolveHomeDir } from './env';
 import { isNewerVersion } from '../bin/version-compare.js';
 import { readPreferences, writePreferences } from './preferences';
 
@@ -33,7 +33,7 @@ export function isUpdateCheckDisabled(env: NodeJS.ProcessEnv = process.env): boo
 }
 
 export function createUpdateChecker(options: UpdateCheckerOptions): UpdateChecker {
-  const homeDir = options.homeDir ?? process.env.MD_REDLINE_HOME ?? homedir();
+  const homeDir = options.homeDir ?? resolveHomeDir();
   const registryUrl = (
     options.registryUrl ??
     process.env.MD_REDLINE_REGISTRY_URL ??

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,14 @@ import react from '@vitejs/plugin-react';
 import tailwindcss from '@tailwindcss/vite';
 import type { HmrContext, Plugin, ViteDevServer } from 'vite';
 
-const serverPort = Number.parseInt(process.env.MD_REDLINE_VITE_PORT ?? '5188', 10);
-const apiPort = Number.parseInt(process.env.MD_REDLINE_PORT ?? process.env.PORT ?? '6373', 10);
+import { resolveApiPort, resolveVitePort } from './server/env';
+
+// Shared with the server and the CLI on purpose. While each side computed the port
+// from its own inline copy, a documented `PORT=7100` bound the server and aimed
+// this proxy at 7100 while the CLI scanned from 6373. server/env.test.ts asserts
+// this proxy target against the port the server resolves.
+const serverPort = resolveVitePort();
+const apiPort = resolveApiPort();
 
 export function ignoreMarkdownHotUpdatePlugin(): Plugin {
   return {


### PR DESCRIPTION
## Why

Three bugs, all the same shape: a blank environment variable was treated as set rather than unset. A blank value is easy to produce by accident, e.g. `export MD_REDLINE_PORT="$SOME_UNSET_VAR"` in a shell profile, or a blank entry in a CI env block.

- **`MD_REDLINE_PORT=""` aborted startup.** It beat a working `PORT` and reached `Number.parseInt('')`. The resulting NaN was not merely a wrong port: `findAvailablePort` loops while `p < DEFAULT_PORT + MAX_PORT_ATTEMPTS`, which is false on the very first comparison, so the server tried no port at all and died with `No available port found (tried NaN-NaN)` while ignoring the port that was actually set. The same blank killed `npm run dev` with `ERR_SOCKET_BAD_PORT`.
- **`MD_REDLINE_HOME=""` silently misplaced preferences.** It resolved `.md-redline.json` against the current working directory, so trusted roots and the update-check cache were written wherever the user happened to launch from and never persisted across launches. Two independent call sites, both live in production: the update checker is constructed with no `homeDir` option, so its own read is not a test-only fallback.
- **The CLI ignored `PORT`,** although the README documents it as an alias. `PORT=7100` bound the server and aimed the Vite dev proxy at 7100 while the CLI scanned from 6373, so the CLI could find the server through the port file or not at all.

## What changed

Port and home resolution happens once, in `bin/ports.js`, imported by `bin/md-redline`, re-exported by `server/env.ts` and reached by `vite.config.ts`. Three readers, one function, so the disagreement is unreachable rather than merely fixed.

It is plain JavaScript because `bin/md-redline` is a dependency-free CLI with no build step of its own, and `bin/` is what package.json `files` ships beside `dist/`. Types come from a hand-written `bin/ports.d.ts`, which is the same arrangement `bin/version-compare.js` has already used to be shared between the CLI and `server/update-check.ts`.

A malformed value warns and defers to the next candidate instead of throwing, because this runs while the module is still evaluating, before the startup chain that renders errors as one readable line, and a mistyped port should not brick a local tool. `Number` rather than `parseInt`, so `7100nonsense` is rejected instead of silently becoming 7100.

## Naming

`MDR_BROWSER` becomes `MD_REDLINE_BROWSER` and `MDR_BASE_URL` becomes `MD_REDLINE_BASE_URL`. `MDR_BROWSER` shipped and is documented, so it stays as a fallback until a major; `MDR_BASE_URL` was read only by two dev scripts and never documented, so both call sites moved together with no fallback.

Also renames the two internal variables the Windows launcher passes through `cmd.exe`, and collapses each to a single named constant. Each name previously appeared twice, once as an env key and once as a `%VAR%` placeholder inside a command string, so a rename touching one spelling and not the other would have degraded silently to `start "" ""`, which opens Explorer. No test can catch that (Node refuses to spawn a `.cmd` stub without a shell, and only real `cmd.exe` expands `%VAR%`), so the second spelling is gone instead.

## Docs

`CONTRIBUTING.md` is new and deliberately covers only what the code and CI config do not state: that formatting gates everything else, that `bin/md-redline` is extensionless and so escapes the format globs, that a stale `dist/` makes the MCP stdio tests skip rather than fail so a green summary can hide them, that root `tsc --noEmit` verifies nothing, and that formatting before a rebase collapses the whitespace conflicts. It points at `ci.yml` rather than reproducing its steps.

The README's proxy section is **prose-only**: every security caveat stays in plain sight and only the implementation reference moves behind a `<details>` block (the endpoint list, the nginx Host-header behaviour, the SSE buffering note). No endpoint was dropped, and the guard that stops a client writing `trustedRoots` through `PUT /api/preferences` is untouched.

## Verification

- `format:check`, `lint`, `tsc -b` and `build` clean
- 1692 unit tests across 85 files
- Full e2e suite: 331 passed
- Installed the packed tarball into a clean directory and ran the real CLI from it, confirming `bin/ports.js` resolves post-install, the `PORT` alias is honoured and a malformed value warns
- Each of the four commits type-checks and passes its own unit suite independently
- Every new test was mutation-tested. Re-inlining the port expression in `vite.config.ts` turns 3 of the 4 agreement cases red, and the `mdr __port` cases go red on exactly the three inputs the old expression got wrong

Filed #36 separately for an unrelated precedence bug found along the way: `--stop` consults the port file before the explicitly requested port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014bjgyjihtatrm1oBqDgyAp