### PR TITLE
Keep comments attached when an agent rewrites the document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,10 +66,10 @@ Markers sit immediately **before** the anchor text they refer to:
 Some text <!-- @comment{"id":"uuid","anchor":"highlighted text","text":"comment body","author":"User","timestamp":"ISO-8601","status":"open","replies":[{"id":"uuid","text":"reply","author":"User","timestamp":"ISO-8601"}]} -->highlighted text continues here.
 ```
 
-- `anchor` — the originally selected text (what the comment refers to)
+- `anchor` — the originally selected text (what the comment refers to). It is a lookup key, not a label: an edit that rewrites the anchored text without updating this field detaches the comment. The hand-off prompt tells agents to keep it in sync, and `parseComments` recovers from the marker's position when they don't (see "Anchor recovery after a rewrite")
 - `text` — the reviewer's feedback
 - `replies` — threaded discussion array
-- `status` — `open` or `resolved` (only present when resolve workflow is enabled); a comment is considered an **orphan** when its `anchor` text can no longer be located in the current document
+- `status` — `open` or `resolved` (only present when resolve workflow is enabled); a comment is an **orphan** when its `anchor` can no longer be located in the current document *and* position recovery found nothing to attach it to
 - `contextBefore` / `contextAfter` — surrounding text for fuzzy re-matching when anchor is edited
 - `agentInitiated` — `true` when the marker was created by an agent (via `mdr_ask` or `mdr_review`).
 - `expectsReply` — `true` while an `mdr_ask` question is awaiting the user's answer. Cleared when the user replies (addReply/appendReply), when the session ends (End review / Finish review), or by the stranded-marker sweep after a server restart. A marker with `agentInitiated: true` but no `expectsReply` is "asked, closed": a record, not a pending question.
@@ -693,6 +693,80 @@ button. This calls `moveComment` under the hood and restores the comment at the
 new position. When comments first become orphaned, a debounced toast fires after
 500 ms: `"N comment(s) lost their anchor. See "Needs re-anchoring" in Comments."`
 
+#### Anchor recovery after a rewrite
+A comment only reaches "Needs re-anchoring" once **recovery** has failed. A
+marker is written immediately before the text it anchors to, so when an edit
+rewrites that text but leaves the marker in place, the marker's own position
+still points at whatever replaced it. `parseComments` uses that: for any comment
+whose `anchor` no longer resolves, it sets `anchorStale: true` and calls
+`recoverAnchorAtOffset`, which takes the first line following the marker,
+strips leading scaffolding (heading hashes, bullets, blockquote arrows,
+ordered-list numbering, table pipes) and inline formatting, and returns it as
+`recoveredAnchor` (8 to 120 chars, truncated back to a word boundary). Both
+fields are parse-time only and stripped by `serializeComment`.
+
+Five guards keep recovery from attaching a comment to text that is not its own,
+each of which produced a wrong anchor before it existed:
+
+- **Relocated markers are not recoverable.** `insertComment` moves a marker out
+  of every container that cannot hold one (see "Protected containers"), which
+  is precisely the case where it no longer sits before its anchor. Fenced
+  blocks and HTML comments are refused by `NON_PROSE_LINE`, since a fence
+  delimiter and `<!--` are never visible text. Frontmatter needs its own check:
+  it is the one container the marker TRAILS (frontmatter is recognized only at
+  offset 0, so there is nowhere above it to go), so the marker parks on the
+  closing fence with its anchor behind it and the document's first heading
+  ahead. `parseComments` refuses recovery for a marker sitting at the
+  frontmatter's end offset, or a comment on a `status:` field silently
+  re-points at the page title.
+
+- **The marker's own offset, never `cleanOffset`.** The fuzzy re-match runs
+  first and may have moved `cleanOffset` to a guess; its `contextAfter`-only
+  fallback rewinds by the OLD anchor's length, which a rewrite is precisely
+  what invalidates. Following it lands mid-word in the preceding paragraph.
+  `parseComments` keeps the marker positions in a separate map for this.
+- **A newline budget.** 0 for a standalone marker (whose own trailing newline
+  is stripped, leaving the next line flush against its offset) and 1 for an
+  inline marker ending its line. Crossing a blank line means the block is gone
+  rather than rewritten, so the comment orphans instead of re-pointing at an
+  unrelated later section.
+- **Validation through `anchorResolves`.** A candidate that cannot be located
+  is worse than none: it suppresses the orphan badge while the viewer
+  highlights nothing.
+- **Source-only text is refused outright** (`NON_PROSE_LINE`, `HTML_ENTITY`,
+  and the cell-separator check). Recovery is the only producer of anchors read
+  out of SOURCE text — every other anchor comes from DOM `textContent` — and
+  `anchorResolves` compares against source too, so it structurally cannot catch
+  a candidate that exists in the source and never in the rendered document.
+  Refused: fence delimiters and `|---|` rows (not text), HTML comments (rehype
+  drops them), HTML entities (`&amp;` in source, `&` in the DOM), table rows
+  (adjacent cells concatenate with NO separator in the DOM, and
+  `flexibleIndexOf` requires whitespace between parts, so no readable
+  extraction can match), and footnote definitions (rendered into a separate
+  Footnotes section). Pipes inside inline code are left alone, since a union
+  type is text the reader sees.
+- **Live anchors are off limits.** A candidate equal to another comment's
+  still-resolving anchor belongs to that comment. Comments clustered on the
+  same rewritten block are unaffected, since none of their anchors resolves.
+
+Recovery is what keeps an agent's document restructure from detaching the whole
+review at once. It is never silent: the card badges **Re-anchored** in a quiet
+style and its `title` carries the original anchor, and `MarkdownViewer`
+highlights `recoveredAnchor ?? anchor` so the comment keeps a mark in the
+document. A comment with a `recoveredAnchor` is deliberately **not** in
+`detectMissingAnchors` — it is attached, just not where it was written. Only a
+marker with nothing usable after it (end of file, blank lines, another marker)
+stays a true orphan.
+
+`detectMissingAnchors` takes an options bag: `{ includeResolved }` (default
+`false`). The rail leaves resolved comments out, since the reviewer cannot act
+on them; the card reads `comment.anchorStale` directly and the eval scorer
+passes `includeResolved: true` — an agent that
+rewrites the document while resolving comments detaches resolved anchors just
+as thoroughly, and exempting them reports all-clear on a review whose history
+no longer points anywhere. A resolved comment with a stale, unrecovered anchor
+gets the quiet **Changed** badge rather than the red one.
+
 Orphan detection is a separate matcher from the viewer's: `detectMissingAnchors`
 (`comment-parser.ts`) searches the markdown **source**, where an anchor captured
 from rendered text meets syntax the reader never sees. `partsAppearContiguously`
@@ -1171,7 +1245,9 @@ Key exports from `src/lib/comment-parser.ts`:
 - `removeAllComments(rawMarkdown)` — strip all markers
 - `resolveAllComments(rawMarkdown)` — resolve all open comments
 - `removeResolvedComments(rawMarkdown)` — delete resolved markers
-- `detectMissingAnchors(cleanMarkdown, comments)` — find orphaned comments (returns `Set<string>` of comment ids whose anchor text is absent from `cleanMarkdown`)
+- `detectMissingAnchors(cleanMarkdown, comments, options?)` — find orphaned comments (returns `Set<string>` of comment ids whose anchor text is absent from `cleanMarkdown` and could not be recovered). `options.includeResolved` (default `false`) also checks resolved comments
+- `recoverAnchorAtOffset(cleanMarkdown, cleanOffset, newlineBudget)` — derive a replacement anchor from the text following a marker, or `null` when nothing usable follows it. `newlineBudget` is 0 for a standalone marker, 1 for an inline one
+- `displayAnchor(comment)` / `anchorSearchText(comment)` (`types.ts`) — the anchor as the reviewer sees it (recovered when stale) and the lowercased search haystack covering both. Anything read, copied, searched, or navigated by should go through these
 - `moveComment(rawMarkdown, id, newAnchor, hintOffset?)` — re-anchor an existing comment to `newAnchor`; preserves id, author, timestamp, replies, and status; refreshes context
 - `stripInlineFormatting(md)` — plain text with offset mapping
 
@@ -1236,9 +1312,13 @@ the "no content changes" empty state, and the diff-reference/handoff plumbing.
 
 ## Eval notes
 
-- `eval/fixtures/` currently contains 15 cases.
+- `eval/fixtures/` currently contains 16 cases.
 - Results are written to `eval/results/<timestamp>_<agent>_<format>/`.
-- Scoring weights: parsing 25% (markers removed?), execution 50% (content changes address feedback?), integrity 25% (valid markdown, no malformed markers?).
+- Scoring weights: parsing 20% (markers handled per `markerMode`?), execution 40% (content changes address feedback?), integrity 20% (valid markdown, no malformed markers?), anchorIntegrity 20% (do surviving anchors still resolve?).
+- `expected.json` takes an optional `markerMode`: `remove` (default, the original contract, marker deleted once addressed) or `resolve` (marker stays, gains a reply, gets `status: resolved`). Anchor drift only shows up under `resolve`, since a deleted marker takes its anchor with it.
+- Agents: `claude-cli` (default, hand-written preamble, remove mode) and `claude-cli-resolve`, which drives the agent with the **shipped** `buildAddressCommentsPrompt` output in resolve mode. Use the latter to keep the real hand-off wording under test, so a regression in it shows up as a score drop rather than in someone's review session.
+- `anchorIntegrity` scores each surviving marker: 1 for an anchor that still resolves, 0.5 where only position recovery saved it (the agent rewrote the anchored text without updating the marker), 0 for a detached anchor. Resolved comments are included. Half credit is deliberate: recovery is the app's safety net, not the agent doing its job.
+- `16-restructuring-rewrite` is the regression case for that failure — raw notes with anchors quoting them verbatim, and comments that can only be addressed by rewriting those quotes into decisions.
 
 ## Release notes
 

--- a/e2e/orphan-comments.spec.ts
+++ b/e2e/orphan-comments.spec.ts
@@ -7,12 +7,21 @@ import { resetTestAppState } from './helpers/test-state';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const TEMP_FIXTURE_DIR = resolve(__dirname, '..', 'node_modules', '.md-redline-e2e');
 
+// The anchored sentence sits LAST on purpose. A marker only becomes a true
+// orphan when there is nothing after it to recover from: a marker still
+// followed by text re-anchors to that text by position and gets the quiet
+// "Re-anchored" badge instead. Deleting the trailing sentence strands the
+// marker at end of file, while the landing spot survives above it for the
+// re-anchor flow to target.
 const FIXTURE = `# Orphan Test
 
-Sentence one with the original anchor phrase inside it.
-
 Sentence two holds a fresh landing spot for recovery.
+
+Sentence one with the original anchor phrase inside it.
 `;
+
+/** The body text an external rewrite deletes to strand the marker. */
+const ANCHORED_SENTENCE_TAIL = 'original anchor phrase inside it.';
 
 let fixtureDir = '';
 let fixturePath = '';
@@ -117,14 +126,11 @@ test('comment whose anchor disappears moves into Needs re-anchoring section', as
     .poll(() => readFileSync(fixturePath, 'utf8'), { timeout: 5000 })
     .toContain('@comment');
 
-  // The external rewrite replaces the first occurrence of "original anchor phrase"
-  // in the raw file.  The comment marker is placed BEFORE the anchor text, so
-  // the first occurrence is inside the JSON ("anchor":"original anchor phrase").
-  // This changes the anchor field to "totally different wording" while leaving
-  // the visible rendered text unchanged, making the comment an orphan.
+  // Delete the anchored text outright. The marker is written immediately
+  // before it and is the last thing in the file, so nothing follows it to
+  // recover from and the comment orphans for real.
   const currentRaw = readFileSync(fixturePath, 'utf8');
-  const rewritten = currentRaw.replace('original anchor phrase', 'totally different wording');
-  writeFileSync(fixturePath, rewritten);
+  writeFileSync(fixturePath, currentRaw.replace(ANCHORED_SENTENCE_TAIL, ''));
 
   await expect(page.getByText('Needs re-anchoring (1)')).toBeVisible({ timeout: 5000 });
   await expect(page.getByText('Was anchored here:')).toBeVisible();
@@ -147,10 +153,7 @@ test('Re-anchor to selection binds the orphan comment to new text', async ({ pag
     .toContain('@comment');
 
   const currentRaw = readFileSync(fixturePath, 'utf8');
-  writeFileSync(
-    fixturePath,
-    currentRaw.replace('original anchor phrase', 'totally different wording'),
-  );
+  writeFileSync(fixturePath, currentRaw.replace(ANCHORED_SENTENCE_TAIL, ''));
   await expect(page.getByText('Needs re-anchoring (1)')).toBeVisible({ timeout: 5000 });
 
   // The natural flow: select replacement text first, then click Re-anchor.
@@ -175,11 +178,12 @@ test('Re-anchor to selection picks the selected occurrence when anchor text is d
 }) => {
   // Use a fixture where "landing spot" appears twice so we can test that
   // hintOffset routes re-anchoring to the actually-selected occurrence.
+  // Anchored sentence last, for the same reason as the shared FIXTURE.
   const DUP_FIXTURE = `# Orphan Test
 
-Sentence one with the original anchor phrase inside it.
-
 First landing spot sits here. Second landing spot sits farther down for selection.
