### PR TITLE
fix: open a file with a full tab strip and land the tab fully in view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,11 @@ button and the rest of the toolbar controls on the same baseline. Below it, the
 per-panel toolbar (`PanelToolbar.tsx`: search, view-mode, diff controls) is a
 slimmer 2rem strip.
 
+The open-file button is sticky at the right edge of the tab strip, so it overlays
+whichever tab ends there. The strip carries a `scroll-pr-10` that must stay at or
+above that button's `w-9`, otherwise the browser parks the active tab underneath
+it when scrolling the tab into view.
+
 ### Review banner
 When a review session is active, a sticky banner appears at the top with one row
 per session:

--- a/e2e/advanced.spec.ts
+++ b/e2e/advanced.spec.ts
@@ -259,6 +259,46 @@ test.describe('Multi-tab support', () => {
     await expect(page.getByRole('heading', { name: 'Test Document' })).toBeVisible();
     await expect(page.locator('button[title="Open file"]')).toBeVisible();
   });
+
+  test('a file opened on top of a full tab strip lands fully in view', async ({ page }) => {
+    // Regression: the new tab was scrolled into view before the overflow
+    // arrows mounted and narrowed the strip, and scrollIntoView knows nothing
+    // about the open-file button pinned to the right edge. Both left the tab
+    // clipped in half.
+    await page.setViewportSize({ width: 900, height: 900 });
+    await page.goto('/');
+    await page.evaluate((tabs) => {
+      localStorage.setItem(
+        'md-redline-session',
+        JSON.stringify({ openTabs: tabs, activeFilePath: tabs[tabs.length - 1] }),
+      );
+    }, OVERFLOW_FIXTURES);
+
+    await page.goto(`/?file=${FIXTURE_1}`);
+    await expect(page.getByRole('heading', { name: 'Test Document' })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.locator('button[title="Scroll tabs right"]')).toBeVisible();
+
+    const activeTab = page.locator(`.h-11 button[title="${FIXTURE_1}"]`);
+    const openFileButton = page.locator('button[title="Open file"]');
+    const tabStrip = page.locator('.h-11 .overflow-x-auto');
+
+    // Both edges matter: clearing the sticky button is satisfied by any tab
+    // left of it, including one scrolled off the start of the strip entirely.
+    await expect
+      .poll(async () => {
+        const tab = await activeTab.boundingBox();
+        const openButton = await openFileButton.boundingBox();
+        const strip = await tabStrip.boundingBox();
+        if (!tab || !openButton || !strip) return null;
+        return {
+          clearsOpenFileButton: Math.round(openButton.x - (tab.x + tab.width)) >= 0,
+          startsInsideStrip: Math.round(tab.x - strip.x) >= 0,
+        };
+      })
+      .toEqual({ clearsOpenFileButton: true, startsInsideStrip: true });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/TabBar.test.tsx
+++ b/src/components/TabBar.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+import { TabBar } from './TabBar';
+
+// jsdom has no ResizeObserver. TabBar watches the tab strip's scrollport and
+// its content row, so every test here needs a stub. The stub models the two
+// behaviours the component depends on: observe() delivers an initial
+// observation, and disconnect() stops delivery. Without the initial delivery a
+// test cannot tell "the observer was rebuilt" from "someone fired it by hand",
+// which is exactly the distinction the cold-boot retry rests on.
+let observers: ResizeObserverStub[] = [];
+class ResizeObserverStub {
+  callback: () => void;
+  connected = true;
+  constructor(callback: () => void) {
+    this.callback = callback;
+    observers.push(this);
+  }
+  observe() {
+    if (this.connected) this.callback();
+  }
+  unobserve() {}
+  disconnect() {
+    this.connected = false;
+  }
+}
+
+/** Let the alignment effect's requestAnimationFrame run. */
+async function settle() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 40));
+  });
+}
+
+/** A resize of an already-observed element, as opposed to a fresh observe(). */
+function fireResize() {
+  act(() => {
+    for (const observer of observers) {
+      if (observer.connected) observer.callback();
+    }
+  });
+}
+
+// jsdom reports every rect as zero, so the width the component reads has to be
+// driven directly. It is set before the first render so a test can hold the
+// width CONSTANT across an observer rebuild.
+let viewportWidth = 600;
+
+const TABS = ['/docs/one.md', '/docs/two.md', '/docs/three.md'].map((filePath) => ({
+  filePath,
+  error: null,
+}));
+
+function renderTabBar(activeFilePath: string, tabs = TABS) {
+  const props = {
+    tabs,
+    activeFilePath,
+    commentCounts: new Map<string, number>(),
+    onSwitchTab: () => {},
+    onCloseTab: () => {},
+    onOpenFile: () => {},
+  };
+  const { rerender } = render(<TabBar {...props} />);
+  return {
+    setTabs: (next: typeof TABS) => act(() => rerender(<TabBar {...props} tabs={next} />)),
+  };
+}
+
+beforeEach(() => {
+  observers = [];
+  viewportWidth = 600;
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  vi.spyOn(Element.prototype, 'getBoundingClientRect').mockImplementation(
+    () =>
+      ({
+        width: viewportWidth,
+        height: 0,
+        top: 0,
+        left: 0,
+        right: viewportWidth,
+        bottom: 0,
+        x: 0,
+        y: 0,
+      }) as DOMRect,
+  );
+  // jsdom does not implement scrollIntoView; the component calls it to bring
+  // the active tab into view.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  // @ts-expect-error - test-only cleanup of the jsdom stub
+  delete Element.prototype.scrollIntoView;
+});
+
+describe('TabBar: keeping the active tab in view', () => {
+  it('re-aligns the active tab when the scrollport narrows', () => {
+    renderTabBar('/docs/two.md');
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    // The overflow arrows mount, or the explorer opens, and the strip loses
+    // width after the tab was already scrolled into place.
+    viewportWidth = 400;
+    fireResize();
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('leaves the scroll position alone when only the content grows', () => {
+    renderTabBar('/docs/two.md');
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    // The observer also watches the content row, so it fires when a comment
+    // badge appears on a tab. Re-aligning here would yank the strip back to
+    // the active tab while the user is reading another one.
+    fireResize();
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+
+  it('re-aligns once the active tab mounts, at an unchanged width', () => {
+    // Cold boot: the strip renders before the restored tabs arrive, so the
+    // first observation finds nothing to align. Two things have to hold for
+    // the tab to end up aligned anyway, and the width never changes across
+    // them, so nothing else can account for the alignment: the width must not
+    // be recorded when no alignment ran, and the observer must be rebuilt when
+    // the tabs arrive so it delivers a fresh observation.
+    const { setTabs } = renderTabBar('/docs/two.md', []);
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+
+    setTabs(TABS);
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalled();
+  });
+
+  it('leaves the strip alone when a tab opens in the background', async () => {
+    // The retry above deliberately lives in the resize effect rather than the
+    // alignment effect. Moving it to the alignment effect reads as simpler and
+    // states its trigger more directly, but that effect re-aligns
+    // unconditionally, so every background open (an agent opening a file, a
+    // review session restoring tabs) would pull the strip off whatever the
+    // user is reading.
+    const { setTabs } = renderTabBar('/docs/two.md');
+    await settle();
+    vi.mocked(Element.prototype.scrollIntoView).mockClear();
+
+    setTabs([...TABS, { filePath: '/docs/four.md', error: null }]);
+    await settle();
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -27,8 +27,11 @@ interface Props {
 const tabControlButtonClass =
   'flex h-full w-8 items-center justify-center shrink-0 border-l border-border text-content-muted transition-colors hover:bg-tint hover:text-content-secondary disabled:pointer-events-none disabled:opacity-35';
 
+// w-9 (36px) is load-bearing: it has to stay in step with the scrollport's
+// scroll-pr-10 below, which is what keeps a tab from scrolling under this
+// button.
 const tabActionButtonClass =
-  'sticky right-0 z-10 flex h-full items-center justify-center bg-surface-secondary px-2.5 shrink-0 rounded-t-md text-content-muted transition-colors hover:bg-tint hover:text-content';
+  'sticky right-0 z-10 flex h-full w-9 items-center justify-center bg-surface-secondary shrink-0 rounded-t-md text-content-muted transition-colors hover:bg-tint hover:text-content';
 
 export function TabBar({
   tabs,
@@ -45,6 +48,11 @@ export function TabBar({
   const tabsContentRef = useRef<HTMLDivElement>(null);
   const tabListRef = useRef<HTMLDivElement>(null);
   const tabButtonRefs = useRef(new Map<string, HTMLButtonElement>());
+  const viewportWidthRef = useRef(-1);
+  // Read inside scrollActiveTabIntoView so that callback keeps a stable
+  // identity and the resize observer below survives tab switches.
+  const activeFilePathRef = useRef(activeFilePath);
+  activeFilePathRef.current = activeFilePath;
   const [tabListOpen, setTabListOpen] = useState(false);
   const [isOverflowing, setIsOverflowing] = useState(false);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
@@ -58,6 +66,20 @@ export function TabBar({
     setIsOverflowing(maxScrollLeft > 1);
     setCanScrollLeft(viewport.scrollLeft > 1);
     setCanScrollRight(viewport.scrollLeft < maxScrollLeft - 1);
+  }, []);
+
+  // Bring the active tab into view. The scrollport's scroll-padding is what
+  // holds it clear of the sticky open-file button pinned to the right edge;
+  // without that padding the browser parks the tab's tail underneath it.
+  // Reports whether there was a tab to align, so a caller that tracks state
+  // across calls can tell an alignment from a no-op.
+  const scrollActiveTabIntoView = useCallback(() => {
+    const activePath = activeFilePathRef.current;
+    const tabButton = activePath ? tabButtonRefs.current.get(activePath) : null;
+    if (!tabButton) return false;
+
+    tabButton.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+    return true;
   }, []);
 
   const scrollTabsBy = useCallback((direction: 'left' | 'right') => {
@@ -81,7 +103,26 @@ export function TabBar({
     viewport.addEventListener('scroll', handleScroll, { passive: true });
 
     const resizeObserver =
-      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(() => updateTabOverflow()) : null;
+      typeof ResizeObserver !== 'undefined'
+        ? new ResizeObserver(() => {
+            // The scrollport keeps narrowing after the active tab was scrolled
+            // into view (the overflow arrows mount, the explorer opens, the
+            // window resizes), and a scroll position computed against the old
+            // width leaves the active tab clipped. Re-align on width changes
+            // only, so content growth such as a new comment badge doesn't yank
+            // the strip back while the user is looking at another tab.
+            // Fractional width, not clientWidth: a sub-pixel settle at the end
+            // of the explorer's open animation rounds to the same integer and
+            // would skip the last re-align. Record the width only once an
+            // alignment actually ran, so a resize that lands before the active
+            // tab has mounted gets another chance.
+            const width = viewport.getBoundingClientRect().width;
+            if (width !== viewportWidthRef.current && scrollActiveTabIntoView()) {
+              viewportWidthRef.current = width;
+            }
+            updateTabOverflow();
+          })
+        : null;
 
     resizeObserver?.observe(viewport);
     if (tabsContentRef.current) resizeObserver?.observe(tabsContentRef.current);
@@ -90,20 +131,25 @@ export function TabBar({
       viewport.removeEventListener('scroll', handleScroll);
       resizeObserver?.disconnect();
     };
-  }, [tabs.length, updateTabOverflow]);
+    // tabs.length is not a stale-closure leftover: rebuilding the observer
+    // re-delivers an observation once the tabs arrive, which is the other half
+    // of the retry above. The obvious simplification is to move that retry to
+    // the alignment effect below, whose stated job it already is. Don't: that
+    // effect aligns unconditionally, so every background tab open would pull
+    // the strip off whatever the user is reading. Both halves are pinned by
+    // TabBar.test.tsx.
+  }, [tabs.length, scrollActiveTabIntoView, updateTabOverflow]);
 
   useEffect(() => {
     if (!activeFilePath) return;
 
     const frame = window.requestAnimationFrame(() => {
-      tabButtonRefs.current
-        .get(activeFilePath)
-        ?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+      scrollActiveTabIntoView();
       updateTabOverflow();
     });
 
     return () => window.cancelAnimationFrame(frame);
-  }, [activeFilePath, updateTabOverflow]);
+  }, [activeFilePath, scrollActiveTabIntoView, updateTabOverflow]);
 
   useEffect(() => {
     if (!tabListOpen) return;
@@ -162,7 +208,13 @@ export function TabBar({
           </button>
         )}
 
-        <div ref={tabsViewportRef} className="min-w-0 flex-1 h-full overflow-x-auto no-scrollbar">
+        {/* scroll-pr-10 is what keeps scrollIntoView from tucking a tab under
+            the sticky open-file button, so it has to stay >= that button's
+            w-9. The extra 4px is breathing room, not a second constraint. */}
+        <div
+          ref={tabsViewportRef}
+          className="min-w-0 flex-1 h-full overflow-x-auto no-scrollbar scroll-pr-10"
+        >
           <div ref={tabsContentRef} className="flex h-full items-stretch min-w-max gap-1">
             {tabs.map((tab) => {
               const isActive = tab.filePath === activeFilePath;


### PR DESCRIPTION
## Summary

Opening a file into an already-crowded tab strip left the new tab clipped, often down to two or three characters, with its close control hidden under the sticky open-file button. Two separate causes:

1. **The scroll ran against a layout that was about to change.** It fires one frame after the tab mounts, and the overflow arrows then mount and narrow the strip, so a position computed against the old width left the tab past the right edge. Measured on a repro: `scrollLeft` settled at 628 where 668 was needed. The resize observer now re-aligns whenever the scrollport's width changes, which also covers the explorer opening and the window resizing.

2. **`scrollIntoView` has no notion of a sticky overlay.** The open-file button is pinned to the right edge of the scrollport, so it covers the tail of whichever tab ends there. Even a fresh `scrollIntoView` left the tab spanning 621 to 821 with the button occupying 785 to 821. The scrollport now carries a `scroll-padding-right` matching the button's width, which is the CSS mechanism for exactly this case.

Two details in the resize path carry their own weight: it compares the fractional width, because a sub-pixel settle at the end of the explorer's open animation rounds to the same `clientWidth` and would skip the last re-align; and it records that width only once an alignment actually ran, so a resize arriving before the tabs do gets retried when they mount. It re-aligns on width changes only, so a new comment badge does not pull the strip back while you are reading another tab.

Verified in Chrome across open-on-load with a restored session, window resize, explorer toggle, and a strip too narrow to fit one tab. Also documents the `w-9` / `scroll-pr-10` coupling in AGENTS.md, since a future restyle of that row could silently reintroduce the bug.

## Testing

- [x] `npm run lint`
- [x] `npm test`
- [x] `npm run test:e2e` (332 passed)
- [x] `npm run eval:dry`

Plus `npm run format:check` and `npm run build`, matching the CI gates.

New coverage: an e2e regression test asserting both edges of the active tab, and `TabBar.test.tsx` pinning the resize mechanism. Five mutants were each confirmed to fail: record-width-anyway, drop-`tabs.length`-dep, no-realign-at-all, no-width-gate, and moving the retry to the alignment effect.

## Checklist

- [x] Docs updated if behavior changed
- [ ] Screenshots added for UI changes
- [x] New tests added or existing coverage updated
- [x] No tracked build artifacts or local test output included

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwNwyxS4YEswXCqFVJ4bTV