### PR TITLE
docs: put the container-rewrite trigger where the next editor will stand

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,13 @@ highlighting, orphan detection, and agent handoff are unaffected.
 | YAML/TOML frontmatter (offset 0 only) | After the closing fence, own line | It can't go before, and a comment body containing `: ` breaks the YAML parse |
 | HTML comment | Before the block; own line only when the comment owns its line | Nested comments don't exist: the first `-->` closes the outer one and the rest becomes visible text |
 
+The ranges are computed with regexes, and each container's scan excludes the
+others (a fence line inside frontmatter is YAML, a `<!--` inside a fence is
+sample text). Do not add a fifth exclusion: four rounds of that have already
+happened and the fourth cost a silently lost comment. #30 replaces the
+computation with ranges derived from the parse, and the next container bug to
+land here is the trigger to do it.
+
 ## API endpoints
 
 **Files**

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -633,6 +633,12 @@ export function insertComment(
   // relocate it to the nearest legal position outside the container. The
   // anchor is unaffected: it stays the real text, so highlighting, orphan
   // detection, and agent handoff all keep working.
+  //
+  // Before adding a fifth exclusion or special case here: don't. Four rounds
+  // have now taught one of these regexes about a case another already knew,
+  // and the fourth cost a silently lost comment. #30 replaces this whole
+  // computation with ranges derived from the parse, where the two consumers
+  // cannot disagree. The next container bug that lands here is the trigger.
   let ownLine = false;
   let leadingNewline = false;
   {


### PR DESCRIPTION
One commit that was pushed to this branch after #29 merged, so it never reached `main`. Its whole purpose is to be read at the moment someone is about to make a specific mistake, and stranded on a merged branch it does the opposite.

## Why

The review pass on the protected-container work reached a design verdict it deliberately did not act on: the container ranges are computed with regexes, each container's scan excludes the others, and four rounds of fixes have now taught one of those regexes about a case another one already knew. The fourth cost a silently lost comment. The verdict is that #30 should replace the computation with ranges derived from the real parse, where the two consumers cannot disagree.

That rewrite was correctly left alone: it replaces the module the UI, the MCP routes and the CLI all sit on, and doing it inside a review pass would ship a large unreviewed change under the heading of a review.

But recording the decision in a PR description is useless. The decision arrives when someone is editing the relocation block, not when they are reading merge history, and every individual fix looks smaller than the rewrite every time. Four of them already did.

## What it does

Two notes, in the two places someone will actually be standing:

- a comment at the relocation block in `src/lib/comment-parser.ts`, for whoever is editing it
- a paragraph under Protected containers in `AGENTS.md`, which is what an agent reads before touching this code

Both point at #30 for the substance rather than restating it, and both give the same mechanical trigger: the next container bug that lands here is the trigger to do the rewrite. The trigger is deliberately mechanical precisely because the judgement call has already been made wrong four times.

Comments and docs only. No behaviour change.