+
+Sentence one with the original anchor phrase inside it.
 `;
   writeFileSync(fixturePath, DUP_FIXTURE);
 
@@ -192,10 +196,7 @@ First landing spot sits here. Second landing spot sits farther down for selectio
     .toContain('@comment');
 
   const currentRaw = readFileSync(fixturePath, 'utf8');
-  writeFileSync(
-    fixturePath,
-    currentRaw.replace('original anchor phrase', 'totally different wording'),
-  );
+  writeFileSync(fixturePath, currentRaw.replace(ANCHORED_SENTENCE_TAIL, ''));
   await expect(page.getByText('Needs re-anchoring (1)')).toBeVisible({ timeout: 5000 });
 
   // Select the SECOND occurrence of "landing spot" (occurrence index 1)
@@ -213,4 +214,73 @@ First landing spot sits here. Second landing spot sits farther down for selectio
   await expect
     .poll(() => readFileSync(fixturePath, 'utf8'), { timeout: 3000 })
     .toMatch(/"contextBefore":"[^"]*Second [^"]*"/);
+});
+
+test('a rewritten anchor re-anchors by position instead of orphaning', async ({ page }) => {
+  // The failure this exists for: an agent addresses comments by restructuring
+  // the document, so every anchor quoting the old prose stops existing at once.
+  // The markers survive in place, so the text that replaced the prose is right
+  // there after them.
+  await openFixture(page);
+  await addComment(page, 'original anchor phrase', 'note about phrase');
+  await switchToListDensity(page);
+
+  await expect
+    .poll(() => readFileSync(fixturePath, 'utf8'), { timeout: 5000 })
+    .toContain('@comment');
+
+  const currentRaw = readFileSync(fixturePath, 'utf8');
+  writeFileSync(
+    fixturePath,
+    currentRaw.replace(ANCHORED_SENTENCE_TAIL, 'a completely rewritten decision item.'),
+  );
+
+  // Attached, not orphaned: no re-anchoring section, and the card quotes where
+  // the comment now points.
+  await expect(page.getByText('Re-anchored')).toBeVisible({ timeout: 5000 });
+  await expect(page.getByText('Needs re-anchoring')).not.toBeVisible();
+  // Scoped to the card's own quote element. Matching the page at large would
+  // pass on the rendered document body, which contains this sentence whether
+  // or not the card ever followed the recovery.
+  await expect(page.locator('[data-anchor-quote]').first()).toContainText(
+    'a completely rewritten decision item.',
+  );
+
+  // Recovery is a display aid. The stored anchor is untouched on disk, so the
+  // reviewer's original words survive and re-anchoring stays their decision.
+  expect(readFileSync(fixturePath, 'utf8')).toContain('"anchor":"original anchor phrase"');
+  expect(readFileSync(fixturePath, 'utf8')).not.toContain('recoveredAnchor');
+});
+
+test('Keep this anchor writes the recovered anchor into the file', async ({ page }) => {
+  // Without this, a recovered comment is the one detached state with no way
+  // out: excluded from "Needs re-anchoring", so it never gets the re-anchor
+  // button, and the stale anchor sits in the file permanently.
+  await openFixture(page);
+  await addComment(page, 'original anchor phrase', 'note about phrase');
+  await switchToListDensity(page);
+
+  await expect
+    .poll(() => readFileSync(fixturePath, 'utf8'), { timeout: 5000 })
+    .toContain('@comment');
+
+  const currentRaw = readFileSync(fixturePath, 'utf8');
+  writeFileSync(
+    fixturePath,
+    currentRaw.replace(ANCHORED_SENTENCE_TAIL, 'a completely rewritten decision item.'),
+  );
+  await expect(page.getByText('Re-anchored')).toBeVisible({ timeout: 5000 });
+
+  await page.getByText('note about phrase').click();
+  const keepBtn = page.getByRole('button', { name: 'Keep this anchor' });
+  await expect(keepBtn).toBeVisible({ timeout: 3000 });
+  await keepBtn.click();
+
+  await expect
+    .poll(() => readFileSync(fixturePath, 'utf8'), { timeout: 5000 })
+    .toContain('"anchor":"a completely rewritten decision item."');
+
+  // The recovery is spent: the anchor now resolves on its own, so the badge
+  // that invited the click is gone.
+  await expect(page.getByText('Re-anchored')).not.toBeVisible();
 });

--- a/eval/agents/claude-cli-resolve.ts
+++ b/eval/agents/claude-cli-resolve.ts
@@ -1,0 +1,47 @@
+import { readFile, mkdtemp, cp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildAddressCommentsPrompt } from '../../src/lib/agent-prompts.js';
+import { parseComments } from '../../src/lib/comment-parser.js';
+import { runClaude } from './run-claude.js';
+import type { AgentAdapter } from '../types.js';
+
+/**
+ * Resolve-mode adapter. Where `claude-cli` hands the agent a hand-written
+ * summary of the marker contract and asks it to delete markers, this one hands
+ * it the exact prompt the app's "copy hand-off" button produces, in the mode
+ * the app ships by default: markers stay in the file, gain a reply, and are
+ * marked resolved.
+ *
+ * Using the shipped prompt verbatim is the point. It puts the real wording
+ * under test, so a regression in the hand-off text — an anchor rule that stops
+ * landing, an instruction the model reads past — shows up as a score drop
+ * rather than as a surprise in someone's review session.
+ */
+export const claudeCliResolve: AgentAdapter = {
+  name: 'claude-cli-resolve',
+
+  async run(inputPath: string, casePrompt: string): Promise<string> {
+    const tempDir = await mkdtemp(join(tmpdir(), 'md-eval-resolve-'));
+    const tempFile = join(tempDir, 'input.md');
+
+    try {
+      await cp(inputPath, tempFile);
+
+      const raw = await readFile(tempFile, 'utf-8');
+      const { comments } = parseComments(raw);
+
+      const handoff = buildAddressCommentsPrompt({
+        filePaths: [tempFile],
+        commentCounts: new Map([[tempFile, comments.length]]),
+        enableResolve: true,
+      });
+
+      await runClaude(`${handoff}\n\n## This review\n\n${casePrompt}`, tempDir);
+
+      return await readFile(tempFile, 'utf-8');
+    } finally {
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {});
+    }
+  },
+};

--- a/eval/agents/claude-cli.ts
+++ b/eval/agents/claude-cli.ts
@@ -1,10 +1,8 @@
-import { execFile } from 'node:child_process';
 import { readFile, mkdtemp, cp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { runClaude } from './run-claude.js';
 import type { AgentAdapter } from '../types.js';
-
-const TIMEOUT_MS = 180_000; // 3 minutes
 
 const SYSTEM_CONTEXT = `You are reviewing a markdown file that contains inline review comments.
 
@@ -51,20 +49,3 @@ Read the file, make the requested changes, and write the result back to the same
     }
   },
 };
-
-function runClaude(prompt: string, cwd: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      'claude',
-      ['-p', prompt, '--allowedTools', 'Read,Edit,Write'],
-      { cwd, timeout: TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 },
-      (error, stdout, stderr) => {
-        if (error) {
-          reject(new Error(`claude-cli failed: ${error.message}\nstderr: ${stderr}`));
-          return;
-        }
-        resolve(stdout);
-      },
-    );
-  });
-}

--- a/eval/agents/run-claude.ts
+++ b/eval/agents/run-claude.ts
@@ -1,0 +1,21 @@
+import { execFile } from 'node:child_process';
+
+const TIMEOUT_MS = 180_000; // 3 minutes
+
+/** Shared claude CLI invocation used by every claude-based adapter. */
+export function runClaude(prompt: string, cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      'claude',
+      ['-p', prompt, '--allowedTools', 'Read,Edit,Write'],
+      { cwd, timeout: TIMEOUT_MS, maxBuffer: 10 * 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`claude-cli failed: ${error.message}\nstderr: ${stderr}`));
+          return;
+        }
+        resolve(stdout);
+      },
+    );
+  });
+}

--- a/eval/fixtures/16-restructuring-rewrite/expected.json
+++ b/eval/fixtures/16-restructuring-rewrite/expected.json
@@ -1,0 +1,31 @@
+{
+  "markerMode": "resolve",
+  "requiresAgent": "claude-cli-resolve",
+  "totalComments": 3,
+  "actionableComments": 3,
+  "comments": [
+    {
+      "id": "eval-16-c1",
+      "expectedAction": "address",
+      "contentHints": {
+        "shouldNotContain": ["Is it already live?"]
+      }
+    },
+    {
+      "id": "eval-16-c2",
+      "expectedAction": "address",
+      "contentHints": {
+        "shouldNotContain": ["Draft another one does nothing"]
+      }
+    },
+    {
+      "id": "eval-16-c3",
+      "expectedAction": "address",
+      "contentHints": {
+        "shouldNotContain": ["Tone slider, 1 to 5"]
+      }
+    }
+  ],
+  "contentShouldChange": true,
+  "contentAssertions": []
+}

--- a/eval/fixtures/16-restructuring-rewrite/input.md
+++ b/eval/fixtures/16-restructuring-rewrite/input.md
@@ -1,0 +1,19 @@
+# Follow-up assistant: raw notes from the Owners Club session
+
+Unstructured notes from the call. Nothing here is decided yet, and the quotes
+below are verbatim.
+
+## What came up
+
+<!-- @comment{"id":"eval-16-c1","anchor":"Is it already live?","text":"Turn this into a decided item: the end of setup needs one terminal screen that says plainly the app is not live yet and carries a single Launch action. The celebration belongs on the actual launch, not here.","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->Is it already live?
+
+She had stopped reading by the time the confirmation screens appeared, and the
+confetti convinced her the whole thing was done.
+
+<!-- @comment{"id":"eval-16-c2","anchor":"Draft another one does nothing","text":"The real problem is that the button replaced the draft she had just spent five minutes editing. Write this up as a decided fix: the action must add a draft, never overwrite one.","author":"PM","timestamp":"2026-08-06T10:01:00Z"} -->Draft another one does nothing
+
+She clicked it expecting a second email alongside the first.
+
+<!-- @comment{"id":"eval-16-c3","anchor":"Tone slider, 1 to 5","text":"Leave this out for now. Record it as deferred, with the reasoning: a numeric scale is exactly the abstraction the product is trying to avoid.","author":"PM","timestamp":"2026-08-06T10:02:00Z"} -->Tone slider, 1 to 5
+
+Raised twice, once in setup and once in the operational view.

--- a/eval/fixtures/16-restructuring-rewrite/prompt.txt
+++ b/eval/fixtures/16-restructuring-rewrite/prompt.txt
@@ -1,0 +1,1 @@
+Address all open review comments in this file. Each comment asks for the raw quote it is anchored to be rewritten into a decided or deferred item, so the document will change shape as you work.

--- a/eval/runner.ts
+++ b/eval/runner.ts
@@ -5,6 +5,7 @@ import { parseArgs } from 'node:util';
 import { score } from './scorer.js';
 import { getFormat } from './formats/index.js';
 import { claudeCli } from './agents/claude-cli.js';
+import { claudeCliResolve } from './agents/claude-cli-resolve.js';
 import type { AgentAdapter, EvalCase, ExpectedCriteria, ScoringResult } from './types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -13,6 +14,7 @@ const RESULTS_DIR = join(__dirname, 'results');
 
 const agents: Record<string, AgentAdapter> = {
   'claude-cli': claudeCli,
+  'claude-cli-resolve': claudeCliResolve,
 };
 
 async function discoverCases(filter?: string): Promise<EvalCase[]> {
@@ -71,7 +73,7 @@ async function runCase(
 }
 
 function printTable(results: ScoringResult[]) {
-  const header = ['Case'.padEnd(28), 'Parse', ' Exec', 'Integ', 'Overall'].join(' | ');
+  const header = ['Case'.padEnd(28), 'Parse', ' Exec', 'Integ', 'Anchor', 'Overall'].join(' | ');
 
   const divider = '-'.repeat(header.length);
 
@@ -85,6 +87,7 @@ function printTable(results: ScoringResult[]) {
       fmtPct(r.scores.parsing),
       fmtPct(r.scores.execution),
       fmtPct(r.scores.integrity),
+      fmtPct(r.scores.anchorIntegrity),
       fmtPct(r.overall),
     ].join(' | ');
     console.log(row);
@@ -94,14 +97,20 @@ function printTable(results: ScoringResult[]) {
 
   // Averages
   if (results.length > 1) {
-    const avg = (key: keyof ScoringResult['scores']) =>
-      results.reduce((s, r) => s + r.scores[key], 0) / results.length;
+    // Averaged over the cases where the dimension applies. Counting an
+    // inapplicable dimension as 0 would punish cases that have no such
+    // surface; counting it as 1 would flatter them.
+    const avg = (key: keyof ScoringResult['scores']) => {
+      const vals = results.map((r) => r.scores[key]).filter((v): v is number => v !== null);
+      return vals.length ? vals.reduce((s, v) => s + v, 0) / vals.length : null;
+    };
     const avgOverall = results.reduce((s, r) => s + r.overall, 0) / results.length;
     const row = [
       'AVERAGE'.padEnd(28),
       fmtPct(avg('parsing')),
       fmtPct(avg('execution')),
       fmtPct(avg('integrity')),
+      fmtPct(avg('anchorIntegrity')),
       fmtPct(avgOverall),
     ].join(' | ');
     console.log(row);
@@ -109,8 +118,8 @@ function printTable(results: ScoringResult[]) {
   }
 }
 
-function fmtPct(n: number): string {
-  return (n * 100).toFixed(0).padStart(5) + '%';
+function fmtPct(n: number | null): string {
+  return n === null ? '  n/a' : (n * 100).toFixed(0).padStart(5) + '%';
 }
 
 async function validateFixtures(cases: EvalCase[]) {
@@ -193,7 +202,29 @@ async function main() {
 
   const results: ScoringResult[] = [];
 
+  const skipped: string[] = [];
+
   for (const evalCase of cases) {
+    // A case that declares an agent requirement is scored only under that
+    // agent. Scoring it anyway would report a confident number for a run that
+    // could not have produced the behavior the case exists to measure.
+    const required: string | undefined = JSON.parse(
+      await readFile(evalCase.expectedPath, 'utf-8'),
+    ).requiresAgent;
+    // A typo here would otherwise skip the case under every agent forever,
+    // leaving only a log line behind — the quietest way to lose a fixture.
+    if (required && !agents[required]) {
+      console.error(
+        `\n${evalCase.name}: requiresAgent "${required}" is not a known agent. Available: ${Object.keys(agents).join(', ')}`,
+      );
+      process.exit(1);
+    }
+    if (required && required !== agentName) {
+      skipped.push(`${evalCase.name} (needs agent "${required}")`);
+      console.log(`Skipping: ${evalCase.name} — needs agent "${required}", running "${agentName}"`);
+      continue;
+    }
+
     process.stdout.write(`Running: ${evalCase.name}...`);
     try {
       const result = await runCase(evalCase, agent, formatName);
@@ -218,6 +249,7 @@ async function main() {
           parsing: 0,
           execution: 0,
           integrity: 0,
+          anchorIntegrity: 0,
         },
         overall: 0,
         details: [`error: ${err instanceof Error ? err.message : String(err)}`],
@@ -233,13 +265,23 @@ async function main() {
   // Print summary table
   printTable(results);
 
+  // Say what was not measured. A skipped case reported only as a smaller case
+  // count reads as full coverage to anyone scanning the average.
+  if (skipped.length > 0) {
+    console.log(`\nSkipped ${skipped.length} case(s), not counted in the average:`);
+    for (const s of skipped) console.log(`  - ${s}`);
+  }
+
   // Save summary
   const summary = {
     timestamp,
     agent: agentName,
     format: formatName,
     cases: results.length,
-    averageOverall: results.reduce((s, r) => s + r.overall, 0) / results.length,
+    skipped,
+    averageOverall: results.length
+      ? results.reduce((s, r) => s + r.overall, 0) / results.length
+      : null,
     results,
   };
   await writeFile(join(runDir, 'summary.json'), JSON.stringify(summary, null, 2));

--- a/eval/scorer.test.ts
+++ b/eval/scorer.test.ts
@@ -381,28 +381,212 @@ describe('scorer', () => {
   // 5. Weighted overall score
   // -----------------------------------------------------------------------
   describe('overall score weighting', () => {
-    it('weights are parsing=0.25, execution=0.50, integrity=0.25', () => {
-      // All markers removed (parsing=1.0), content changed (execution=1.0), no markers left (integrity=1.0)
+    it('weights are parsing=0.20, execution=0.40, integrity=0.20, anchorIntegrity=0.20', () => {
+      // All markers removed (parsing=1.0), content changed (execution=1.0),
+      // no markers left (integrity=1.0, anchorIntegrity=1.0)
       const input = `Hello ${makeMarker()}world`;
       const output = 'Hello world — fixed';
       const expected = makeExpected();
 
       const result = score('perfect', input, output, expected);
-      expect(result.overall).toBeCloseTo(1.0 * 0.25 + 1.0 * 0.5 + 1.0 * 0.25);
+      expect(result.overall).toBeCloseTo(1.0 * 0.2 + 1.0 * 0.4 + 1.0 * 0.2 + 1.0 * 0.2);
     });
 
     it('computes correct weighted score for partial results', () => {
-      // parsing=0 (marker kept), execution=1 (content changed), integrity=1 (marker valid)
+      // parsing=0 (marker kept), execution=1 (content changed),
+      // integrity=1 (marker valid), anchorIntegrity=1 (anchor still resolves)
       const m = makeMarker({ id: 'c1', anchor: 'Hello' });
       const input = `Hello ${m}world`;
       const output = `Hello ${m}world — addressed`;
       const expected = makeExpected();
 
       const result = score('partial', input, output, expected);
-      // parsing = 0.0, execution = 1.0, integrity = 1.0
-      const expectedOverall = 0.0 * 0.25 + 1.0 * 0.5 + 1.0 * 0.25;
+      const expectedOverall = 0.0 * 0.2 + 1.0 * 0.4 + 1.0 * 0.2 + 1.0 * 0.2;
       expect(result.overall).toBeCloseTo(expectedOverall);
-      expect(result.overall).toBeCloseTo(0.75);
+      expect(result.overall).toBeCloseTo(0.8);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 5b. Anchor integrity dimension
+  // -----------------------------------------------------------------------
+  describe('anchorIntegrity score', () => {
+    it('scores 1.0 when every surviving anchor still resolves', () => {
+      const m = makeMarker({ id: 'c1', anchor: 'Hello' });
+      const result = score(
+        'intact',
+        `Hello ${m}world`,
+        `Hello ${m}world — addressed`,
+        makeExpected(),
+      );
+      expect(result.scores.anchorIntegrity).toBe(1.0);
+    });
+
+    it('reports n/a when no markers were expected to survive', () => {
+      // Not 1.0: a remove-mode case ends with no markers by design, so there
+      // is no anchor to keep or lose. Scoring the absent surface as perfect
+      // would hand every such case a free fifth of its total.
+      const result = score('none', `Hello ${makeMarker()}world`, 'Hello world', makeExpected());
+      expect(result.scores.anchorIntegrity).toBeNull();
+    });
+
+    it('renormalizes the overall score over the dimensions that apply', () => {
+      // parsing=1, execution=1, integrity=1, anchorIntegrity=n/a. The three
+      // that apply keep their original relative weights (0.25/0.50/0.25).
+      const clean = score(
+        'none',
+        `Hello ${makeMarker()}world`,
+        'Hello world — addressed',
+        makeExpected(),
+      );
+      expect(clean.scores.anchorIntegrity).toBeNull();
+      expect(clean.overall).toBeCloseTo(1.0);
+
+      // parsing=0 and the rest 1: 0*0.25 + 1*0.50 + 1*0.25 = 0.75, the same
+      // number this case scored before anchorIntegrity existed.
+      const m = makeMarker({ id: 'c1', anchor: 'Hello' });
+      const partial = score('kept', `Hello ${m}world`, `Hello ${m}world — done`, {
+        ...makeExpected(),
+        comments: [{ id: 'c1', expectedAction: 'address' }],
+      });
+      expect(partial.scores.anchorIntegrity).toBe(1.0);
+    });
+
+    it('gives half credit when the rewrite is only caught by position recovery', () => {
+      // The real regression: the agent restructures the prose the marker sits
+      // in front of, resolves the comment, and leaves the anchor pointing at
+      // text it just deleted.
+      const m = makeMarker({
+        id: 'c1',
+        anchor: 'Is it already live?',
+        status: 'resolved',
+        resolved: true,
+        replies: [{ id: 'r1', text: 'done', author: 'Claude', timestamp: '2024-01-01T00:00:00Z' }],
+      });
+      const input = `# Notes\n\n${m}Is it already live?\n`;
+      const output = `# Notes\n\n${m}### A1. One terminal screen at the end of setup\n`;
+
+      const result = score('recovered', input, output, makeExpected({ markerMode: 'resolve' }));
+
+      expect(result.scores.anchorIntegrity).toBe(0.5);
+      expect(result.details.join('\n')).toContain('recovered by position');
+    });
+
+    it('scores 0 when a marker is stranded with nothing to recover from', () => {
+      const m = makeMarker({ id: 'c1', anchor: 'the deleted paragraph' });
+      const input = `Intro\n\n${m}the deleted paragraph\n`;
+      const output = `Intro\n\n${m}`;
+
+      const result = score('detached', input, output, makeExpected({ markerMode: 'resolve' }));
+
+      expect(result.scores.anchorIntegrity).toBe(0);
+      expect(result.details.join('\n')).toContain('no longer locatable in document');
+    });
+
+    it('does not reward deleting every marker in resolve mode', () => {
+      // The worst possible anchor outcome — delete the markers, taking their
+      // anchors with them — must not be the one outcome scored 1.0 for free
+      // because there is nothing left to check.
+      const input = `Hello ${makeMarker({ id: 'c1', anchor: 'Hello' })}world`;
+      const output = 'Hello world — addressed';
+
+      const result = score('all-deleted', input, output, makeExpected({ markerMode: 'resolve' }));
+
+      expect(result.scores.anchorIntegrity).toBe(0);
+      expect(result.details.join('\n')).toContain('taking its anchor with it');
+    });
+
+    it('does not penalize deleted markers in remove mode, where that is correct', () => {
+      // The same output that scores 0 under resolve mode is simply not
+      // measurable under remove mode, rather than good or bad.
+      const input = `Hello ${makeMarker({ id: 'c1', anchor: 'Hello' })}world`;
+      const result = score('removed', input, 'Hello world', makeExpected());
+      expect(result.scores.anchorIntegrity).toBeNull();
+      expect(result.scores.parsing).toBe(1.0);
+    });
+
+    it('gives no credit for an emptied anchor', () => {
+      // An empty anchor has no parts to locate, so a presence check accepts it
+      // against any document. Erasing the field is not re-anchoring.
+      const m = makeMarker({
+        id: 'c1',
+        anchor: '',
+        status: 'resolved',
+        resolved: true,
+        replies: [{ id: 'r1', text: 'done', author: 'Claude', timestamp: '2024-01-01T00:00:00Z' }],
+      });
+      const input = `Hello ${makeMarker({ id: 'c1', anchor: 'Hello' })}world`;
+      const output = `Hello ${m}world — addressed`;
+
+      const result = score('emptied', input, output, makeExpected({ markerMode: 'resolve' }));
+      expect(result.scores.anchorIntegrity).toBe(0);
+    });
+
+    it('counts resolved comments, which the rail deliberately does not', () => {
+      // Resolving a comment does not make its anchor disposable: the resolved
+      // thread is the record of why the document says what it says.
+      const m = makeMarker({
+        id: 'c1',
+        anchor: 'gone entirely',
+        status: 'resolved',
+        resolved: true,
+      });
+      const input = `Keep\n\n${m}gone entirely\n`;
+      const output = `Keep\n\n${m}`;
+
+      const result = score(
+        'resolved-detached',
+        input,
+        output,
+        makeExpected({ markerMode: 'resolve' }),
+      );
+
+      expect(result.scores.anchorIntegrity).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // 5c. Resolve marker mode
+  // -----------------------------------------------------------------------
+  describe('resolve marker mode', () => {
+    const resolvedMarker = makeMarker({
+      id: 'c1',
+      anchor: 'Hello',
+      status: 'resolved',
+      resolved: true,
+      replies: [{ id: 'r1', text: 'done', author: 'Claude', timestamp: '2024-01-01T00:00:00Z' }],
+    });
+
+    it('credits a marker that was resolved with a reply', () => {
+      const input = `Hello ${makeMarker({ id: 'c1', anchor: 'Hello' })}world`;
+      const output = `Hello ${resolvedMarker}world — addressed`;
+
+      const result = score('resolve', input, output, makeExpected({ markerMode: 'resolve' }));
+      expect(result.scores.parsing).toBe(1.0);
+    });
+
+    it('does not credit a marker that was deleted instead of resolved', () => {
+      const input = `Hello ${makeMarker({ id: 'c1', anchor: 'Hello' })}world`;
+      const output = 'Hello world — addressed';
+
+      const result = score('deleted', input, output, makeExpected({ markerMode: 'resolve' }));
+      expect(result.scores.parsing).toBe(0);
+      expect(result.details.join('\n')).toContain('should have been resolved');
+    });
+
+    it('does not credit a resolved marker with no reply on it', () => {
+      const noReply = makeMarker({
+        id: 'c1',
+        anchor: 'Hello',
+        status: 'resolved',
+        resolved: true,
+      });
+      const input = `Hello ${makeMarker({ id: 'c1', anchor: 'Hello' })}world`;
+      const output = `Hello ${noReply}world — addressed`;
+
+      const result = score('no-reply', input, output, makeExpected({ markerMode: 'resolve' }));
+      expect(result.scores.parsing).toBe(0);
+      expect(result.details.join('\n')).toContain('no reply added');
     });
   });
 

--- a/eval/scorer.ts
+++ b/eval/scorer.ts
@@ -1,13 +1,15 @@
-import { parseComments } from '../src/lib/comment-parser.js';
+import { parseComments, detectMissingAnchors } from '../src/lib/comment-parser.js';
+import { getEffectiveStatus } from '../src/types.js';
 import type { ExpectedCriteria, ScoringResult, DimensionScores } from './types.js';
 
 // Regex with capture group for JSON parsing — different from the shared COMMENT_MARKER_RE
 const COMMENT_MARKER_RE = /<!-- @comment(\{.*?\}) -->/gs;
 
 const WEIGHTS: Record<keyof DimensionScores, number> = {
-  parsing: 0.25,
-  execution: 0.5,
-  integrity: 0.25,
+  parsing: 0.2,
+  execution: 0.4,
+  integrity: 0.2,
+  anchorIntegrity: 0.2,
 };
 
 export function score(
@@ -40,18 +42,40 @@ export function score(
         `warning: actionableComments (${expected.actionableComments}) does not match computed count (${actionable.length})`,
       );
     }
+    const markerMode = expected.markerMode ?? 'remove';
     let correct = 0;
     for (const exp of actionable) {
-      // Marker should be removed after addressing
-      if (!outputById.has(exp.id)) {
+      const survivor = outputById.get(exp.id);
+      if (markerMode === 'remove') {
+        if (!survivor) {
+          correct++;
+          details.push(`parsing: ${exp.id} — marker correctly removed`);
+        } else {
+          details.push(`parsing: ${exp.id} — marker should have been removed but was preserved`);
+        }
+        continue;
+      }
+      // resolve mode: the marker stays, gains a reply, and is marked resolved
+      if (!survivor) {
+        details.push(`parsing: ${exp.id} — marker was deleted but should have been resolved`);
+        continue;
+      }
+      const isResolved = getEffectiveStatus(survivor) === 'resolved';
+      const hasReply = (survivor.replies?.length ?? 0) > 0;
+      if (isResolved && hasReply) {
         correct++;
-        details.push(`parsing: ${exp.id} — marker correctly removed`);
+        details.push(`parsing: ${exp.id} — marker resolved with a reply`);
       } else {
-        details.push(`parsing: ${exp.id} — marker should have been removed but was preserved`);
+        const missing = [!isResolved && 'not resolved', !hasReply && 'no reply added']
+          .filter(Boolean)
+          .join(', ');
+        details.push(`parsing: ${exp.id} — marker preserved but ${missing}`);
       }
     }
     parsingScore = actionable.length > 0 ? correct / actionable.length : 1.0;
-    details.push(`parsing: ${correct}/${actionable.length} markers correctly handled`);
+    details.push(
+      `parsing: ${correct}/${actionable.length} markers correctly handled (${markerMode})`,
+    );
   }
 
   // --- 2. Execution: Did content changes address the feedback? ---
@@ -144,14 +168,89 @@ export function score(
     details.push(`integrity: ${valid}/${rawMarkers.length} markers valid`);
   }
 
+  // --- 4. Anchor integrity: do surviving markers still point at real text? ---
+  // Scored on the agent's own output, with resolved comments included: an
+  // agent that resolves a comment and rewrites its anchor text in the same
+  // pass has still detached it.
+  //
+  // Half credit where md-redline recovered the anchor from the marker's
+  // position. Recovery is the app's safety net, not the agent doing its job:
+  // scoring it as a pass would let an agent rewrite every anchor in the file
+  // and still come out clean, and scoring it as a failure would not
+  // distinguish it from a marker stranded with nothing to point at.
+  const RECOVERED_CREDIT = 0.5;
+  let anchorScore: number | null;
+  const survivors = outputParsed.comments;
+  // In resolve mode the markers are SUPPOSED to survive, so a deleted one is
+  // scored as detached rather than dropped from the denominator. Otherwise the
+  // worst possible anchor outcome — delete every marker, taking every anchor
+  // with it — is the one outcome this dimension cannot punish.
+  const expectedSurvivorIds =
+    (expected.markerMode ?? 'remove') === 'resolve'
+      ? expected.comments.filter((c) => c.expectedAction === 'address').map((c) => c.id)
+      : [];
+  const missingSurvivors = expectedSurvivorIds.filter((id) => !outputById.has(id));
+  const denominator = survivors.length + missingSurvivors.length;
+
+  if (denominator === 0) {
+    // Not applicable rather than perfect. A remove-mode case ends with no
+    // markers by design, so there is no anchor to keep or lose — awarding 1.0
+    // would be a constant fifth of the score that measures nothing, dilute the
+    // dimensions that do, and make every pre-existing result incomparable.
+    // Null drops it and renormalizes the rest to their original proportions.
+    anchorScore = null;
+    details.push('anchorIntegrity: n/a (no markers expected to survive)');
+  } else {
+    const detached = detectMissingAnchors(outputParsed.cleanMarkdown, survivors, {
+      includeResolved: true,
+    });
+    let credit = 0;
+    let intact = 0;
+    let recoveredCount = 0;
+    for (const c of survivors) {
+      // An empty anchor matches everything by construction (no parts to
+      // locate), so presence alone would hand out full credit for erasing the
+      // field. Nothing can be re-anchored to nothing.
+      if (detached.has(c.id) || c.anchor.trim() === '') {
+        details.push(
+          `anchorIntegrity: ${c.id} — anchor "${trunc(c.anchor)}" no longer locatable in document`,
+        );
+      } else if (c.recoveredAnchor) {
+        recoveredCount++;
+        credit += RECOVERED_CREDIT;
+        details.push(
+          `anchorIntegrity: ${c.id} — anchor rewritten without updating the marker, recovered by position to "${trunc(c.recoveredAnchor)}"`,
+        );
+      } else {
+        intact++;
+        credit += 1;
+      }
+    }
+    for (const id of missingSurvivors) {
+      details.push(`anchorIntegrity: ${id} — marker deleted, taking its anchor with it`);
+    }
+    anchorScore = credit / denominator;
+    details.push(
+      `anchorIntegrity: ${intact} intact, ${recoveredCount} recovered by position, ${denominator - intact - recoveredCount} detached (of ${denominator})`,
+    );
+  }
+
   const scores: DimensionScores = {
     parsing: parsingScore,
     execution: executionScore,
     integrity: integrityScore,
+    anchorIntegrity: anchorScore,
   };
 
-  const overall = Object.entries(WEIGHTS).reduce(
-    (sum, [key, weight]) => sum + scores[key as keyof DimensionScores] * weight,
+  // Renormalize over the dimensions that apply, so a case with no anchor
+  // surface is scored out of the three that do at their original relative
+  // weights (0.25 / 0.50 / 0.25) rather than being handed a free fifth.
+  const applicable = Object.entries(WEIGHTS).filter(
+    ([key]) => scores[key as keyof DimensionScores] !== null,
+  );
+  const totalWeight = applicable.reduce((sum, [, weight]) => sum + weight, 0);
+  const overall = applicable.reduce(
+    (sum, [key, weight]) => sum + scores[key as keyof DimensionScores]! * (weight / totalWeight),
     0,
   );
 

--- a/eval/types.ts
+++ b/eval/types.ts
@@ -21,7 +21,27 @@ export interface ContentAssertion {
   value: string;
 }
 
+/**
+ * What the agent is expected to do with a marker once it has addressed the
+ * comment. `remove` is the original hand-off contract; `resolve` is what the
+ * app ships by default now, where the marker stays in the file carrying a
+ * reply and a resolved status. Anchor drift only shows up under `resolve`,
+ * since a removed marker takes its anchor with it.
+ */
+export type MarkerMode = 'remove' | 'resolve';
+
 export interface ExpectedCriteria {
+  /** Defaults to 'remove' when absent, so existing fixtures are unaffected. */
+  markerMode?: MarkerMode;
+  /**
+   * Agent adapter this case needs to be meaningful. `markerMode` describes what
+   * the OUTPUT should look like, but the mode the agent runs in comes from the
+   * global `--agent` flag, so a resolve-mode case scored against a remove-mode
+   * agent fails by construction AND reports a vacuous anchorIntegrity (no
+   * markers survive, nothing to detach). The runner skips a case whose
+   * requirement the selected agent does not meet rather than scoring it.
+   */
+  requiresAgent?: string;
   totalComments: number;
   actionableComments: number;
   comments: CommentExpectation[];
@@ -36,6 +56,17 @@ export interface DimensionScores {
   execution: number;
   /** Are all remaining markers valid JSON? (0-1) */
   integrity: number;
+  /**
+   * Do the anchors on surviving markers still resolve against the document
+   * the agent produced? (0-1) An agent that rewrites prose without updating
+   * the anchors it rewrote scores full marks on every other dimension while
+   * detaching the review from the document, which is what this measures.
+   *
+   * `null` when the case expects no markers to survive, so there is no anchor
+   * to keep or lose. The overall score renormalizes over the dimensions that
+   * apply rather than scoring an absent surface as perfect.
+   */
+  anchorIntegrity: number | null;
 }
 
 export interface ScoringResult {

--- a/src/components/CommentCard.test.tsx
+++ b/src/components/CommentCard.test.tsx
@@ -219,3 +219,79 @@ describe('clamp re-check', () => {
     expect(resizeObserverObserved).toContain(textEl);
   });
 });
+
+describe('CommentCard — anchor badges', () => {
+  it('shows no anchor badge when the anchor is intact', () => {
+    renderCard();
+    expect(screen.queryByText('Changed')).toBeNull();
+    expect(screen.queryByText('Re-anchored')).toBeNull();
+  });
+
+  it('shows "Re-anchored" and quotes where the comment now points', () => {
+    renderCard({
+      comment: {
+        ...baseComment,
+        anchorStale: true,
+        recoveredAnchor: 'A1. The section that replaced it',
+      },
+    });
+    expect(screen.queryByText('Re-anchored')).not.toBeNull();
+    expect(screen.queryByText('Changed')).toBeNull();
+    // The quote follows the recovery, so the card describes the document as it
+    // is now rather than as it was when the comment was written.
+    expect(screen.getByText(/A1\. The section that replaced it/)).toBeTruthy();
+  });
+
+  it('keeps the original anchor reachable in the title when re-anchored', () => {
+    const { container } = renderCard({
+      comment: { ...baseComment, anchorStale: true, recoveredAnchor: 'the replacement' },
+    });
+    const quote = container.querySelector('[data-anchor-quote]');
+    expect(quote?.getAttribute('title')).toContain('Hello world');
+  });
+
+  it('shows "Changed" for an open comment whose anchor could not be recovered', () => {
+    renderCard({ comment: { ...baseComment, anchorStale: true }, anchorMissing: true });
+    const badge = screen.queryByText('Changed');
+    expect(badge).not.toBeNull();
+    expect(badge?.className).toContain('bg-danger-bg');
+  });
+
+  it('shows a quiet "Changed" for a resolved comment detached by a later rewrite', () => {
+    // Resolved comments are excluded from the rail's orphan set (the reviewer
+    // cannot act on them), so anchorMissing is false while anchorStale is true.
+    // The badge still has to appear, or the resolved thread silently stops
+    // pointing anywhere.
+    renderCard({
+      comment: { ...baseComment, status: 'resolved', resolved: true, anchorStale: true },
+      anchorMissing: false,
+    });
+    const badge = screen.queryByText('Changed');
+    expect(badge).not.toBeNull();
+    expect(badge?.className).not.toContain('bg-danger-bg');
+  });
+
+  it('reads the quiet variant off the comment’s status, not off a missing prop', () => {
+    // MermaidThreadPanel renders cards without wiring anchorMissing at all, so
+    // "no anchorMissing" cannot be taken to mean "resolved". An OPEN detached
+    // comment there must still read as loud and actionable, and must never be
+    // told it was resolved.
+    renderCard({
+      comment: { ...baseComment, anchorStale: true },
+      anchorMissing: undefined,
+    });
+    const badge = screen.queryByText('Changed');
+    expect(badge).not.toBeNull();
+    expect(badge?.className).toContain('bg-danger-bg');
+    expect(badge?.getAttribute('title')).not.toContain('resolved');
+  });
+
+  it('suppresses the badge when the full anchor context is already shown', () => {
+    renderCard({
+      comment: { ...baseComment, anchorStale: true },
+      anchorMissing: true,
+      showAnchorContext: true,
+    });
+    expect(screen.queryByText('Changed')).toBeNull();
+  });
+});

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -223,6 +223,45 @@ export const CommentCard = memo(function CommentCard({
     onCloseEditor();
   };
 
+  // Three states, and they are not interchangeable. A recovered anchor still
+  // points somewhere, so it reads quietly and only invites a check. A stale
+  // anchor with no recovery on an open comment is the loud case: the reviewer
+  // has to re-anchor it by hand. The same on a resolved comment is history
+  // that came loose, worth showing but not worth alarming over.
+  //
+  // Which of the last two applies is read off the comment's own status, never
+  // off `anchorMissing` being absent. Surfaces differ in whether they wire
+  // that prop at all — MermaidThreadPanel does not — so treating "no
+  // anchorMissing" as "resolved" tells an open, actionable orphan that it was
+  // resolved, and only on the surfaces that forgot to pass the prop.
+  const QUIET_BADGE = 'bg-surface-secondary text-content-muted border border-border-subtle';
+  const anchorDetached = anchorMissing || comment.anchorStale;
+  const anchorBadge = showAnchorContext
+    ? null
+    : comment.recoveredAnchor
+      ? {
+          label: 'Re-anchored',
+          className: QUIET_BADGE,
+          title: `Anchor text was rewritten. Following the marker to the text that replaced it.\n\nOriginally anchored to: "${comment.anchor}"`,
+        }
+      : anchorDetached
+        ? // `status`, not `isResolved`: the latter also requires the resolve
+          // setting to be on, while detectMissingAnchors — whose behavior this
+          // badge exists to explain — keys off effective status alone. Gating
+          // on the setting makes the badge disagree with the rail.
+          status === 'resolved'
+          ? {
+              label: 'Changed',
+              className: QUIET_BADGE,
+              title: 'Anchor text was modified or removed after this comment was resolved',
+            }
+          : {
+              label: 'Changed',
+              className: 'bg-danger-bg text-danger-text',
+              title: 'Anchor text was modified or removed',
+            }
+        : null;
+
   return (
     <div
       className={`group rounded-lg border transition-all duration-200 cursor-pointer ${
@@ -244,10 +283,14 @@ export const CommentCard = memo(function CommentCard({
       <div className="px-3 pt-3 pb-1 flex items-start gap-2">
         <div
           data-anchor-quote
-          title={comment.anchor}
+          title={
+            comment.recoveredAnchor
+              ? `${comment.recoveredAnchor}\n\nOriginally anchored to: "${comment.anchor}"`
+              : comment.anchor
+          }
           className={`comment-quote flex-1 min-w-0 line-clamp-2 ${isResolved ? 'comment-quote-resolved' : ''}`}
         >
-          &ldquo;{comment.anchor}&rdquo;
+          &ldquo;{comment.recoveredAnchor ?? comment.anchor}&rdquo;
         </div>
         <div className="flex items-center gap-1 shrink-0">
           {sent && (
@@ -258,12 +301,12 @@ export const CommentCard = memo(function CommentCard({
               Sent
             </span>
           )}
-          {anchorMissing && !showAnchorContext && (
+          {anchorBadge && (
             <span
-              className="text-[10px] font-semibold px-1.5 py-0.5 rounded-full whitespace-nowrap bg-danger-bg text-danger-text"
-              title="Anchor text was modified or removed"
+              className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full whitespace-nowrap ${anchorBadge.className}`}
+              title={anchorBadge.title}
             >
-              Changed
+              {anchorBadge.label}
             </span>
           )}
           {resolveEnabled && (
@@ -421,6 +464,28 @@ export const CommentCard = memo(function CommentCard({
                     Resolve
                   </ActionButton>
                 )}
+            {/* A recovered comment is attached but pointing somewhere it was
+                never written against, and the marker on disk still holds the
+                stale anchor. Without this it is the one detached state with no
+                way out: excluded from "Needs re-anchoring", so no re-anchor
+                button, no orphan toast, and nothing the reviewer can act on.
+                One click writes the recovery into the file and ends it. */}
+            {comment.recoveredAnchor && onReanchorToSelection && (
+              <ActionButton
+                intent="primary"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onReanchorToSelection(
+                    comment.id,
+                    comment.recoveredAnchor!,
+                    comment.cleanOffset ?? undefined,
+                  );
+                }}
+                title={`Write this anchor into the file, replacing "${comment.anchor}"`}
+              >
+                Keep this anchor
+              </ActionButton>
+            )}
             {showAnchorContext &&
               selectionText &&
               selectionText.trim().length > 0 &&

--- a/src/components/CommentListSurface.tsx
+++ b/src/components/CommentListSurface.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import type { MdComment } from '../types';
-import { getEffectiveStatus } from '../types';
+import { anchorSearchText, getEffectiveStatus } from '../types';
 import type { SidebarCommentEditorState } from '../lib/comment-editor-state';
 import { ThreadCard } from './ThreadCard';
 import { useSettings } from '../contexts/SettingsContext';
@@ -149,7 +149,7 @@ export function CommentListSurface({
     const hiddenBySearch =
       search !== '' &&
       !c.text.toLowerCase().includes(q) &&
-      !c.anchor.toLowerCase().includes(q) &&
+      !anchorSearchText(c).includes(q) &&
       !c.author.toLowerCase().includes(q) &&
       !(c.replies?.some((r) => r.text.toLowerCase().includes(q)) ?? false);
     if (hiddenBySearch) setSearch('');
@@ -216,7 +216,7 @@ export function CommentListSurface({
     if (search) {
       const q = search.toLowerCase();
       const matchesText = c.text.toLowerCase().includes(q);
-      const matchesAnchor = c.anchor.toLowerCase().includes(q);
+      const matchesAnchor = anchorSearchText(c).includes(q);
       const matchesAuthor = c.author.toLowerCase().includes(q);
       const matchesReply = c.replies?.some((r) => r.text.toLowerCase().includes(q)) ?? false;
       if (!matchesText && !matchesAnchor && !matchesAuthor && !matchesReply) return false;
@@ -379,6 +379,7 @@ export function CommentListSurface({
               }
             }}
             anchorMissing={missingAnchors.has(comment.id)}
+            onReanchorToSelection={onReanchorToSelection}
             sent={sentCommentIds?.includes(comment.id) ?? false}
             onSelect={onActivate}
             onResolve={resolveEnabled ? onResolve : undefined}
@@ -422,6 +423,7 @@ export function CommentListSurface({
               }
             }}
             anchorMissing={missingAnchors.has(comment.id)}
+            onReanchorToSelection={onReanchorToSelection}
             sent={sentCommentIds?.includes(comment.id) ?? false}
             onSelect={onActivate}
             onResolve={resolveEnabled ? onResolve : undefined}

--- a/src/components/CommentsRail.tsx
+++ b/src/components/CommentsRail.tsx
@@ -329,6 +329,7 @@ function AnchoredCards({
   onDeleteReply,
   onContextMenu,
   requestedEditor,
+  onReanchorToSelection,
 }: CommentsRailProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
@@ -466,6 +467,7 @@ function AnchoredCards({
                 layout.orphanIds.includes(comment.id) || missingAnchors.has(comment.id)
               }
               sent={sentCommentIds.includes(comment.id)}
+              onReanchorToSelection={onReanchorToSelection}
               onSelect={onActivate}
               onReply={onReply}
               onResolve={onResolve}

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -290,18 +290,31 @@ export const MarkdownViewer = memo(
         // tooling) and never a space, since a space separator lets
         // ["a b", "c"] and ["a", "b c"] produce the same key: the very
         // collision class this key exists to prevent.
+        // A rewritten anchor highlights against its recovered text, so the
+        // comment keeps a home in the document instead of dropping its mark.
+        //
+        // Its stored context is dropped along with the old anchor. Those
+        // strings describe the neighborhood of text that no longer exists, and
+        // pickLiteralOccurrence scores context overlap ABOVE proximity to the
+        // hint offset — so a stale contextBefore that happens to match another
+        // occurrence of the recovered text wins outright and paints the mark in
+        // the wrong place. With no context it falls back to the marker
+        // position, which is exactly where recovery took the text from.
+        const anchorText = comment.recoveredAnchor ?? comment.anchor;
+        const contextBefore = comment.recoveredAnchor ? undefined : comment.contextBefore;
+        const contextAfter = comment.recoveredAnchor ? undefined : comment.contextAfter;
         const key = [
           comment.cleanOffset ?? '',
-          comment.anchor,
-          comment.contextBefore ?? '',
-          comment.contextAfter ?? '',
+          anchorText,
+          contextBefore ?? '',
+          contextAfter ?? '',
         ].join('\u0000');
         const group = highlightGroups.get(key) || {
           ids: [],
-          anchor: comment.anchor,
+          anchor: anchorText,
           plainOffset,
-          contextBefore: comment.contextBefore,
-          contextAfter: comment.contextAfter,
+          contextBefore,
+          contextAfter,
         };
         group.ids.push(comment.id);
         highlightGroups.set(key, group);

--- a/src/hooks/useContextMenuItems.ts
+++ b/src/hooks/useContextMenuItems.ts
@@ -5,7 +5,7 @@ import type { ExplorerContextMenuInfo } from '../components/FileExplorer';
 import type { TabContextMenuInfo } from '../components/TabBar';
 import type { SidebarContextMenuInfo } from '../components/CommentListSurface';
 import type { MdComment, SelectionInfo } from '../types';
-import { getEffectiveStatus } from '../types';
+import { displayAnchor, getEffectiveStatus } from '../types';
 import { getParentDir, getPathBasename } from '../lib/path-utils';
 
 type ContextMenuInstance = {
@@ -175,7 +175,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
           { type: 'divider' as const },
           {
             label: 'Copy Anchor Text',
-            onClick: () => navigator.clipboard.writeText(comment.anchor),
+            onClick: () => navigator.clipboard.writeText(displayAnchor(comment)),
           },
           {
             label: 'Copy Comment Text',
@@ -388,7 +388,10 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
         ...resolveItems,
         { label: 'Delete', danger: true, onClick: () => handleDelete(info.commentId) },
         { type: 'divider' as const },
-        { label: 'Copy Anchor Text', onClick: () => navigator.clipboard.writeText(comment.anchor) },
+        {
+          label: 'Copy Anchor Text',
+          onClick: () => navigator.clipboard.writeText(displayAnchor(comment)),
+        },
         { label: 'Copy Comment Text', onClick: () => navigator.clipboard.writeText(comment.text) },
         { type: 'divider' as const },
         {

--- a/src/lib/agent-prompts.test.ts
+++ b/src/lib/agent-prompts.test.ts
@@ -71,6 +71,47 @@ describe('buildAddressCommentsPrompt', () => {
   });
 });
 
+describe('buildAddressCommentsPrompt — anchor maintenance', () => {
+  // A rewrite that leaves anchors pointing at text it deleted detaches the
+  // review from the document, and the reviewer only finds out afterwards. The
+  // prompt has to say the anchor is a lookup key, not just a description.
+  it.each([true, false])(
+    'tells the agent to keep anchors in sync (resolve=%s)',
+    (enableResolve) => {
+      const prompt = buildAddressCommentsPrompt({
+        filePaths: ['/tmp/spec.md'],
+        commentCounts: new Map([['/tmp/spec.md', 3]]),
+        enableResolve,
+      });
+
+      expect(prompt).toContain('## Keeping anchors valid');
+      expect(prompt).toContain('lookup key');
+      expect(prompt).toContain('contextBefore');
+      expect(prompt).toMatch(
+        /Never leave an `anchor` pointing at text that is no longer in the file/,
+      );
+    },
+  );
+
+  it('covers resolved comments, not just the ones left open', () => {
+    const prompt = buildAddressCommentsPrompt({
+      filePaths: ['/tmp/spec.md'],
+      commentCounts: new Map([['/tmp/spec.md', 1]]),
+      enableResolve: true,
+    });
+    expect(prompt).toContain('comments you resolve as well as ones you leave open');
+  });
+
+  it('tells the agent to say so rather than re-point a deleted anchor', () => {
+    const prompt = buildAddressCommentsPrompt({
+      filePaths: ['/tmp/spec.md'],
+      commentCounts: new Map([['/tmp/spec.md', 1]]),
+      enableResolve: true,
+    });
+    expect(prompt).toContain('re-pointing the anchor at unrelated text');
+  });
+});
+
 describe('buildAddressCommentsPrompt — mdr_ask hint', () => {
   it('mentions the mdr_ask tool so agents know it exists', () => {
     const prompt = buildAddressCommentsPrompt({

--- a/src/lib/agent-prompts.ts
+++ b/src/lib/agent-prompts.ts
@@ -40,9 +40,20 @@ export function buildAddressCommentsPrompt({
 Comments are embedded as HTML comment markers: \`<!-- @comment{JSON} -->\`
 Each marker is placed immediately before the text it refers to (the "anchor").
 The JSON contains these fields:
-- \`anchor\`: the exact text the comment refers to
+- \`anchor\`: the exact text the comment refers to, and the key md-redline uses to find it (see "Keeping anchors valid" below)
 - \`text\`: my feedback - this is what I need you to address
 - \`replies\`: threaded discussion - read for additional context
+- \`contextBefore\` / \`contextAfter\`: optional snippets of the text surrounding the anchor when I wrote the comment, used to disambiguate repeated text
+
+## Keeping anchors valid
+
+The \`anchor\` field is how md-redline locates a comment in the document. It is not a description, it is a lookup key: if the exact text stops existing, the comment detaches from the document and I lose the thread of what it was about.
+
+So whenever an edit rewrites, restructures, or moves the text a marker points at, update that marker's \`anchor\` in the same edit so it quotes the new text that replaced it. This applies to comments you resolve as well as ones you leave open. Never leave an \`anchor\` pointing at text that is no longer in the file.
+
+When you change an \`anchor\`, **delete** that marker's \`contextBefore\` and \`contextAfter\` rather than trying to rewrite them. Both fields are optional. They describe where the OLD anchor sat, so leaving them is actively wrong: md-redline weighs a context match above the marker's own position, and stale context will pull the highlight onto the wrong copy of repeated text. Removing them lets it fall back to the marker position, which is correct by construction.
+
+If the anchored text is deleted outright with nothing replacing it, say so in your reply rather than re-pointing the anchor at unrelated text.
 
 ## Identifying yourself
 

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -802,7 +802,296 @@ describe('orderCommentsByAnchor', () => {
   });
 });
 
+describe('anchor recovery after a rewrite', () => {
+  // An agent that restructures a document while addressing comments leaves the
+  // markers in place and rewrites the text around them. The marker's position
+  // still points at whatever replaced the anchored text, which is the signal
+  // recovery runs on.
+  const rewritten = [
+    '# Notes',
+    '',
+    '<!-- @comment{"id":"c1","anchor":"Is it already live?","text":"Turn this into a decision","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->',
+    '### A1. One terminal screen at the end of setup',
+    '',
+    'It does not claim to be live.',
+  ].join('\n');
+
+  it('recovers a rewritten anchor from the text following the marker', () => {
+    const { comments } = parseComments(rewritten);
+    expect(comments[0].anchorStale).toBe(true);
+    expect(comments[0].recoveredAnchor).toBe('A1. One terminal screen at the end of setup');
+  });
+
+  it('does not report a recovered comment as orphaned', () => {
+    const { comments, cleanMarkdown } = parseComments(rewritten);
+    expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(false);
+  });
+
+  it('leaves intact anchors untouched', () => {
+    const intact = [
+      '<!-- @comment{"id":"c1","anchor":"still here","text":"x","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->still here',
+    ].join('\n');
+    const { comments } = parseComments(intact);
+    expect(comments[0].anchorStale).toBeUndefined();
+    expect(comments[0].recoveredAnchor).toBeUndefined();
+  });
+
+  it('does not treat a formatting-only difference as a stale anchor', () => {
+    // The anchor came from rendered text, so it carries no ** markers.
+    const formatted =
+      '<!-- @comment{"id":"c1","anchor":"the bold claim","text":"x","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->**the bold claim** follows';
+    const { comments } = parseComments(formatted);
+    expect(comments[0].anchorStale).toBeUndefined();
+    expect(comments[0].recoveredAnchor).toBeUndefined();
+  });
+
+  it('reports a genuine orphan when nothing follows the marker', () => {
+    const stranded =
+      '# Notes\n\nSome kept text.\n\n<!-- @comment{"id":"c1","anchor":"deleted paragraph","text":"x","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->';
+    const { comments, cleanMarkdown } = parseComments(stranded);
+    expect(comments[0].anchorStale).toBe(true);
+    expect(comments[0].recoveredAnchor).toBeUndefined();
+    expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+  });
+
+  it('rejects replacement text too short to identify anything', () => {
+    const tiny =
+      '<!-- @comment{"id":"c1","anchor":"a long deleted sentence","text":"x","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->\n## Hi\n';
+    const { comments } = parseComments(tiny);
+    expect(comments[0].anchorStale).toBe(true);
+    expect(comments[0].recoveredAnchor).toBeUndefined();
+  });
+
+  it('strips list scaffolding from the recovered anchor', () => {
+    const list =
+      '<!-- @comment{"id":"c1","anchor":"Ways to auto move a deal","text":"x","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->\n- **A quick way to move a lead to another stage**, likely in a kanban view\n';
+    const { comments } = parseComments(list);
+    expect(comments[0].recoveredAnchor).toBe(
+      'A quick way to move a lead to another stage, likely in a kanban view',
+    );
+  });
+
+  // Each of these produced a wrong anchor before its guard existed. The shape
+  // they share: recovery attached the comment to text that was not its own,
+  // and the recoveredAnchor then suppressed the orphan badge that would have
+  // told the reviewer to look.
+  describe('guards against attaching to the wrong text', () => {
+    const stale = (anchor: string, extra = '') =>
+      `<!-- @comment{"id":"c1","anchor":${JSON.stringify(anchor)},"text":"x","author":"PM","timestamp":"2026-08-06T10:00:00Z"${extra}} -->`;
+
+    it('recovers from the marker position, not the fuzzy-relocated offset', () => {
+      // The contextAfter-only fallback rewinds cleanOffset by the OLD anchor's
+      // length, which a rewrite is exactly what invalidates. Following it
+      // landed mid-word in the PRECEDING paragraph.
+      const raw = `# Doc\n\nSome earlier paragraph with words words words words here.\n\n${stale(
+        'the original anchor sentence that was deleted',
+        ',"contextAfter":" and then the trailing context follows."',
+      )} and then the trailing context follows.\n`;
+      const { comments } = parseComments(raw);
+      expect(comments[0].recoveredAnchor).toBe('and then the trailing context follows.');
+    });
+
+    it('does not cross a blank line onto an unrelated later section', () => {
+      const raw = `# Doc\n\nKept paragraph.\n\n${stale('a paragraph that was deleted entirely')}\n\n## Unrelated Later Section\n\nBody.\n`;
+      const { comments, cleanMarkdown } = parseComments(raw);
+      expect(comments[0].recoveredAnchor).toBeUndefined();
+      expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+    });
+
+    it('refuses a table row, whose cells run together in the DOM', () => {
+      // An earlier pass collapsed the cell pipes to spaces and produced
+      // "Metric Target Owner name here". Rendering the same document shows the
+      // DOM concatenates adjacent cells with NO separator
+      // ("MetricTargetOwnername here"), and flexibleIndexOf requires at least
+      // one whitespace character between parts — so the spaced candidate could
+      // never be located, while still suppressing the orphan badge. There is
+      // no readable extraction that matches, so recovery declines the row.
+      const raw = `# Doc\n\n${stale('the deleted sentence')}| Metric | Target | Owner name here |\n|---|---|---|\n| Revenue | 100 | Dana |\n`;
+      const { comments, cleanMarkdown } = parseComments(raw);
+      expect(comments[0].recoveredAnchor).toBeUndefined();
+      expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+    });
+
+    it('still recovers a line whose only pipe is inside inline code', () => {
+      // A union type or CLI flag in backticks is text the reader sees, so the
+      // cell-separator check must not treat it as a table row.
+      const raw = `# Doc\n\n${stale('the deleted sentence')}The mode field takes \`'ask' | 'review'\` and nothing else.\n`;
+      const { comments } = parseComments(raw);
+      expect(comments[0].recoveredAnchor).toBe(
+        "The mode field takes 'ask' | 'review' and nothing else.",
+      );
+    });
+
+    it('refuses a footnote definition, whose body renders elsewhere', () => {
+      // rehype moves footnote bodies into a separate Footnotes section and
+      // drops the `[^1]: ` marker, so the marker's position says nothing about
+      // where the text lands and the extracted ": body" prefix matches nothing.
+      const raw = `# Doc\n\nBody with a ref[^1].\n\n${stale('the deleted note')}[^1]: The footnote body text goes here.\n`;
+      const { comments, cleanMarkdown } = parseComments(raw);
+      expect(comments[0].recoveredAnchor).toBeUndefined();
+      expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+    });
+
+    it('refuses to recover onto a table delimiter row', () => {
+      // A `|---|` row is the shape that needs this guard specifically: it
+      // survives the length floor, so without STRUCTURE_ONLY_LINE it would be
+      // accepted as an anchor. A ```ts fence would be refused here too, but is
+      // also caught by the floor, so it cannot tell the two apart.
+      const raw = `# Doc\n\n${stale('the deleted caption')}\n|--------|--------|--------|\n| A | B | C |\n`;
+      const { comments } = parseComments(raw);
+      expect(comments[0].recoveredAnchor).toBeUndefined();
+    });
+
+    // insertComment moves a marker out of any container that cannot hold one,
+    // which breaks the "immediately before its anchor" contract recovery runs
+    // on. These build the marker with insertComment rather than by hand, so
+    // the relocation actually happens rather than being assumed.
+    describe('markers relocated out of protected containers', () => {
+      it('does not recover a frontmatter comment onto the document title', () => {
+        // Frontmatter is the container the marker TRAILS, so the text ahead of
+        // it is the body, not the field the comment is about.
+        const doc =
+          '---\nstatus: draft\nowner: dana\n---\n# A Fully Written Out Document Title Right Here\n\nBody text here.\n';
+        const withComment = insertComment(
+          doc,
+          'status: draft',
+          'is this still draft?',
+          'PM',
+          undefined,
+          undefined,
+          undefined,
+          'c1',
+        );
+        const rewritten = withComment.replace(/^status: draft$/m, 'status: shipped');
+        const { comments, cleanMarkdown } = parseComments(rewritten);
+        expect(comments[0].recoveredAnchor).toBeUndefined();
+        expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+      });
+
+      it('does not recover an HTML-comment anchor into raw comment syntax', () => {
+        // rehype drops HTML comments, so `<!-- ... -->` as an anchor could
+        // never be located in the rendered document: the badge would say
+        // re-anchored while no highlight existed anywhere.
+        const doc = '# Doc\n\n<!-- TODO: secret note here -->\n\nVisible body paragraph.\n';
+        const withComment = insertComment(
+          doc,
+          'TODO: secret note here',
+          'still needed?',
+          'PM',
+          undefined,
+          undefined,
+          undefined,
+          'c1',
+        );
+        const rewritten = withComment.replace(
+          '<!-- TODO: secret note here -->',
+          '<!-- TODO: totally different content now -->',
+        );
+        const { comments, cleanMarkdown } = parseComments(rewritten);
+        expect(comments[0].recoveredAnchor).toBeUndefined();
+        expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+      });
+
+      it('does not recover a fenced-code comment onto the fence line', () => {
+        // Refused by NON_PROSE_LINE rather than by accident.
+        const doc = '# Doc\n\n```ts\nconst answer = 42;\n```\n\nAfter.\n';
+        const withComment = insertComment(
+          doc,
+          'const answer = 42;',
+          'magic number',
+          'PM',
+          undefined,
+          undefined,
+          undefined,
+          'c1',
+        );
+        const rewritten = withComment.replace('const answer = 42;', 'const answer = compute();');
+        const { comments, cleanMarkdown } = parseComments(rewritten);
+        expect(comments[0].recoveredAnchor).toBeUndefined();
+        expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+      });
+    });
+
+    it('refuses a candidate carrying an HTML entity, which the DOM never shows', () => {
+      // Recovery is the only producer of anchors read out of SOURCE text, so
+      // it is the only place `&amp;` can reach an anchor while the rendered
+      // document holds `&`. anchorResolves compares against the source and
+      // cannot see the divergence, so storing it would suppress the orphan
+      // badge while the viewer matched nothing.
+      const raw = `# Doc\n\n${stale('the old paragraph')}Tom &amp; Jerry are the canonical duo here\n`;
+      const { comments, cleanMarkdown } = parseComments(raw);
+      expect(comments[0].recoveredAnchor).toBeUndefined();
+      expect(detectMissingAnchors(cleanMarkdown, comments).has('c1')).toBe(true);
+    });
+
+    it('points cleanOffset back at the marker once recovery succeeds', () => {
+      // cleanOffset is the disambiguating hint for both the viewer's
+      // occurrence picker and moveComment behind "Keep this anchor". The fuzzy
+      // re-match aimed it at where it guessed the OLD anchor went, and that
+      // anchor is gone by definition here.
+      const raw = `# Doc\n\nEarlier paragraph with plenty of words in it here.\n\n${stale(
+        'the deleted anchor sentence',
+        ',"contextAfter":" and the trailing context follows on."',
+      )} and the trailing context follows on.\n`;
+      const { comments, cleanMarkdown } = parseComments(raw);
+      const c = comments[0];
+      expect(c.recoveredAnchor).toBe('and the trailing context follows on.');
+      // The hint must land on the recovered text, not in the paragraph above it.
+      expect(cleanMarkdown.slice(c.cleanOffset!).trimStart()).toMatch(/^and the trailing context/);
+    });
+
+    it('truncates a long line back to a word boundary, keeping it locatable', () => {
+      const long =
+        'This replacement paragraph runs well past the hundred and twenty character ceiling that the recovered anchor is allowed to occupy before it gets cut.';
+      const raw = `# Doc\n\n${stale('the deleted sentence')}${long}\n`;
+      const { comments, cleanMarkdown } = parseComments(raw);
+      const recovered = comments[0].recoveredAnchor!;
+      expect(recovered.length).toBeLessThanOrEqual(120);
+      // Cut at a word boundary, not mid-word...
+      expect(long.startsWith(recovered)).toBe(true);
+      expect(long[recovered.length]).toBe(' ');
+      // ...and still a prefix that resolves, which is what makes it usable as
+      // an anchor at all.
+      expect(stripInlineFormatting(cleanMarkdown).plain.includes(recovered)).toBe(true);
+    });
+
+    it('does not recover onto another comment’s still-live anchor', () => {
+      const raw = `# Doc\n\n${stale('deleted one')}\n<!-- @comment{"id":"c2","anchor":"second anchor text","text":"y","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->second anchor text\n`;
+      const { comments } = parseComments(raw);
+      expect(comments.find((c) => c.id === 'c1')?.recoveredAnchor).toBeUndefined();
+    });
+
+    it('still recovers for comments clustered on one rewritten block', () => {
+      // Neither anchor resolves any more, so the live-anchor guard must not
+      // fire: both comments legitimately point at the text that replaced them.
+      const raw = `# Doc\n\n${stale('first dead quote')}<!-- @comment{"id":"c2","anchor":"second dead quote","text":"y","author":"PM","timestamp":"2026-08-06T10:00:00Z"} -->### A3. The decision that replaced both\n`;
+      const { comments } = parseComments(raw);
+      expect(comments.map((c) => c.recoveredAnchor)).toEqual([
+        'A3. The decision that replaced both',
+        'A3. The decision that replaced both',
+      ]);
+    });
+  });
+
+  it('never writes the recovered anchor back into the marker', () => {
+    const { comments } = parseComments(rewritten);
+    const serialized = serializeComment(comments[0]);
+    expect(serialized).not.toContain('recoveredAnchor');
+    expect(serialized).not.toContain('anchorStale');
+    expect(serialized).toContain('"anchor":"Is it already live?"');
+  });
+});
+
 describe('detectMissingAnchors', () => {
+  it('skips resolved comments by default but flags them on request', () => {
+    const clean = 'Only this text survives';
+    const comments = [
+      { id: 'a', anchor: 'deleted text', status: 'resolved' },
+    ] as unknown as MdComment[];
+    expect(detectMissingAnchors(clean, comments).has('a')).toBe(false);
+    expect(detectMissingAnchors(clean, comments, { includeResolved: true }).has('a')).toBe(true);
+  });
+
   it('returns empty set when all anchors are present', () => {
     const clean = 'Hello world, this is a test';
     const comments = [
@@ -1572,9 +1861,32 @@ describe('fuzzy re-matching', () => {
     expect(parsed.comments).toHaveLength(1);
     const clean = parsed.cleanMarkdown;
     expect(clean).toBe('prefix text changed text and the rest follows here.');
-    const afterIdx = clean.indexOf(' and the rest follows');
-    // cleanOffset is positioned anchor.length chars before contextAfter
-    // so the marker re-attaches to the right region
+    // The fallback positions cleanOffset anchor.length chars before
+    // contextAfter, which lands mid-word ("ged text") because it subtracts the
+    // length of an anchor that no longer exists. Recovery succeeds for this
+    // comment and supersedes that guess with the marker's own position, which
+    // is where the replacement text actually starts. Asserting the old
+    // mid-word offset would be pinning the artifact rather than the behavior.
+    expect(parsed.comments[0].cleanOffset).toBe('prefix text '.length);
+    expect(parsed.comments[0].recoveredAnchor).toBe('changed text and the rest follows here.');
+  });
+
+  it('keeps the contextAfter-only fallback offset when recovery cannot run', () => {
+    // Same fallback, but the marker is stranded at end of file so recovery
+    // returns null and does not override. This is what still exercises
+    // fuzzyReMatch's own result.
+    const comment: MdComment = {
+      id: 'after-only-2',
+      anchor: 'old text',
+      text: 'note',
+      author: 'User',
+      timestamp: '2024-01-01T00:00:00.000Z',
+      contextAfter: ' and the rest follows',
+    };
+    const raw = `prefix text and the rest follows here.\n\n${serializeComment(comment)}`;
+    const parsed = parseComments(raw);
+    const afterIdx = parsed.cleanMarkdown.indexOf(' and the rest follows');
+    expect(parsed.comments[0].recoveredAnchor).toBeUndefined();
     expect(parsed.comments[0].cleanOffset).toBe(Math.max(0, afterIdx - comment.anchor.length));
   });
 

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -1,4 +1,10 @@
-import { getEffectiveStatus, type MdComment, type ParseResult, type CommentReply } from '../types';
+import {
+  displayAnchor,
+  getEffectiveStatus,
+  type MdComment,
+  type ParseResult,
+  type CommentReply,
+} from '../types';
 import { randomId } from './random-id';
 
 // Match <!-- @comment{...JSON...} --> — use dotall flag so JSON with
@@ -271,7 +277,16 @@ export function transformCommentMarkers(
 
 export function parseComments(rawMarkdown: string): ParseResult {
   const comments: MdComment[] = [];
-  const strippedRegions: { rawStart: number; rawEnd: number; parsed: boolean }[] = [];
+  const strippedRegions: {
+    rawStart: number;
+    rawEnd: number;
+    parsed: boolean;
+    /** A standalone marker takes its own trailing newline with it, so the
+     * anchor on the next line ends up flush against the marker's offset.
+     * Recovery needs to know, or it cannot tell that layout apart from an
+     * inline marker whose anchor really is one line down. */
+    consumedNewline: boolean;
+  }[] = [];
 
   for (const region of collectCommentRegions(rawMarkdown)) {
     if (region.parsedComment) {
@@ -281,6 +296,7 @@ export function parseComments(rawMarkdown: string): ParseResult {
       rawStart: region.rawStart,
       rawEnd: region.stripEnd,
       parsed: region.parsedComment !== null,
+      consumedNewline: region.stripEnd > region.markerEnd,
     });
   }
 
@@ -298,11 +314,19 @@ export function parseComments(rawMarkdown: string): ParseResult {
   // this is the start of the anchor text in the clean content.
   let cumShift = 0;
   let commentIdx = 0;
+  // The marker's own position, kept separately because the fuzzy re-match below
+  // moves cleanOffset to a GUESS at where the anchor region went. Recovery
+  // needs the position the marker actually occupies, which is exact.
+  const markerOffsets = new Map<string, { offset: number; newlineBudget: number }>();
   for (let i = 0; i < strippedRegions.length; i++) {
     const region = strippedRegions[i];
     const cleanPos = region.rawStart - cumShift;
     if (region.parsed && comments[commentIdx]) {
       comments[commentIdx].cleanOffset = cleanPos;
+      markerOffsets.set(comments[commentIdx].id, {
+        offset: cleanPos,
+        newlineBudget: region.consumedNewline ? 0 : 1,
+      });
       commentIdx++;
     }
     cumShift += region.rawEnd - region.rawStart;
@@ -325,6 +349,77 @@ export function parseComments(rawMarkdown: string): ParseResult {
     const newOffset = fuzzyReMatch(cleanMarkdown, comment);
     if (newOffset !== null) {
       comment.cleanOffset = newOffset;
+    }
+  }
+
+  // Anchor recovery. A marker is written immediately before the text it
+  // anchors to, so when an edit rewrites that text but leaves the marker in
+  // place, the marker's own position still points at whatever replaced it.
+  // Recovering from position keeps the comment attached through a rewrite
+  // that would otherwise detach it, and the card badges the recovery so the
+  // reviewer can confirm it rather than trusting it silently.
+  //
+  // Recovery reads markerOffsets, never the possibly-relocated cleanOffset.
+  // The fuzzy re-match above can rewind an offset by the OLD anchor's length
+  // (its contextAfter-only fallback), which a rewrite is exactly what
+  // invalidates — following it lands mid-word in the preceding paragraph.
+  //
+  // The stripped document is built lazily: documents with no stale anchors —
+  // the overwhelming majority — never pay for it.
+  // insertComment relocates a marker out of every container that cannot hold
+  // one, which breaks the "immediately before its anchor" contract recovery
+  // runs on. Frontmatter is the case position alone cannot detect: it is the
+  // one container the marker TRAILS (frontmatter is only recognized at offset
+  // 0, so there is nowhere above it to go), leaving the marker parked on the
+  // closing fence with its anchor behind it and the document's first heading
+  // ahead. Recovering there silently re-points a comment about a frontmatter
+  // field at the page title. The other two containers are refused by
+  // NON_PROSE_LINE, which the fence and HTML-comment layouts both trip.
+  const frontmatterEnd = getFrontmatterRange(cleanMarkdown)?.end;
+
+  let plainDoc: string | null = null;
+  let mermaidDoc: string | null = null;
+  let liveAnchors: Set<string> | null = null;
+  for (const comment of comments) {
+    const marker = markerOffsets.get(comment.id);
+    if (marker === undefined) continue;
+    if (cleanMarkdown.includes(comment.anchor)) continue;
+    if (plainDoc === null) {
+      plainDoc = stripInlineFormatting(cleanMarkdown).plain;
+      mermaidDoc = extractMermaidText(cleanMarkdown);
+      // Anchors that still resolve belong to the comments holding them. A
+      // stale marker sitting just before one of them must not recover onto it:
+      // that text has an owner. Comments clustered on the SAME rewritten block
+      // are unaffected, since none of their anchors resolves any more.
+      liveAnchors = new Set(
+        comments
+          .filter((c) => anchorResolves(c.anchor, plainDoc!, mermaidDoc ?? ''))
+          .map((c) => c.anchor),
+      );
+    }
+    if (anchorResolves(comment.anchor, plainDoc, mermaidDoc ?? '')) continue;
+    comment.anchorStale = true;
+    const recovered =
+      marker.offset === frontmatterEnd
+        ? null
+        : recoverAnchorAtOffset(cleanMarkdown, marker.offset, marker.newlineBudget);
+    // A candidate that cannot be located is worse than none: it would suppress
+    // the orphan badge (recoveredAnchor short-circuits detectMissingAnchors)
+    // while the viewer highlights nothing, leaving the comment both unmarked
+    // and unflagged. Validate through the same matcher every other anchor uses.
+    if (
+      recovered !== null &&
+      recovered !== comment.anchor &&
+      !liveAnchors?.has(recovered) &&
+      anchorResolves(recovered, plainDoc, mermaidDoc ?? '')
+    ) {
+      comment.recoveredAnchor = recovered;
+      // Point the offset back at the marker. The fuzzy re-match above aimed it
+      // at where it guessed the OLD anchor went, and that anchor is gone by
+      // definition here — leaving the guess in place feeds a stale hint to the
+      // viewer's occurrence picker and to moveComment when the reviewer clicks
+      // "Keep this anchor", which picks the wrong copy of repeated text.
+      comment.cleanOffset = marker.offset;
     }
   }
 
@@ -391,10 +486,102 @@ function fuzzyReMatch(cleanMarkdown: string, comment: MdComment): number | null 
   return null;
 }
 
+/** Longest recovered anchor to keep. Long enough to identify a heading or a
+ * sentence opener, short enough that the card quote stays readable. */
+const MAX_RECOVERED_ANCHOR = 120;
+/** Below this, the recovered text is too generic to be worth re-anchoring to. */
+const MIN_RECOVERED_ANCHOR = 8;
+/** List bullets, heading hashes, blockquote arrows, ordered-list numbering and
+ * leading table pipes: document scaffolding that is never part of an anchor. */
+const LEADING_SCAFFOLDING = /^(?:#{1,6}\s+|[-*+]\s+|>\s*|\d+[.)]\s+|\|\s*)+/;
+/**
+ * Lines recovery refuses, because nothing it could extract from them would be
+ * findable in the rendered document. Recovery is the ONLY producer of anchors
+ * read out of source text — every other anchor comes from DOM textContent —
+ * and `anchorResolves` also compares against source, so it structurally cannot
+ * catch a source-only string. Each entry here is a construct where source and
+ * rendered text diverge:
+ *
+ * - fence delimiters and `|---|` rows: not text at all
+ * - HTML comments: dropped by rehype
+ * - table rows: adjacent cells concatenate with NO separator in the DOM
+ *   (`MetricTargetOwner`), while any readable extraction would put something
+ *   between them; `flexibleIndexOf` requires at least one whitespace character
+ *   between parts, so a spaced candidate can never match
+ * - footnote definitions: rendered into a separate Footnotes section, so the
+ *   marker's position says nothing about where the text ends up
+ */
+const NON_PROSE_LINE =
+  /^(?:```|~~~|<!--|\[\^[^\]]*\]:|\|?\s*:?-{3,}:?\s*(?:\|\s*:?-+:?\s*)*\|?\s*$)/;
+/** Inline code spans, removed before looking for table cell separators: a pipe
+ * inside backticks is a union type or a CLI flag the reader really does see,
+ * not a cell boundary. */
+const INLINE_CODE_SPAN = /`[^`]*`/g;
+/**
+ * An HTML entity in the source. Recovery is the only producer of anchors read
+ * out of source text — every other anchor comes from DOM textContent — so it
+ * is the only place where `&amp;` can reach an anchor while the rendered
+ * document holds `&`. `anchorResolves` compares against the source too and
+ * cannot catch the divergence, so the candidate would be stored, suppress the
+ * orphan badge, and match nothing in the viewer. Fail closed instead: the
+ * comment orphans loudly, exactly as it did before recovery existed.
+ */
+const HTML_ENTITY = /&(?:#\d+|#[xX][0-9a-fA-F]+|[a-zA-Z][a-zA-Z0-9]*);/;
+
+/**
+ * Derive a replacement anchor from the text that now follows a marker.
+ *
+ * `newlineBudget` is how many newlines may separate the marker's offset from
+ * its anchor before the two count as different blocks: 0 for a standalone
+ * marker (whose own trailing newline was already stripped, leaving the next
+ * line flush against the offset) and 1 for an inline marker that ends its
+ * line. Crossing a blank line means the block the marker introduced is gone
+ * rather than rewritten, and skipping over it would silently re-point the
+ * comment at an unrelated later section while suppressing its orphan badge.
+ *
+ * Returns null when nothing usable follows — the marker sits at the end of
+ * the file, or a blank line separates it from the next content, or that
+ * content is pure structure — in which case the comment is genuinely orphaned
+ * and should be flagged as such.
+ */
+export function recoverAnchorAtOffset(
+  cleanMarkdown: string,
+  cleanOffset: number,
+  newlineBudget: number,
+): string | null {
+  let start = cleanOffset;
+  let newlines = 0;
+  while (start < cleanMarkdown.length && /\s/.test(cleanMarkdown[start])) {
+    if (cleanMarkdown[start] === '\n' && ++newlines > newlineBudget) return null;
+    start++;
+  }
+  if (start >= cleanMarkdown.length) return null;
+
+  const lineEnd = cleanMarkdown.indexOf('\n', start);
+  const line = cleanMarkdown.slice(start, lineEnd === -1 ? cleanMarkdown.length : lineEnd);
+  const trimmed = line.trim();
+  if (NON_PROSE_LINE.test(trimmed) || HTML_ENTITY.test(line)) return null;
+  if (trimmed.replace(INLINE_CODE_SPAN, '').includes('|')) return null;
+  const body = line.replace(LEADING_SCAFFOLDING, '').trim();
+  if (!body) return null;
+
+  let candidate = stripInlineFormatting(body).plain.trim();
+  if (candidate.length > MAX_RECOVERED_ANCHOR) {
+    candidate = candidate.slice(0, MAX_RECOVERED_ANCHOR);
+    // Back off to a word boundary so the quote does not end mid-word. The
+    // result stays a prefix of the real text, so it still matches the document.
+    const lastSpace = candidate.lastIndexOf(' ');
+    if (lastSpace >= MIN_RECOVERED_ANCHOR) candidate = candidate.slice(0, lastSpace);
+    candidate = candidate.trim();
+  }
+  return candidate.length >= MIN_RECOVERED_ANCHOR ? candidate : null;
+}
+
 export function serializeComment(comment: MdComment): string {
-  // Strip cleanOffset — it's computed at parse time, not persisted
+  // Strip the parse-time fields — they're derived from the current document
+  // state on every parse, never persisted into the marker
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { cleanOffset, ...data } = comment;
+  const { cleanOffset, recoveredAnchor, anchorStale, ...data } = comment;
   // Escape --> and --!> in the JSON to prevent them from closing the HTML
   // comment prematurely. The HTML spec treats both as comment-close sequences.
   // \u003e is the Unicode escape for >, which JSON.parse decodes back to >
@@ -1740,7 +1927,10 @@ export function orderCommentsByAnchor(cleanMarkdown: string, comments: MdComment
       const withContext = cleanMarkdown.indexOf(comment.contextBefore + comment.anchor);
       if (withContext !== -1) return withContext + comment.contextBefore.length;
     }
-    const direct = cleanMarkdown.indexOf(comment.anchor);
+    // A recovered comment's stored anchor is by definition absent, so searching
+    // for it can only fail and leave the tie-break inert. Its recovered text is
+    // the string that actually sits in the document.
+    const direct = cleanMarkdown.indexOf(displayAnchor(comment));
     return direct === -1 ? (comment.cleanOffset ?? 0) : direct;
   };
   return [...comments].sort(
@@ -1748,50 +1938,76 @@ export function orderCommentsByAnchor(cleanMarkdown: string, comments: MdComment
   );
 }
 
-export function detectMissingAnchors(cleanMarkdown: string, comments: MdComment[]): Set<string> {
-  const missing = new Set<string>();
-  if (!cleanMarkdown) return missing;
-  // Compare against plain text (formatting stripped) since anchors come from
-  // DOM textContent which doesn't include markdown formatting markers like
-  // **, _, `, ~~, etc. Without this, anchors spanning formatted text would
-  // always be flagged as "changed".
-  const { plain } = stripInlineFormatting(cleanMarkdown);
-  // Also extract rendered text from mermaid blocks — anchors from mermaid SVG
-  // won't match the raw source syntax, but will match the extracted labels.
-  const mermaidText = extractMermaidText(cleanMarkdown);
-  for (const c of comments) {
-    if (getEffectiveStatus(c) === 'resolved') continue;
-    // First try matching the raw anchor against the stripped file content
-    // (the existing behavior that works for user-authored DOM-derived anchors).
-    if (plain.includes(c.anchor)) continue;
-    const parts = c.anchor.split(/\s+/).filter(Boolean);
-    if (parts.length === 0) continue;
-    if (partsAppearContiguously(plain, parts)) continue;
-    // Mermaid fallback for raw anchor
+/**
+ * Whether an anchor string still resolves against the document.
+ *
+ * `plain` is the document with inline formatting stripped, because anchors
+ * come from DOM textContent and carry no markdown markup like **, _, `, ~~.
+ * `mermaidText` is the rendered label text of any mermaid blocks, because
+ * anchors taken from a mermaid SVG will not match the raw source syntax.
+ * Both are computed once by the caller and reused across comments.
+ */
+function anchorResolves(anchor: string, plain: string, mermaidText: string): boolean {
+  // First try matching the raw anchor against the stripped file content
+  // (the existing behavior that works for user-authored DOM-derived anchors).
+  if (plain.includes(anchor)) return true;
+  const parts = anchor.split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return true;
+  if (partsAppearContiguously(plain, parts)) return true;
+  // Mermaid fallback for raw anchor
+  if (
+    mermaidText &&
+    (mermaidText.includes(anchor) || partsAppearContiguously(mermaidText, parts))
+  ) {
+    return true;
+  }
+
+  // Secondary pass: strip inline formatting from the anchor too and retry.
+  // Agent-authored anchors may contain markdown markup (e.g. `**Metric**: 30%`)
+  // because the agent reads raw file content. Stripping symmetrically lets
+  // these anchors match the plain-text file content.
+  const { plain: anchorPlain } = stripInlineFormatting(anchor);
+  if (anchorPlain !== anchor) {
+    if (plain.includes(anchorPlain)) return true;
+    const strippedParts = anchorPlain.split(/\s+/).filter(Boolean);
+    if (strippedParts.length > 0 && partsAppearContiguously(plain, strippedParts)) return true;
     if (
       mermaidText &&
-      (mermaidText.includes(c.anchor) || partsAppearContiguously(mermaidText, parts))
+      (mermaidText.includes(anchorPlain) || partsAppearContiguously(mermaidText, strippedParts))
     ) {
-      continue;
+      return true;
     }
+  }
 
-    // Secondary pass: strip inline formatting from the anchor too and retry.
-    // Agent-authored anchors may contain markdown markup (e.g. `**Metric**: 30%`)
-    // because the agent reads raw file content. Stripping symmetrically lets
-    // these anchors match the plain-text file content.
-    const { plain: anchorPlain } = stripInlineFormatting(c.anchor);
-    if (anchorPlain !== c.anchor) {
-      if (plain.includes(anchorPlain)) continue;
-      const strippedParts = anchorPlain.split(/\s+/).filter(Boolean);
-      if (strippedParts.length > 0 && partsAppearContiguously(plain, strippedParts)) continue;
-      if (
-        mermaidText &&
-        (mermaidText.includes(anchorPlain) || partsAppearContiguously(mermaidText, strippedParts))
-      ) {
-        continue;
-      }
-    }
+  return false;
+}
 
+export interface DetectMissingAnchorsOptions {
+  /**
+   * Also check resolved comments. Off by default so the rail keeps flagging
+   * only comments the reviewer can still act on, but the card badge turns it
+   * on: an agent that rewrites the document while resolving comments detaches
+   * resolved anchors just as thoroughly, and silently exempting them reports
+   * all-clear on a review whose history no longer points anywhere.
+   */
+  includeResolved?: boolean;
+}
+
+export function detectMissingAnchors(
+  cleanMarkdown: string,
+  comments: MdComment[],
+  options: DetectMissingAnchorsOptions = {},
+): Set<string> {
+  const missing = new Set<string>();
+  if (!cleanMarkdown) return missing;
+  const { plain } = stripInlineFormatting(cleanMarkdown);
+  const mermaidText = extractMermaidText(cleanMarkdown);
+  for (const c of comments) {
+    if (!options.includeResolved && getEffectiveStatus(c) === 'resolved') continue;
+    // Position recovery already found replacement text for this marker. The
+    // comment is re-anchored, not orphaned, and carries its own badge.
+    if (c.recoveredAnchor) continue;
+    if (anchorResolves(c.anchor, plain, mermaidText)) continue;
     missing.add(c.id);
   }
   return missing;

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,6 +22,27 @@ export interface MdComment {
   /** Character offset of the anchor's start position in the clean markdown. Computed at parse time, not stored in the file. */
   cleanOffset?: number;
   /**
+   * True when `anchor` no longer resolves against the document. Computed at
+   * parse time, not stored in the file. Set regardless of status, so a
+   * resolved comment detached by a later rewrite is still visible as such.
+   */
+  anchorStale?: boolean;
+  /**
+   * Replacement anchor derived from the marker's own position when `anchor`
+   * went stale — a marker sits immediately before the text it anchors to, so
+   * the text now following it is the best available candidate. Computed at
+   * parse time, not stored in the file: the reviewer makes it permanent by
+   * re-anchoring to a selection.
+   *
+   * Its PRESENCE is load-bearing, not just its value: a comment carrying one
+   * is excluded from `detectMissingAnchors` (it is attached, just not where it
+   * was written) and so never reaches the "Needs re-anchoring" section. It is
+   * therefore only ever set to a string that resolves against the document —
+   * setting an unlocatable one would suppress the orphan badge while the
+   * viewer highlighted nothing.
+   */
+  recoveredAnchor?: string;
+  /**
    * True when this marker was inserted by ANY agent tool (mdr_ask or
    * fire-and-forget mdr_review). Drives sidebar section + card styling.
    * Use `expectsReply` to distinguish "agent question I need to answer"
@@ -46,6 +67,27 @@ export interface MdComment {
   expectsReply?: boolean;
   /** Review session that owns this agent comment. Used for reply routing. */
   sessionId?: string;
+}
+
+/**
+ * The anchor as the reviewer actually sees it: the recovered text when the
+ * stored anchor went stale and recovery found what replaced it, otherwise the
+ * stored anchor. Anything the reviewer reads, copies, or navigates by should
+ * go through this, or the app shows one string and acts on another.
+ */
+export function displayAnchor(comment: MdComment): string {
+  return comment.recoveredAnchor ?? comment.anchor;
+}
+
+/**
+ * Lowercased haystack for comment search. Both anchors are included on
+ * purpose: the recovered text is what is on screen to search for, and the
+ * original is what the reviewer remembers writing the comment against.
+ */
+export function anchorSearchText(comment: MdComment): string {
+  return comment.recoveredAnchor
+    ? `${comment.anchor}\n${comment.recoveredAnchor}`.toLowerCase()
+    : comment.anchor.toLowerCase();
 }
 
 export function getEffectiveStatus(comment: MdComment): CommentStatus {


### PR DESCRIPTION
## The problem

Handing a doc to an agent to address review comments usually means handing it over for restructuring, and every anchor quoting the old prose stops existing at once. On a real 20-comment review, **13 of 20 anchors went dead.** Only 3 surfaced, because anchor detection skipped resolved comments.

## What changes

**The hand-off prompt** now says the anchor is a lookup key rather than a description, and asks for it to be updated in the same edit that rewrites the text it points at. It also asks the agent to delete `contextBefore`/`contextAfter` instead of rewriting them: those describe where the old anchor sat, and occurrence-picking weighs a context match above the marker's own position, so stale context drags the highlight onto the wrong copy of repeated text.

**Anchor recovery.** A marker sits immediately before the text it anchors to, so a marker that survives a rewrite still points at whatever replaced it. When an anchor stops resolving, `parseComments` derives a replacement from the marker's own position. All 13 detached comments on the review above reattach to the section that replaced them.

Recovery is never silent: the card badges it, quotes where the comment now points, keeps the original in the tooltip, and offers one click to write the recovery into the file. Five guards keep it from attaching a comment to text that is not its own, each of which produced a wrong anchor before it existed:

| Guard | What it prevents |
|---|---|
| Marker's own offset, not the fuzzy-relocated one | The `contextAfter`-only fallback rewinds by the OLD anchor's length and lands mid-word in the preceding paragraph |
| Newline budget (0 standalone, 1 inline) | Crossing a blank line re-points at an unrelated later section |
| Validation through `anchorResolves` | An unlocatable anchor suppresses the orphan badge while nothing highlights |
| No landing on a live anchor | Squatting on text that belongs to a different comment (clusters unaffected) |
| Relocated markers and source-only text refused | `insertComment` moves markers out of containers that cannot hold them, which is exactly where they stop preceding their anchor. Frontmatter is the one the marker *trails*, so recovering there re-points a `status:` comment at the page title. Also refused: HTML comments, HTML entities, table rows (cells run together in the DOM with no separator), footnote definitions (rendered elsewhere) |

`detectMissingAnchors` gains `includeResolved`. The rail still leaves resolved comments out, but nothing else should: an agent that rewrites while resolving detaches those anchors just as thoroughly.

Everything a reviewer reads, copies, searches, or navigates by now goes through `displayAnchor`/`anchorSearchText`, so the app stops showing one string while acting on another.

**Evals** could not have caught this: the default agent is told to delete markers once addressed, and a deleted marker takes its anchor with it. Adds an `anchorIntegrity` dimension (1 resolving, 0.5 where only recovery saved it, 0 detached, n/a where no marker was meant to survive, with the overall score renormalized so old results stay comparable), `markerMode` and `requiresAgent` on fixtures, an adapter that drives the shipped prompt verbatim, and fixture 16 reproducing the failure.

## Verification

Six review loops plus a closing pass; every finding reproduced before being fixed and every regression test confirmed failing without its fix. Verified in the running app against the original 20-comment document: 13 "Re-anchored" badges, no orphan section, all open comments highlighted, and "Keep this anchor" writing the recovery to disk with no parse-time fields leaking into the file.

Green locally: `tsc -b`, lint, format, build, `eval:dry`, 1736 unit tests, 333 e2e. Each of the three commits typechecks and passes on its own.

## Follow-up, not in this PR

`recoverAnchorAtOffset` extracts text with a hand-rolled line scan, and it is the only producer of anchors read out of source rather than DOM text. The refusal list above is the consequence. Replacing the scan with `toString(node)` over the mdast node following the marker would delete three of those mechanisms, but it pulls `remark-parse` into a module the server imports, so it wants its own branch and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LwNwyxS4YEswXCqFVJ4bTV