### PR TITLE
feat: leave a faint trace on resolved anchors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -619,10 +619,47 @@ on `--theme-bg-inset`), never the crimson accent:
   down by the residual instead of lifting other cards further. Comments
   whose anchor text can't be found in the document (orphans) stack in a
   block at the top of the rail, above the
-  anchored cards. Resolved comments do not appear in this density at all;
-  they stay in List density's / the drawer's Resolved filter. Geometry comes
-  from `useMarginLayout`; card and connector position changes animate over
-  150ms via `.margin-note-pos`, disabled under `prefers-reduced-motion`.
+  anchored cards. Resolved comments get no card in this density (App's
+  `marginComments` filters them out); their thread lives in List density's /
+  the drawer's Resolved filter. Their anchor still paints a faint dotted
+  underline in the prose (`mark.comment-highlight-resolved`) so a passage that
+  was discussed keeps a trace, and clicking that trace opens the single-thread
+  `CommentPopover` — the same surface used when the rail is hidden — because
+  `railCanShowThread` reports that Anchored density has nowhere to put it. A
+  highlight group paints the resolved treatment only when every comment in it
+  is resolved; one open comment on the same anchor keeps the full highlight,
+  and the settled ids stay out of that mark's `data-comment-ids` entirely. The
+  consequence is worth knowing: a resolved comment sharing an anchor with an
+  open one gets no trace, no density tick, and no scroll target, and is
+  reachable only from List density / the drawer.
+  The trace is suppressed inside Mermaid blocks, where a CSS `text-decoration`
+  on a `<mark>` stops foreignObject labels from wrapping; the post-render pass
+  in `MarkdownViewer` strips the resolved classes and the `data-comment-ids`
+  from those marks, so a diagram label is not left invisibly clickable. (The
+  fullscreen diagram modal does not share that strip and still paints resolved
+  labels as live.) Because the marks now exist, resolved comments also reach
+  the density strip as green `resolved` ticks (`useCommentTicks`), which they
+  never could before. A tick click routes through the same surface decision as
+  a highlight click (`revealCommentThread`), so it opens the popover rather
+  than activating a comment the rail will not draw. Right-clicking a trace
+  omits Edit and Reply, matching the card surfaces, which hide both while a
+  thread is settled; Jump to Sidebar calls `ensureCommentSurface(commentId)`,
+  which falls back to the drawer when the rail would draw no card for that
+  comment (and closes the popover on the way, so the two never stack).
+  Anchors that OVERLAP without matching land in separate highlight groups, so
+  the same-anchor rule above does not cover them: `wrapText` walks into marks
+  that are already painted, which nests the shorter anchor inside the longer
+  one. `markToAct` in `MarkdownViewer` resolves clicks and right-clicks to the
+  nearest OPEN ancestor mark rather than to the innermost one, so a live
+  highlight keeps its own clicks; a trace entirely enclosed by one is visible
+  but not clickable, and is reachable from List density / the drawer. Drag
+  handles can be dragged straight across a trace: `useDragHandles` excludes
+  `.comment-highlight-resolved` from the "don't drag into another comment's
+  mark" guard, since overlapping a settled anchor is what resizing did for as
+  long as resolved comments painted nothing.
+  Geometry comes from `useMarginLayout`; card and connector position changes
+  animate over 150ms via `.margin-note-pos`, disabled under
+  `prefers-reduced-motion`.
 - **List**: a pinned instance of `CommentListSurface`, with full search, status
   filter (All / Open / Resolved), sort, and bulk actions. Filters and search
   share a single header row (search input placeholder is "Search"). The same
@@ -656,16 +693,24 @@ opens the rail where it fits and the drawer everywhere else):
   removed.)
 - **Comment popover** (`CommentPopover.tsx`, `data-comment-popover`): a
   single-thread surface positioned under the clicked highlight, page-relative
-  so it scrolls with the text. Opens when a highlight is clicked (or a new
-  comment created) while the rail is hidden and the drawer is closed; the
-  drawer's own focus-forwarding takes priority when the drawer is already
-  open. Closes on Escape, an outside click, the rail becoming available, or
-  the active file changing.
+  so it scrolls with the text. Opens when a highlight, a resolved anchor's
+  trace, or a density tick is clicked (or a new comment created) and the rail
+  is not drawing that thread; the drawer's own focus-forwarding takes priority
+  when the drawer is already open. The gate is `railCanShowThread(id)`, not
+  `railShown`: in Anchored density a resolved comment has no card however wide
+  the window is, so its popover opens and stays open with the rail up. Closes
+  on Escape, an outside click, the rail gaining that card (reopening the
+  comment, or switching to List density), `ensureCommentSurface` handing the
+  thread to the drawer instead, the view leaving rendered mode, or the active
+  file changing.
 
 Every comment focus request (jump-to-next/prev, agent-ask navigation, toast
 actions, palette commands) is guaranteed to reach one of these surfaces, rail,
-drawer, or popover: never a dead click. Each request carries an origin,
-`'creation'` or `'jump'` (the default set by `requestCommentFocus`). In
+drawer, or popover: never a dead click. Each request carries an origin
+(`CommentFocusOrigin` in `useComments.ts`): `'creation'`, `'jump'` (the
+default set by `requestCommentFocus`), `'highlight'` for the requests a click
+on a highlight, a trace, or a density tick sends into List density, or
+`'reveal'` when `ensureCommentSurface` opened a surface to hold the card. In
 Anchored density a `'creation'` request (a just-added comment, from
 `handleAddComment` in `useComments.ts`) is consumed without activating the
 card, so the anchored stack stays put instead of pinning and shoving cards
@@ -673,6 +718,13 @@ around the new comment; jump-to-ask, palette jumps, and the review banner's
 View action all use the `'jump'` origin and still activate and scroll to the
 card. Creating a comment while the rail is hidden still opens the popover
 regardless of origin.
+
+Origin also decides whether the card takes DOM focus. `'highlight'` scrolls the
+card into view and stops there: a click in the prose means "show me this", the
+card is already beside the text, and moving focus out of the document would
+send the next space or PageDown to the rail and lift a screen reader out of the
+passage. Every other origin names the card deliberately, so the List surface
+focuses it (`ThreadCard` carries `tabIndex={-1}` for exactly this).
 
 **`Cmd+\`** toggles the rail where it fits in the current rendered view;
 otherwise it toggles the drawer, since that's the only comment surface left.
@@ -824,9 +876,12 @@ signals kind: the theme accent color for an agent's open `mdr_ask` question,
 the theme success color for a resolved comment, and the standard
 comment-underline color for a regular open comment. Each tick's title tooltip
 is author-prefixed: `"{author}: {first 60 characters of the comment text}"`.
-Clicking a tick jumps to and activates that comment's anchor, the same as
-clicking it from the rail or drawer. Hidden when there are no anchored
-comments, in raw view, or while the diff overlay is showing.
+Clicking a tick jumps to and activates that comment's anchor, then routes the
+thread through the same surface decision a highlight click makes
+(`revealCommentThread`): usually the card the rail already holds, but a
+popover for a resolved comment in Anchored density, where the rail draws no
+card. Hidden when there are no anchored comments, in raw view, or while the
+diff overlay is showing.
 
 ### Section breadcrumb
 An inline breadcrumb (`data-section-breadcrumb`) rendered in the panel

--- a/e2e/comment-popover.spec.ts
+++ b/e2e/comment-popover.spec.ts
@@ -77,6 +77,21 @@ async function switchToListDensity(page: Page) {
   await page.locator('[data-rail-header] button', { hasText: 'List' }).click();
 }
 
+async function switchToAnchoredDensity(page: Page) {
+  await page.locator('[data-rail-header] button', { hasText: 'Anchored' }).click();
+}
+
+/**
+ * Turn the resolve workflow on and settle one comment. The Resolve action
+ * lives on the List surface's cards, so the density switch is part of the
+ * sequence rather than something each test remembers to do.
+ */
+async function resolveComment(page: Page, commentText: string) {
+  await toggleSetting(page, 'Enable resolve workflow');
+  await switchToListDensity(page);
+  await clickCardAction(page, commentText, 'Resolve');
+}
+
 test.describe('Highlight popover (rail-hidden contexts)', () => {
   test('clicking a highlight opens the popover with the comment text and author byline; Esc and an outside click both close it', async ({
     page,
@@ -172,5 +187,404 @@ test.describe('Filter auto-widen', () => {
     const openCard = getCard(page, 'Auto-widen open comment');
     await expect(openCard).toBeVisible();
     await expect(openCard).toHaveClass(/border-primary-border/);
+  });
+});
+
+test.describe('Resolved anchor traces (Anchored density)', () => {
+  test.use({ viewport: WIDE_VIEWPORT });
+
+  test('clicking a resolved trace opens the popover, since Anchored density gives it no card', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await addComment(page, 'valid credentials', 'Trace open comment');
+    await addComment(page, 'brute force attacks', 'Trace resolved comment');
+
+    await resolveComment(page, 'Trace resolved comment');
+    await switchToAnchoredDensity(page);
+
+    // The resolved anchor keeps a trace in the prose, and only the open
+    // comment gets a margin card. That combination is the whole reason the
+    // click needs somewhere else to land.
+    await expect(page.locator('mark.comment-highlight-resolved')).toHaveCount(1);
+    await expect(page.locator('[data-margin-card-id]')).toHaveCount(1);
+
+    const pop = popover(page);
+    await expect(pop).not.toBeVisible();
+
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(pop).toBeVisible();
+    await expect(pop).toContainText('Trace resolved comment');
+
+    // Clicking an open highlight afterwards must not strand the popover: it
+    // would sit there describing a different comment than the active one.
+    await page.locator('mark.comment-highlight', { hasText: 'valid credentials' }).click();
+    await expect(pop).not.toBeVisible();
+  });
+
+  test('a resolved density tick opens the popover, the same as its trace does', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Tick resolved comment');
+
+    await resolveComment(page, 'Tick resolved comment');
+    await switchToAnchoredDensity(page);
+
+    const tick = page.locator('[data-density-strip] [data-tick-id]').first();
+    await expect(tick).toBeVisible();
+
+    const pop = popover(page);
+    await expect(pop).not.toBeVisible();
+
+    // The strip is a click surface of its own, and resolved comments reach it.
+    // Activating without deciding where the thread goes leaves the tick dead:
+    // Anchored density draws no card for a resolved comment.
+    await tick.click();
+    await expect(pop).toBeVisible();
+    await expect(pop).toContainText('Tick resolved comment');
+  });
+
+  test('reopening from the popover and resolving again does not resurrect it', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Round trip comment');
+
+    await resolveComment(page, 'Round trip comment');
+    await switchToAnchoredDensity(page);
+
+    const pop = popover(page);
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(pop).toBeVisible();
+
+    // Reopening gives the comment a margin card, so the rail takes the thread
+    // back and the popover goes away.
+    await pop.getByRole('button', { name: 'Reopen', exact: true }).click();
+    await expect(pop).not.toBeVisible();
+    await expect(page.locator('[data-margin-card-id]')).toHaveCount(1);
+
+    // Resolving again from the card removes the card. Nothing was clicked in
+    // the prose, so nothing should open: a popover appearing here is a stale
+    // id surviving the round trip.
+    await clickCardAction(page, 'Round trip comment', 'Resolve');
+    await expect(page.locator('[data-margin-card-id]')).toHaveCount(0);
+    await expect(pop).not.toBeVisible();
+  });
+
+  test('the trace context menu offers only what a resolved thread can do, and Jump lands', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Menu resolved comment');
+
+    await resolveComment(page, 'Menu resolved comment');
+    await switchToAnchoredDensity(page);
+
+    await page.locator('mark.comment-highlight-resolved').click({ button: 'right' });
+    const menu = page.locator('.context-menu-enter');
+    await expect(menu).toBeVisible();
+
+    // Every card surface hides Edit and Reply on a settled thread, so the menu
+    // the trace opens must not promise them either.
+    await expect(menu.getByText('Edit', { exact: true })).toHaveCount(0);
+    await expect(menu.getByText('Reply', { exact: true })).toHaveCount(0);
+    await expect(menu.getByText('Reopen', { exact: true })).toBeVisible();
+
+    // Jump to Sidebar has to reach a surface that draws the thread. Revealing
+    // the rail is not enough: Anchored density gives a resolved comment no
+    // card, so the jump would land on a comment nothing renders.
+    await menu.getByText('Jump to Sidebar', { exact: true }).click();
+    await expect(page.getByRole('dialog', { name: 'Comments' })).toBeVisible();
+    await expect(
+      page.getByRole('dialog', { name: 'Comments' }).getByText('Menu resolved comment'),
+    ).toBeVisible();
+  });
+
+  test('handing the thread to the drawer takes the popover away with it', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Handover comment');
+
+    await resolveComment(page, 'Handover comment');
+    await switchToAnchoredDensity(page);
+
+    const pop = popover(page);
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(pop).toBeVisible();
+
+    // Jump to Sidebar reaches the same verdict the click did (Anchored draws
+    // no card for a resolved comment) and opens the drawer instead. The
+    // popover has to go: it renders under the drawer's overlay showing a
+    // second copy of the same thread, and surfaces again when the drawer
+    // closes, unrequested.
+    await page.locator('mark.comment-highlight-resolved').click({ button: 'right' });
+    await page.locator('.context-menu-enter').getByText('Jump to Sidebar', { exact: true }).click();
+
+    const drawer = page.getByRole('dialog', { name: 'Comments' });
+    await expect(drawer).toBeVisible();
+    await expect(pop).not.toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(drawer).not.toBeVisible();
+    await expect(pop).not.toBeVisible();
+  });
+
+  test('a resolved trace still opens after a raw view round trip', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Round trip comment');
+
+    await resolveComment(page, 'Round trip comment');
+    await switchToAnchoredDensity(page);
+
+    const pop = popover(page);
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(pop).toBeVisible();
+
+    // Leave for raw view through the command palette, not the toolbar button.
+    // The popover dismisses itself on any document mousedown outside it, so a
+    // click on the toolbar clears the id on the way past and hides all of
+    // this; the palette route is pure keyboard and leaves the id where it was.
+    await page.keyboard.press(withMod('k'));
+    const palette = page.getByPlaceholder('Type a command...');
+    await expect(palette).toBeVisible();
+    await palette.fill('Switch to raw markdown');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('.raw-view-table')).toBeVisible();
+    await expect(pop).not.toBeVisible();
+
+    // Coming back can use the button: the popover is unmounted in raw view,
+    // so its outside-click listener is gone and cannot mask anything.
+    await page.locator('button[title="Switch to rendered view"]').click();
+    await expect(page.locator('mark.comment-highlight-resolved')).toHaveCount(1);
+    await expect(pop).not.toBeVisible();
+
+    // The payload assertion. Keying the reset on activeFilePath alone let the
+    // id survive into the returning render, where the popover remounts before
+    // the page element it measures against exists: its position effect reads a
+    // null pageRef, bails, and `pos` never gets set, so the component renders
+    // null and the effect's deps never change again. From then on the trace is
+    // dead, not noisy: every click assigns the same id, React bails out of the
+    // update, and nothing remounts. Clearing on railCapable means the click
+    // below mounts a fresh popover against a page that exists.
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(pop).toBeVisible();
+    await expect(pop).toContainText('Round trip comment');
+  });
+});
+
+test.describe('Resolved anchor traces (List density)', () => {
+  test.use({ viewport: WIDE_VIEWPORT });
+
+  test('clicking a resolved trace reveals its card even when it is already active', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'List trace comment');
+
+    await resolveComment(page, 'List trace comment');
+
+    // Exact match: the tab bar's "Open file" button also starts with "Open".
+    // The tab carries no count badge here, since the only comment is resolved.
+    const openFilter = page.getByRole('button', { name: 'Open', exact: true });
+    const card = page.locator('[data-comment-card-id]');
+
+    // First click widens the filter because the active comment CHANGES.
+    await openFilter.click();
+    await expect(card).toHaveCount(0);
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(card).toHaveCount(1);
+
+    // Put the filter back. The comment stays active, so a second click on the
+    // trace changes no state at all, so the widen has to be driven by the click
+    // itself or this one lands nowhere.
+    await openFilter.click();
+    await expect(card).toHaveCount(0);
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(card).toHaveCount(1);
+  });
+
+  test('a highlight click keeps a search that was not hiding the card', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'valid credentials', 'Search survivor comment');
+    await addComment(page, 'brute force attacks', 'Search casualty comment');
+
+    await switchToListDensity(page);
+
+    const search = page.getByPlaceholder('Search');
+    await search.fill('survivor');
+    await expect(getCard(page, 'Search survivor comment')).toBeVisible();
+    await expect(getCard(page, 'Search casualty comment')).not.toBeVisible();
+
+    // Every highlight click sends a focus request now, and the request handler
+    // used to clear the search box before asking whether the search was what
+    // hid the card. Clicking a comment the search already shows must leave the
+    // reviewer's search exactly where it was.
+    await page.locator('mark.comment-highlight', { hasText: 'valid credentials' }).click();
+    await expect(search).toHaveValue('survivor');
+    await expect(getCard(page, 'Search casualty comment')).not.toBeVisible();
+
+    // Clicking one the search DOES hide still widens: the request has to land.
+    await page.locator('mark.comment-highlight', { hasText: 'brute force attacks' }).click();
+    await expect(search).toHaveValue('');
+    await expect(getCard(page, 'Search casualty comment')).toBeVisible();
+  });
+
+  test('a highlight click scrolls the card into view without taking focus', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'valid credentials', 'Focus bystander comment');
+
+    await switchToListDensity(page);
+
+    // Routing every highlight click through a focus request put DOM focus on
+    // a ThreadCard (tabIndex -1) for a click that was only ever "show me this
+    // comment". Focus leaving the document means the next space or PageDown
+    // scrolls the rail instead of the prose, Tab starts walking the cards,
+    // and a screen reader is lifted out of the passage being read.
+    await page.locator('mark.comment-highlight').first().click();
+
+    const card = page.locator('[data-comment-card-id]');
+    await expect(card).toHaveCount(1);
+    await expect(card).not.toBeFocused();
+
+    // The card is still activated and shown; only the focus move is gone.
+    await expect(getCard(page, 'Focus bystander comment')).toBeVisible();
+
+    // And the context menu, which names the card deliberately, still lands on
+    // it. The two paths shared one origin before, so this is what stops a fix
+    // for the click from quietly disarming the jump.
+    await page.locator('mark.comment-highlight').first().click({ button: 'right' });
+    const menu = page.locator('.context-menu-enter');
+    await expect(menu).toBeVisible();
+    await menu.getByText('Jump to Sidebar', { exact: true }).click();
+    await expect(card).toBeFocused();
+  });
+
+  test('dragging a live anchor does not rewrite a resolved comment sharing it', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Live comment');
+    await addComment(page, 'brute force attacks', 'Settled comment');
+
+    await resolveComment(page, 'Settled comment');
+
+    // Both comments sit on the identical span, so they share one mark, and the
+    // live one keeps it painted open. Drag-resize rewrites the anchor of every
+    // id that mark carries, so a settled id riding along here would have its
+    // anchor and context rewritten on disk with nothing on screen to show it.
+    const mark = page.locator('mark.comment-highlight');
+    await expect(mark).toHaveCount(1);
+
+    await getCard(page, 'Live comment').click();
+    const endHandle = page.locator('[data-drag-handle]').last();
+    await expect(endHandle).toBeVisible();
+    const box = await endHandle.boundingBox();
+    // Assert rather than force: boundingBox can return null on a reflow race
+    // even right after toBeVisible, and a null deref in the arithmetic below
+    // reads as a bug in the drag rather than as a missing handle.
+    expect(box).not.toBeNull();
+    await endHandle.hover();
+    await page.mouse.down();
+    await page.mouse.move(box!.x + box!.width + 80, box!.y + box!.height / 2);
+    await page.mouse.up();
+
+    // The cards re-parse from the saved file, so they report what landed there.
+    const liveAnchor = getCard(page, 'Live comment').locator('[data-anchor-quote]').first();
+    await expect(liveAnchor).not.toHaveText(/^["“”]brute force attacks["“”]$/);
+
+    const settledAnchor = getCard(page, 'Settled comment').locator('[data-anchor-quote]').first();
+    await expect(settledAnchor).toHaveText(/^["“”]brute force attacks["“”]$/);
+  });
+
+  test('a live anchor can be dragged across a resolved trace', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'Rate limiting', 'Draggable comment');
+    await addComment(page, 'prevents', 'Trace in the way');
+
+    await resolveComment(page, 'Trace in the way');
+
+    const trace = page.locator('mark.comment-highlight-resolved');
+    await expect(trace).toHaveCount(1);
+
+    await getCard(page, 'Draggable comment').click();
+    const endHandle = page.locator('[data-drag-handle]').last();
+    await expect(endHandle).toBeVisible();
+
+    // Start the gesture BEFORE measuring the trace. Hovering the handle can
+    // scroll it into view, which moves every rect on the page; a box read
+    // earlier points at whatever slid into those coordinates instead.
+    await endHandle.hover();
+    await page.mouse.down();
+    const traceBox = await trace.boundingBox();
+    expect(traceBox).not.toBeNull();
+
+    // Land the pointer in the MIDDLE of the trace and let go there. The guard
+    // that refuses to drag into another comment's mark counted the trace as
+    // one, so the mousemove returned before the anchor grew and the drag
+    // stopped dead against a 1px dotted underline. The midpoint is what makes
+    // that deterministic: clearing the trace in one move steps over the guard,
+    // and even its right edge resolves to a caret outside the mark.
+    await page.mouse.move(traceBox!.x + traceBox!.width / 2, traceBox!.y + traceBox!.height / 2);
+    await page.mouse.up();
+
+    // Mid-word by construction. Anchored to the trace's own text rather than
+    // to a prefix of it: "Rate limiting p" would also match the runaway
+    // whole-paragraph anchor a mis-measured drag produces.
+    const anchor = getCard(page, 'Draggable comment').locator('[data-anchor-quote]').first();
+    await expect(anchor).toHaveText(/^["\u201c\u201d]Rate limiting pre[a-z]*["\u201c\u201d]$/);
+
+    // The trace's own comment is untouched: this widened one anchor over
+    // another, which is what overlapping anchors have always been allowed to do.
+    const traceAnchor = getCard(page, 'Trace in the way').locator('[data-anchor-quote]').first();
+    await expect(traceAnchor).toHaveText(/^["\u201c\u201d]prevents["\u201c\u201d]$/);
+  });
+
+  test('Jump to Sidebar reveals a filtered-out card that is already active', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Jump trace comment');
+
+    await resolveComment(page, 'Jump trace comment');
+
+    const openFilter = page.getByRole('button', { name: 'Open', exact: true });
+    const card = page.locator('[data-comment-card-id]');
+
+    // Same trap as the click path, at the entry point the trace also opened:
+    // the comment stays active behind the filter, so revealing an already
+    // visible rail accomplishes nothing on its own.
+    await page.locator('mark.comment-highlight-resolved').click();
+    await expect(card).toHaveCount(1);
+    await openFilter.click();
+    await expect(card).toHaveCount(0);
+
+    await page.locator('mark.comment-highlight-resolved').click({ button: 'right' });
+    const menu = page.locator('.context-menu-enter');
+    await expect(menu).toBeVisible();
+    await menu.getByText('Jump to Sidebar', { exact: true }).click();
+
+    await expect(card).toHaveCount(1);
+  });
+
+  test('Jump to Sidebar focuses the card in a rail the same call is opening', async ({ page }) => {
+    await openFixture(page);
+    await addComment(page, 'brute force attacks', 'Reveal and focus comment');
+
+    await resolveComment(page, 'Reveal and focus comment');
+
+    // Hide the rail. The window is still wide enough for it, so the reveal
+    // path (rather than the drawer fallback) is what the jump will take.
+    await page.keyboard.press(withMod('\\'));
+    await expect(page.locator('[data-comments-rail]')).toHaveCount(0);
+
+    await page.locator('mark.comment-highlight-resolved').click({ button: 'right' });
+    const menu = page.locator('.context-menu-enter');
+    await expect(menu).toBeVisible();
+    await menu.getByText('Jump to Sidebar', { exact: true }).click();
+
+    // Routing the focus request through requestListFocus dropped it here:
+    // that guard reads railShown, which inside this same call is still the
+    // pre-reveal false. The card landed on screen anyway (a hidden rail
+    // unmounts and remounts with its filter at All), so only the missing
+    // focus tells the two apart.
+    const card = page.locator('[data-comment-card-id]');
+    await expect(card).toHaveCount(1);
+    await expect(card).toBeFocused();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,7 @@ import { useSearch } from './hooks/useSearch';
 import { useCommentCardTriggers } from './hooks/useCommentCardTriggers';
 import { useDiffSnapshot } from './hooks/useDiffSnapshot';
 import { shouldAdvanceFrontier, formatReferenceLabel } from './lib/review-frontier';
-import { useComments } from './hooks/useComments';
+import { useComments, type CommentFocusOrigin } from './hooks/useComments';
 import { useHeadingTracking } from './hooks/useHeadingTracking';
 import { useContextMenuItems } from './hooks/useContextMenuItems';
 import { getCopySelectionFallbackText } from './lib/copy-selection';
@@ -450,7 +450,7 @@ export default function App() {
   const [requestedCommentFocus, setRequestedCommentFocus] = useState<{
     commentId: string;
     token: number;
-    origin: 'creation' | 'jump';
+    origin: CommentFocusOrigin;
   } | null>(null);
 
   // Modal state — only one modal can be open at a time
@@ -581,7 +581,7 @@ export default function App() {
     containerRef as RefObject<HTMLElement | null>,
   );
   const requestCommentFocus = useCallback(
-    (commentId: string, origin: 'creation' | 'jump' = 'jump') =>
+    (commentId: string, origin: CommentFocusOrigin = 'jump') =>
       setRequestedCommentFocus({ commentId, token: Date.now(), origin }),
     [],
   );
@@ -698,6 +698,19 @@ export default function App() {
   // eligibility changes.
   const railCapable = viewMode === 'rendered' && !(diffEnabled && currentSnapshot);
   const railAllowed = railCapable && sidebarVisible && !focusMode;
+  // Resolved comments still paint a faint trace on their anchor, but they get
+  // no margin card: one would read as an orphan, and the whole point of
+  // Anchored density is that the column holds what still needs a decision.
+  const marginComments = useMemo(
+    () => comments.filter((c) => getEffectiveStatus(c) !== 'resolved'),
+    [comments],
+  );
+  // Membership, not a scan: railWouldShowThread below runs in the render body
+  // whenever a popover is open, and App re-renders on every scroll frame.
+  const marginCommentIds = useMemo(
+    () => new Set(marginComments.map((c) => c.id)),
+    [marginComments],
+  );
   // The anchored rail earns its gutter width only once it has a card to
   // place. List density always reserves — its panel is intentional even when
   // empty. Anchored + zero non-resolved comments collapses the empty margin
@@ -706,8 +719,7 @@ export default function App() {
   // unchanged); only the sheet width drops and re-centers, and colWidth is
   // held constant so the first comment slides the gutter open without
   // reflowing the text.
-  const railHasContent =
-    railDensity === 'list' || comments.some((c) => getEffectiveStatus(c) !== 'resolved');
+  const railHasContent = railDensity === 'list' || marginComments.length > 0;
   const geometry = usePageGeometry(
     containerRef as RefObject<HTMLElement | null>,
     railAllowed,
@@ -716,6 +728,32 @@ export default function App() {
     railHasContent,
   );
   const railShown = geometry.railShown;
+
+  // Whether the rail would draw this comment's thread at all, setting aside
+  // whether it happens to be on screen. Anchored density draws only
+  // marginComments, so a resolved comment has no card there however wide the
+  // window is; List density keeps every comment. Callers that are about to
+  // OPEN a surface want this one; callers asking what the user can see right
+  // now want railCanShowThread below.
+  const railWouldShowThread = useCallback(
+    (commentId: string) => railDensity !== 'anchored' || marginCommentIds.has(commentId),
+    [railDensity, marginCommentIds],
+  );
+
+  // List density reveals a card by widening its filter toward whichever comment
+  // is being activated, and that widen fires on an activation CHANGE. Any entry
+  // point that can target a comment which is ALREADY active has to send the
+  // request as an event instead, or it changes no state and lands nowhere. That
+  // is every entry point a trace added: clicking it, its density tick, and the
+  // context menu it opens.
+  const requestListFocus = useCallback(
+    (commentId: string) => {
+      if (railShown && railDensity !== 'anchored') {
+        requestCommentFocus(commentId, 'highlight');
+      }
+    },
+    [railShown, railDensity, requestCommentFocus],
+  );
 
   // The comments drawer is the fallback comment surface wherever the rail
   // cannot show: raw view, diff mode, or a rendered view too narrow to fit
@@ -726,21 +764,65 @@ export default function App() {
     if (railShown) setDrawerOpen(false);
   }, [railShown]);
 
+  // The highlight popover is the single-thread comment surface for contexts
+  // the rail can't serve: a click on a highlight or a resolved trace, or a
+  // comment created while the rail is hidden, opens one thread inline instead
+  // of routing through the drawer. Declared here so ensureCommentSurface can
+  // hand the thread over when it picks the drawer instead.
+  const [popoverCommentId, setPopoverCommentId] = useState<string | null>(null);
+
   // Guarantees a comment surface is open for callers that need one to exist
   // right now (the viewer context menu's Edit/Reply/Jump to Sidebar actions
   // set an activeCommentId or requestedEditor that only a mounted surface
   // consumes). Bare setSidebarVisible(true) is not enough: at a narrow width
   // the rail cannot render at all regardless of sidebarVisible, so the
   // request would strand until some later surface mount fired it
-  // unprompted. Mirrors the rail-can-show predicate the drawer fallback and
-  // the Cmd+\ shortcut already use.
-  const ensureCommentSurface = useCallback(() => {
-    if (railCapable && geometry.railFits) {
-      setSidebarVisibleGuarded(true);
-    } else {
-      setDrawerOpen(true);
-    }
-  }, [railCapable, geometry.railFits, setSidebarVisibleGuarded]);
+  // unprompted.
+  //
+  // Pass the comment being acted on whenever there is one. The rail being able
+  // to render is not the same as the rail being willing to draw THAT thread:
+  // Anchored density gives a resolved comment no card, so revealing the rail
+  // for one strands the request exactly as a too-narrow window would. The
+  // drawer is already the surface that answers for both cases.
+  const ensureCommentSurface = useCallback(
+    (commentId?: string) => {
+      const railServes =
+        railCapable &&
+        geometry.railFits &&
+        (commentId === undefined || railWouldShowThread(commentId));
+      if (railServes) {
+        setSidebarVisibleGuarded(true);
+      } else {
+        setDrawerOpen(true);
+        // The drawer is the surface now. A popover left open under it (a
+        // resolved trace clicked before this, which Anchored density answers
+        // with a popover) sits behind the drawer's overlay showing a second
+        // copy of the same thread, and reappears when the drawer closes.
+        setPopoverCommentId(null);
+      }
+      // Send the request whenever a List surface will be there to take it.
+      // Not via requestListFocus: that reads `railShown`, which is still the
+      // pre-reveal value inside this call, so it would drop the request in
+      // the one case that most needs it, a rail this very call is opening.
+      //
+      // 'reveal', not 'highlight': everything reaching here asked for the
+      // card by name (the viewer's context menu, a created comment), and a
+      // surface was just opened to hold it, so landing focus on it is the
+      // whole point. A click on the highlight itself goes through
+      // requestListFocus and stays out of the reviewer's way.
+      if (commentId !== undefined && railServes && railDensity !== 'anchored') {
+        requestCommentFocus(commentId, 'reveal');
+      }
+    },
+    [
+      railCapable,
+      geometry.railFits,
+      railDensity,
+      railWouldShowThread,
+      setSidebarVisibleGuarded,
+      requestCommentFocus,
+    ],
+  );
 
   // Shared decision behind both comment-surface toggles: the Cmd+\ shortcut
   // and the command palette's "Toggle comments rail" command. Toggle the
@@ -756,11 +838,6 @@ export default function App() {
       toggleSidebarPane();
     }
   }, [railCapable, geometry.railFits, toggleSidebarPane]);
-
-  // The highlight popover is the single-thread comment surface for
-  // rail-hidden contexts: a click on a highlight, or a comment created while
-  // hidden, opens one thread inline instead of routing through the drawer.
-  const [popoverCommentId, setPopoverCommentId] = useState<string | null>(null);
 
   // Creation while the rail is hidden (rendered view, form only exists
   // there): open the popover on the new comment instead of leaving it with
@@ -788,14 +865,18 @@ export default function App() {
     }
   }, [requestedCommentFocus, drawerOpen, railShown, railCapable]);
 
-  // Close the popover once the rail can show its own surface, or when the
-  // file changes out from under it.
-  useEffect(() => {
-    if (railShown) setPopoverCommentId(null);
-  }, [railShown]);
+  // Close the popover when the file changes out from under it, or when the
+  // view stops being one the popover belongs to (raw view, diff overlay).
+  // railCapable is exactly that test, and keying on it covers both edges: the
+  // popover unmounts on the way into raw view but its id used to survive, so
+  // a resolved trace's popover (which railCanShowThread never clears, by
+  // design) reappeared unprompted on the way back. Entering diff mode is the
+  // same story with a worse ending: the popover renders over
+  // RenderedDiffView, which paints no marks, so it parks itself unanchored.
+  // The rail-took-over case is handled below, next to railCanShowThread.
   useEffect(() => {
     setPopoverCommentId(null);
-  }, [activeFilePath]);
+  }, [activeFilePath, railCapable]);
   // A deleted comment (or one an agent rewrite removed) must not leave a
   // stale id behind: if the same id ever reappeared (undo, rewrite), the
   // popover would pop back open unprompted.
@@ -822,22 +903,62 @@ export default function App() {
     }
   }, [requestedCommentFocus, railShown, railDensity, activeCommentId, handleSidebarActivate]);
 
+  // Whether the rail is drawing this comment's thread right now: the same
+  // question railWouldShowThread answers, plus the rail actually being up.
+  const railCanShowThread = useCallback(
+    (commentId: string) => railShown && railWouldShowThread(commentId),
+    [railShown, railWouldShowThread],
+  );
+
+  // Close the popover once the rail can draw this thread itself. Keyed on
+  // railCanShowThread rather than on railShown alone: a resolved trace keeps
+  // its popover with the rail open, since Anchored density gives it no card,
+  // and what should take the popover away is the rail gaining that card:
+  // reopening the comment, or switching to List density. Watching railShown
+  // instead left the id behind whenever the gate closed for one of those other
+  // reasons, so the popover reappeared unprompted the next time it reopened.
+  useEffect(() => {
+    setPopoverCommentId((prev) => (prev !== null && railCanShowThread(prev) ? null : prev));
+  }, [railCanShowThread]);
+
+  // Every route to a single comment ends here: a click on its highlight, on the
+  // faint trace a resolved anchor leaves, or on its density-strip tick. Where
+  // the thread appears is not the caller's business, it is a question about
+  // what the rail can currently draw.
+  const revealCommentThread = useCallback(
+    (commentId: string) => {
+      // Always assign, never only set: with the rail shown, a resolved trace
+      // opens a popover that the next click on an OPEN highlight would
+      // otherwise strand on screen, pointing at a different comment than the
+      // one now active. Clearing it is the same statement as opening it.
+      setPopoverCommentId(railCanShowThread(commentId) ? null : commentId);
+      requestListFocus(commentId);
+    },
+    [railCanShowThread, requestListFocus],
+  );
+
   // Wraps the base highlight-click handler (which only sets activeCommentId)
-  // with the popover trigger: when the rail can't show, a click on a
-  // highlight opens the single-thread popover.
+  // with the surface decision above: when the rail can't show the thread, a
+  // click on a highlight opens the single-thread popover instead of doing
+  // nothing visible. That covers the rail being hidden and, since resolved
+  // anchors paint a trace, clicking one in Anchored density.
   const handleHighlightClickWithPopover = useCallback(
     (commentId: string) => {
       handleHighlightClick(commentId);
-      if (!railShown) setPopoverCommentId(commentId);
+      revealCommentThread(commentId);
     },
-    [handleHighlightClick, railShown],
+    [handleHighlightClick, revealCommentThread],
   );
 
-  // Resolved comments have no highlight marks and would render as fake
-  // orphans in the margin; they live in the List surface instead.
-  const marginComments = useMemo(
-    () => comments.filter((c) => getEffectiveStatus(c) !== 'resolved'),
-    [comments],
+  // A density-strip tick is a highlight click at a distance, and resolved
+  // comments now reach the strip. Activating without deciding where the thread
+  // goes reintroduces the dead click on exactly the surface this change added.
+  const handleDensityJump = useCallback(
+    (commentId: string) => {
+      handleSidebarActivate(commentId);
+      revealCommentThread(commentId);
+    },
+    [handleSidebarActivate, revealCommentThread],
   );
   const marginLayout = useMarginLayout(
     containerRef as RefObject<HTMLElement | null>,
@@ -2821,7 +2942,7 @@ export default function App() {
                           />
                         )}
                         {popoverCommentId &&
-                          !railShown &&
+                          !railCanShowThread(popoverCommentId) &&
                           (() => {
                             const c = comments.find((x) => x.id === popoverCommentId);
                             if (!c) return null;
@@ -2844,7 +2965,7 @@ export default function App() {
                           })()}
                       </div>
                     </div>
-                    <DensityStrip ticks={commentTicks} onJump={handleSidebarActivate} />
+                    <DensityStrip ticks={commentTicks} onJump={handleDensityJump} />
                   </div>
                 )}
               </div>

--- a/src/components/CommentListSurface.test.tsx
+++ b/src/components/CommentListSurface.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
+
+const fetchPreferences = vi.fn();
+const savePreferencesToDisk = vi.fn();
+vi.mock('../lib/preferences-client', () => ({
+  fetchPreferences: (...args: unknown[]) => fetchPreferences(...args),
+  savePreferencesToDisk: (...args: unknown[]) => savePreferencesToDisk(...args),
+}));
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme: 'system', setTheme: vi.fn() }),
+}));
+
+import { SettingsProvider } from '../contexts/SettingsContext';
+import { CommentListSurface } from './CommentListSurface';
+import type { MdComment } from '../types';
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const OPEN_COMMENT: MdComment = {
+  id: 'still-open',
+  anchor: 'first anchor',
+  text: 'This one still needs a decision',
+  author: 'Dennis',
+  timestamp: '2026-08-07T12:00:00.000Z',
+};
+
+const RESOLVED_COMMENT: MdComment = {
+  id: 'settled',
+  anchor: 'second anchor',
+  text: 'This one was already settled',
+  author: 'Dennis',
+  timestamp: '2026-08-07T12:00:00.000Z',
+  status: 'resolved',
+};
+
+function renderSurface(props: Partial<React.ComponentProps<typeof CommentListSurface>> = {}) {
+  const defaults: React.ComponentProps<typeof CommentListSurface> = {
+    comments: [OPEN_COMMENT, RESOLVED_COMMENT],
+    activeCommentId: null,
+    missingAnchors: new Set<string>(),
+    onActivate: vi.fn(),
+    onDelete: vi.fn(),
+    onEdit: vi.fn(),
+    onReply: vi.fn(),
+    onEditReply: vi.fn(),
+    onDeleteReply: vi.fn(),
+    onBulkDelete: vi.fn(),
+  };
+  return render(
+    <SettingsProvider>
+      <CommentListSurface {...defaults} {...props} />
+    </SettingsProvider>,
+  );
+}
+
+/** Put the list on the Resolved filter, which hides the open comment. */
+async function selectResolvedFilter() {
+  const tab = await screen.findByRole('button', { name: /^Resolved/ });
+  fireEvent.click(tab);
+  await waitFor(() => expect(screen.queryByText(OPEN_COMMENT.text)).toBeNull());
+}
+
+beforeEach(() => {
+  fetchPreferences.mockReset();
+  fetchPreferences.mockResolvedValue({ settings: { enableResolve: true } });
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe('focus request for a comment that no longer exists', () => {
+  // A file-watcher reload or an agent rewrite can delete the requested
+  // comment between the request and this effect (`comments` is a dep, so the
+  // effect re-runs on the new list). Defaulting the missing comment's status
+  // to 'open' widened the filter for a card that was never going to appear,
+  // pulling the reviewer off Resolved and then stranding the request: the
+  // re-run finds no node and returns without calling onFocusHandled.
+  it('leaves the filter alone instead of widening toward a guess', async () => {
+    const onFocusHandled = vi.fn();
+    const { rerender } = renderSurface({ onFocusHandled });
+    await selectResolvedFilter();
+
+    rerender(
+      <SettingsProvider>
+        <CommentListSurface
+          comments={[RESOLVED_COMMENT]}
+          activeCommentId={null}
+          missingAnchors={new Set<string>()}
+          onActivate={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onReply={vi.fn()}
+          onEditReply={vi.fn()}
+          onDeleteReply={vi.fn()}
+          onBulkDelete={vi.fn()}
+          onFocusHandled={onFocusHandled}
+          requestedFocus={{ commentId: 'deleted-out-from-under-us', token: 1 }}
+        />
+      </SettingsProvider>,
+    );
+
+    // Still on Resolved: the settled card shows, and nothing widened.
+    await waitFor(() => expect(screen.getByText(RESOLVED_COMMENT.text)).toBeTruthy());
+    expect(screen.queryByText(OPEN_COMMENT.text)).toBeNull();
+  });
+
+  // The guard above must not cost the real case its widen.
+  it('still widens toward a comment that does exist', async () => {
+    const { rerender } = renderSurface();
+    await selectResolvedFilter();
+
+    rerender(
+      <SettingsProvider>
+        <CommentListSurface
+          comments={[OPEN_COMMENT, RESOLVED_COMMENT]}
+          activeCommentId={null}
+          missingAnchors={new Set<string>()}
+          onActivate={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onReply={vi.fn()}
+          onEditReply={vi.fn()}
+          onDeleteReply={vi.fn()}
+          onBulkDelete={vi.fn()}
+          requestedFocus={{ commentId: OPEN_COMMENT.id, token: 1 }}
+        />
+      </SettingsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText(OPEN_COMMENT.text)).toBeTruthy());
+  });
+});
+
+describe('focus request against an active search', () => {
+  // Every highlight click and density tick routes a focus request through
+  // this effect now, so an unconditional setSearch('') threw away a
+  // reviewer's search on a click that was already showing them the card.
+  it('keeps a search that is not hiding the requested card', async () => {
+    const { rerender } = renderSurface();
+    const box = await screen.findByPlaceholderText('Search');
+    fireEvent.change(box, { target: { value: 'still needs' } });
+    await waitFor(() => expect(screen.queryByText(RESOLVED_COMMENT.text)).toBeNull());
+
+    rerender(
+      <SettingsProvider>
+        <CommentListSurface
+          comments={[OPEN_COMMENT, RESOLVED_COMMENT]}
+          activeCommentId={null}
+          missingAnchors={new Set<string>()}
+          onActivate={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onReply={vi.fn()}
+          onEditReply={vi.fn()}
+          onDeleteReply={vi.fn()}
+          onBulkDelete={vi.fn()}
+          requestedFocus={{ commentId: OPEN_COMMENT.id, token: 1 }}
+        />
+      </SettingsProvider>,
+    );
+
+    await waitFor(() =>
+      expect((screen.getByPlaceholderText('Search') as HTMLInputElement).value).toBe('still needs'),
+    );
+  });
+
+  it('clears a search that is hiding the requested card', async () => {
+    const { rerender } = renderSurface();
+    const box = await screen.findByPlaceholderText('Search');
+    fireEvent.change(box, { target: { value: 'still needs' } });
+    await waitFor(() => expect(screen.queryByText(RESOLVED_COMMENT.text)).toBeNull());
+
+    rerender(
+      <SettingsProvider>
+        <CommentListSurface
+          comments={[OPEN_COMMENT, RESOLVED_COMMENT]}
+          activeCommentId={null}
+          missingAnchors={new Set<string>()}
+          onActivate={vi.fn()}
+          onDelete={vi.fn()}
+          onEdit={vi.fn()}
+          onReply={vi.fn()}
+          onEditReply={vi.fn()}
+          onDeleteReply={vi.fn()}
+          onBulkDelete={vi.fn()}
+          requestedFocus={{ commentId: RESOLVED_COMMENT.id, token: 1 }}
+        />
+      </SettingsProvider>,
+    );
+
+    await waitFor(() =>
+      expect((screen.getByPlaceholderText('Search') as HTMLInputElement).value).toBe(''),
+    );
+  });
+});

--- a/src/components/CommentListSurface.tsx
+++ b/src/components/CommentListSurface.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
-import type { MdComment } from '../types';
+import type { CommentStatus, MdComment } from '../types';
+import type { CommentFocusOrigin } from '../hooks/useComments';
 import { anchorSearchText, getEffectiveStatus } from '../types';
 import type { SidebarCommentEditorState } from '../lib/comment-editor-state';
 import { ThreadCard } from './ThreadCard';
@@ -16,6 +17,7 @@ export interface SidebarContextMenuInfo {
 export interface SidebarCommentFocusRequest {
   commentId: string;
   token: number;
+  origin?: CommentFocusOrigin;
 }
 
 interface Props {
@@ -44,6 +46,34 @@ interface Props {
 }
 
 type FilterMode = 'all' | 'open' | 'resolved';
+
+/**
+ * Whether a comment survives the list's search box. One definition for the
+ * three places that ask: the rendered list, the activation widen, and the
+ * focus-request widen. They disagreed before, which is how a focus request
+ * came to throw away a search that was not hiding anything.
+ */
+function matchesSearch(c: MdComment, search: string): boolean {
+  if (!search) return true;
+  const q = search.toLowerCase();
+  return (
+    c.text.toLowerCase().includes(q) ||
+    anchorSearchText(c).includes(q) ||
+    c.author.toLowerCase().includes(q) ||
+    (c.replies?.some((r) => r.text.toLowerCase().includes(q)) ?? false)
+  );
+}
+
+/**
+ * The filter to widen to so a comment of `status` becomes visible, or null
+ * when the current filter already shows it. Resolved widens to All rather
+ * than Resolved: the reviewer asked to see one settled thread, not to hide
+ * every open one.
+ */
+function widenedFilter(filter: FilterMode, status: CommentStatus): FilterMode | null {
+  if (filter === 'all' || filter === status) return null;
+  return status === 'open' ? 'open' : 'all';
+}
 
 export function CommentListSurface({
   comments,
@@ -108,25 +138,51 @@ export function CommentListSurface({
   useEffect(() => {
     if (!requestedFocus) return;
 
-    if (search) {
+    const target = comments.find((c) => c.id === requestedFocus.commentId);
+
+    // Clear the search only when the search is what hides the card. Every
+    // highlight click and density tick routes a focus request through here
+    // now, so an unconditional clear threw away a reviewer's search on a
+    // click that was already showing them the card they asked for.
+    if (search && !(target && matchesSearch(target, search))) {
       setSearch('');
       return;
     }
 
-    if (resolveEnabled && filter === 'resolved') {
-      setFilter('open');
-      return;
+    // Widen toward the requested comment's own status, not toward a fixed
+    // filter. Both halves of the filter can hide a card: Open hides a resolved
+    // comment whose trace was just clicked, and Resolved hides an open one.
+    // Picking a destination without reading the status gets the second case
+    // right and the first case backwards. A request naming a comment that no
+    // longer exists widens nothing: there is no status to widen toward, and
+    // guessing "open" used to yank the reviewer off the Resolved filter for a
+    // card that was never going to appear.
+    if (resolveEnabled && target) {
+      const widened = widenedFilter(filter, getEffectiveStatus(target));
+      if (widened) {
+        setFilter(widened);
+        return;
+      }
     }
 
     const node = commentRefs.current.get(requestedFocus.commentId);
     if (!node) return;
 
+    // Scroll always; take DOM focus only when the reviewer asked to go to the
+    // card. A click on a highlight in the prose is a request to SEE it, and
+    // the card is right there beside the text once scrolled; pulling focus
+    // out of the document for it means the next space or PageDown scrolls
+    // the rail, Tab walks the cards, and a screen reader is lifted out of the
+    // sentence being read. Requests that named the card (see
+    // CommentFocusOrigin) still land on it.
+    const takesFocus = requestedFocus.origin !== 'highlight';
+
     scrollCardIntoList(node);
     requestAnimationFrame(() => {
-      node.focus({ preventScroll: true });
+      if (takesFocus) node.focus({ preventScroll: true });
       onFocusHandled?.();
     });
-  }, [requestedFocus, resolveEnabled, filter, search, onFocusHandled]);
+  }, [requestedFocus, resolveEnabled, filter, search, comments, onFocusHandled]);
 
   // Activating a comment the current filter or search hides widens the view
   // so its card is visible. Clicking a highlight means "show me this
@@ -140,20 +196,9 @@ export function CommentListSurface({
     if (!activeCommentId) return;
     const c = comments.find((x) => x.id === activeCommentId);
     if (!c) return;
-    const status = getEffectiveStatus(c);
-    const hiddenByFilter =
-      resolveEnabled &&
-      ((filter === 'open' && status !== 'open') ||
-        (filter === 'resolved' && status !== 'resolved'));
-    const q = search.toLowerCase();
-    const hiddenBySearch =
-      search !== '' &&
-      !c.text.toLowerCase().includes(q) &&
-      !anchorSearchText(c).includes(q) &&
-      !c.author.toLowerCase().includes(q) &&
-      !(c.replies?.some((r) => r.text.toLowerCase().includes(q)) ?? false);
-    if (hiddenBySearch) setSearch('');
-    if (hiddenByFilter) setFilter(status === 'open' ? 'open' : 'all');
+    const widened = resolveEnabled ? widenedFilter(filter, getEffectiveStatus(c)) : null;
+    if (!matchesSearch(c, search)) setSearch('');
+    if (widened) setFilter(widened);
   }, [activeCommentId, comments, filter, search, resolveEnabled]);
 
   useEffect(() => {
@@ -213,16 +258,7 @@ export function CommentListSurface({
     }
 
     // Text search
-    if (search) {
-      const q = search.toLowerCase();
-      const matchesText = c.text.toLowerCase().includes(q);
-      const matchesAnchor = anchorSearchText(c).includes(q);
-      const matchesAuthor = c.author.toLowerCase().includes(q);
-      const matchesReply = c.replies?.some((r) => r.text.toLowerCase().includes(q)) ?? false;
-      if (!matchesText && !matchesAnchor && !matchesAuthor && !matchesReply) return false;
-    }
-
-    return true;
+    return matchesSearch(c, search);
   });
 
   // Sort: open first, then resolved (only when resolve enabled).

--- a/src/components/MarkdownViewer.mermaid.test.tsx
+++ b/src/components/MarkdownViewer.mermaid.test.tsx
@@ -31,6 +31,18 @@ sequenceDiagram
 \`\`\`
 `;
 
+/** SVG mimicking a mermaid flowchart node, whose label is real HTML inside a
+ *  foreignObject, which is the case that DOES get an HTML <mark>. */
+const FLOWCHART_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 100"><g><foreignObject width="200" height="40"><div xmlns="http://www.w3.org/1999/xhtml" class="label"><span class="nodeLabel">Validate token</span></div></foreignObject></g></svg>`;
+
+const FLOWCHART_MARKDOWN = `# Token Flow
+
+\`\`\`mermaid
+flowchart TD
+    A[Validate token] --> B[Done]
+\`\`\`
+`;
+
 function baseProps() {
   return {
     html: renderMarkdown(SEQUENCE_MARKDOWN),
@@ -124,5 +136,107 @@ describe('MarkdownViewer: mermaid sequence-diagram comment highlights', () => {
     // Still no HTML <mark> inside the SVG text.
     expect(svgText.querySelector('mark')).toBeNull();
     expect(svgText.textContent).toBe('POST /auth/login');
+  });
+
+  it('leaves a resolved anchor unpainted on an SVG <text> label', async () => {
+    // A trace in a diagram would have to be a rect drawn over the label, which
+    // is not faint by any reading. Diagrams keep the pre-trace behaviour.
+    const comment: MdComment = {
+      id: 'c-auth',
+      anchor: 'auth',
+      text: 'settled',
+      author: 'Test',
+      timestamp: '2026-04-11T00:00:00.000Z',
+      status: 'resolved',
+      contextBefore: 'POST /',
+      contextAfter: '/login',
+    };
+
+    const { container } = render(
+      <MarkdownViewer {...baseProps()} comments={[comment]} enableResolve />,
+    );
+    const svgText = await waitForMermaidText(container);
+
+    expect(svgText.classList.contains('mermaid-comment-highlight')).toBe(false);
+    expect((svgText as SVGElement).dataset.commentIds).toBeUndefined();
+  });
+});
+
+describe('MarkdownViewer: mermaid flowchart foreignObject labels', () => {
+  beforeEach(() => {
+    mockHasMermaidBlocks.mockReset();
+    mockRenderMermaidBlock.mockReset();
+    mockHasMermaidBlocks.mockReturnValue(true);
+    mockRenderMermaidBlock.mockResolvedValue({ svg: FLOWCHART_SVG });
+  });
+
+  function flowchartProps() {
+    return {
+      ...baseProps(),
+      html: renderMarkdown(FLOWCHART_MARKDOWN),
+      cleanMarkdown: FLOWCHART_MARKDOWN,
+    };
+  }
+
+  async function waitForLabel(container: HTMLElement) {
+    await waitFor(() => {
+      if (!container.querySelector('.mermaid-block foreignObject .nodeLabel')) {
+        throw new Error('mermaid label not rendered yet');
+      }
+    });
+    return container.querySelector('.mermaid-block foreignObject .nodeLabel')!;
+  }
+
+  it('strips a resolved mark of everything that makes it a click target', async () => {
+    // The underline cannot paint here (quirk 2), so a resolved mark left in
+    // place is invisible AND still clickable: it opens a popover from blank
+    // -looking label text and puts a density tick where there is no trace.
+    const comment: MdComment = {
+      id: 'c-token',
+      anchor: 'Validate token',
+      text: 'settled',
+      author: 'Test',
+      timestamp: '2026-04-11T00:00:00.000Z',
+      status: 'resolved',
+    };
+
+    const { container } = render(
+      <MarkdownViewer {...flowchartProps()} comments={[comment]} enableResolve />,
+    );
+    await waitForLabel(container);
+
+    await waitFor(() => {
+      expect(container.querySelector('.mermaid-block mark.comment-highlight-resolved')).toBeNull();
+    });
+    expect(
+      container.querySelector('.mermaid-block mark.comment-highlight-resolved-active'),
+    ).toBeNull();
+    // No survivor carries the id list the click and tick paths read.
+    for (const el of container.querySelectorAll('.mermaid-block [data-comment-ids]')) {
+      expect((el as HTMLElement).dataset.commentIds).toBeUndefined();
+    }
+  });
+
+  it('still converts an OPEN mark in a foreignObject to the inline-style treatment', async () => {
+    // Guards the fix above against over-reach: only the resolved branch is
+    // stripped, the open one keeps its id list and gets the mermaid classes.
+    const comment: MdComment = {
+      id: 'c-token',
+      anchor: 'Validate token',
+      text: 'live',
+      author: 'Test',
+      timestamp: '2026-04-11T00:00:00.000Z',
+    };
+
+    const { container } = render(
+      <MarkdownViewer {...flowchartProps()} comments={[comment]} enableResolve />,
+    );
+    await waitForLabel(container);
+
+    await waitFor(() => {
+      const mark = container.querySelector('.mermaid-block mark.mermaid-comment-highlight');
+      expect(mark).not.toBeNull();
+      expect((mark as HTMLElement).dataset.commentIds).toBe('c-token');
+    });
   });
 });

--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import {
   MarkdownViewer,
@@ -475,5 +475,251 @@ describe('MarkdownViewer selection highlights', () => {
 
     const leadingCode = paragraph?.querySelector('mark.selection-highlight > code');
     expect(leadingCode?.textContent).toBe('md-redline');
+  });
+});
+
+describe('MarkdownViewer comment highlights — resolved anchors', () => {
+  const markdown = '# Doc\n\nThe timing question is two questions being conflated here.\n';
+  const html = renderMarkdown(markdown);
+
+  const base = {
+    anchor: 'two questions',
+    text: 'Worth splitting?',
+    author: 'Dennis',
+    timestamp: new Date().toISOString(),
+  };
+
+  function renderWith(comments: Parameters<typeof MarkdownViewer>[0]['comments'], resolve = true) {
+    return render(
+      <MarkdownViewer
+        html={html}
+        cleanMarkdown={markdown}
+        comments={comments}
+        activeCommentId={null}
+        selectionText={null}
+        selectionOffset={null}
+        enableResolve={resolve}
+        onHighlightClick={vi.fn()}
+      />,
+    );
+  }
+
+  it('paints a resolved anchor as a trace rather than dropping it', async () => {
+    // Resolved anchors used to be skipped entirely, which left no sign that a
+    // passage had ever been discussed.
+    const { container } = renderWith([{ ...base, id: 'c1', status: 'resolved' as const }]);
+
+    await waitFor(() => {
+      const mark = container.querySelector('mark.comment-highlight-resolved');
+      expect(mark).not.toBeNull();
+      expect(mark?.textContent).toBe('two questions');
+      expect((mark as HTMLElement).dataset.commentIds).toBe('c1');
+    });
+    expect(container.querySelector('mark.comment-highlight')).toBeNull();
+  });
+
+  it('keeps the full highlight when one comment on the anchor is still open', async () => {
+    // Same anchor and offset puts both comments in one highlight group, and
+    // that group paints one mark. The passage still has something live on it,
+    // so the open treatment has to win.
+    //
+    // The resolved id stays OUT of that mark. Consumers read this list as the
+    // comments the mark answers for: the click handler and context menu take
+    // the first, drag-resize rewrites the anchor of every one, and the density
+    // strip emits a tick per one. A settled id riding along in a mark that
+    // paints as live reaches all three, and the drag one writes to the file.
+    const { container } = renderWith([
+      { ...base, id: 'c1', status: 'resolved' as const },
+      { ...base, id: 'c2' },
+    ]);
+
+    await waitFor(() => {
+      const mark = container.querySelector('mark.comment-highlight');
+      expect(mark).not.toBeNull();
+      expect((mark as HTMLElement).dataset.commentIds).toBe('c2');
+    });
+    expect(container.querySelector('mark.comment-highlight-resolved')).toBeNull();
+  });
+
+  it('clicking a mixed group activates the open comment, not the resolved one', async () => {
+    // The mark paints as open, and the rail is holding the open comment's card.
+    // Handing the click to the resolved id would open the settled thread in a
+    // popover while the card the user is looking at stays untouched.
+    const onHighlightClick = vi.fn();
+    const { container } = render(
+      <MarkdownViewer
+        html={html}
+        cleanMarkdown={markdown}
+        comments={[
+          { ...base, id: 'c1', status: 'resolved' as const },
+          { ...base, id: 'c2' },
+        ]}
+        activeCommentId={null}
+        selectionText={null}
+        selectionOffset={null}
+        enableResolve
+        onHighlightClick={onHighlightClick}
+      />,
+    );
+
+    const mark = await waitFor(() => {
+      const el = container.querySelector('mark.comment-highlight');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    fireEvent.click(mark);
+    expect(onHighlightClick).toHaveBeenCalledWith('c2');
+  });
+
+  it('does not light a mixed group when the resolved member is the active one', async () => {
+    // The active styles are the open ones here, and getActiveMarks feeds
+    // drag-resize off `.comment-highlight-active`. Letting a settled comment
+    // switch them on puts the full fill on the passage and hands out anchor
+    // handles for a thread that cannot even be edited.
+    const { container } = render(
+      <MarkdownViewer
+        html={html}
+        cleanMarkdown={markdown}
+        comments={[
+          { ...base, id: 'c1', status: 'resolved' as const },
+          { ...base, id: 'c2' },
+        ]}
+        activeCommentId="c1"
+        selectionText={null}
+        selectionOffset={null}
+        enableResolve
+        onHighlightClick={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('mark.comment-highlight')).not.toBeNull();
+    });
+    expect(container.querySelector('mark.comment-highlight-active')).toBeNull();
+    expect(container.querySelector('mark.comment-highlight-resolved-active')).toBeNull();
+  });
+
+  it('treats resolved as open when the resolve feature is off', async () => {
+    const { container } = renderWith([{ ...base, id: 'c1', status: 'resolved' as const }], false);
+
+    await waitFor(() => {
+      expect(container.querySelector('mark.comment-highlight')).not.toBeNull();
+    });
+    expect(container.querySelector('mark.comment-highlight-resolved')).toBeNull();
+  });
+
+  it('marks the active resolved trace without giving it the open active fill', async () => {
+    const { container } = render(
+      <MarkdownViewer
+        html={html}
+        cleanMarkdown={markdown}
+        comments={[{ ...base, id: 'c1', status: 'resolved' as const }]}
+        activeCommentId="c1"
+        selectionText={null}
+        selectionOffset={null}
+        enableResolve
+        onHighlightClick={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('mark.comment-highlight-resolved-active')).not.toBeNull();
+    });
+    expect(container.querySelector('mark.comment-highlight-active')).toBeNull();
+  });
+});
+
+describe('MarkdownViewer comment highlights — overlapping resolved and open anchors', () => {
+  // Anchors that OVERLAP without matching land in different highlight groups,
+  // so the mixed-group rules above never see them. wrapText walks into marks
+  // that are already painted, so the shorter anchor nests inside the longer
+  // one and `closest` hands a click on the shared words to the inner mark.
+  const markdown = '# Doc\n\nThe system blocks brute force attacks reliably.\n';
+  const html = renderMarkdown(markdown);
+
+  const base = {
+    text: 'Worth a look',
+    author: 'Dennis',
+    timestamp: new Date().toISOString(),
+  };
+
+  function renderOverlapping(onHighlightClick: () => void) {
+    return render(
+      <MarkdownViewer
+        html={html}
+        cleanMarkdown={markdown}
+        comments={[
+          { ...base, id: 'open-1', anchor: 'brute force attacks' },
+          { ...base, id: 'settled-1', anchor: 'brute force', status: 'resolved' as const },
+        ]}
+        activeCommentId={null}
+        selectionText={null}
+        selectionOffset={null}
+        enableResolve
+        onHighlightClick={onHighlightClick}
+      />,
+    );
+  }
+
+  it('nests the trace inside the live highlight', async () => {
+    const { container } = renderOverlapping(vi.fn());
+
+    // Pins the premise the click test below depends on. If painting ever
+    // stops nesting these, that test would pass for the wrong reason.
+    const trace = await waitFor(() => {
+      const el = container.querySelector('mark.comment-highlight-resolved');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    expect(trace.closest('mark.comment-highlight')).not.toBeNull();
+  });
+
+  it('gives a click on the overlap to the open comment, not the settled one', async () => {
+    const onHighlightClick = vi.fn();
+    const { container } = renderOverlapping(onHighlightClick);
+
+    const trace = await waitFor(() => {
+      const el = container.querySelector('mark.comment-highlight-resolved');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    // A click that lands squarely on the trace: the innermost mark is the
+    // settled thread, and taking it would open a resolved comment while the
+    // live one's card sits untouched in the rail.
+    fireEvent.click(trace);
+    expect(onHighlightClick).toHaveBeenCalledWith('open-1');
+  });
+
+  it('still opens a trace that no live highlight encloses', async () => {
+    // The preference is for an OPEN ancestor, not against traces: a trace
+    // standing on its own is the only thing on that passage and stays
+    // clickable.
+    const onHighlightClick = vi.fn();
+    const { container } = render(
+      <MarkdownViewer
+        html={html}
+        cleanMarkdown={markdown}
+        comments={[
+          { ...base, id: 'open-1', anchor: 'The system blocks' },
+          { ...base, id: 'settled-1', anchor: 'reliably', status: 'resolved' as const },
+        ]}
+        activeCommentId={null}
+        selectionText={null}
+        selectionOffset={null}
+        enableResolve
+        onHighlightClick={onHighlightClick}
+      />,
+    );
+
+    const trace = await waitFor(() => {
+      const el = container.querySelector('mark.comment-highlight-resolved');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    fireEvent.click(trace);
+    expect(onHighlightClick).toHaveBeenCalledWith('settled-1');
   });
 });

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -59,6 +59,46 @@ export interface TocHeading {
   level: number; // 1-6
 }
 
+/**
+ * Every painted comment mark that answers for a thread: what a click, a
+ * right-click, and scroll-to-comment all look for. One list, because the three
+ * of them have to agree: a class wired into the click path but missed in the
+ * context-menu path is a mark you can open but not act on.
+ *
+ * Deliberately NOT the list the active-mark queries use. Those drive
+ * drag-resize, and `comment-highlight-resolved-active` is left out of them on
+ * purpose: a settled thread offers no anchor handles, and nothing in
+ * useDragHandles checks status, so this omission is the only thing enforcing
+ * that.
+ */
+const COMMENT_MARK_SELECTOR =
+  '.comment-highlight, .comment-highlight-sent, .comment-highlight-resolved, .mermaid-comment-highlight';
+
+/**
+ * The mark a pointer event should act on. `closest` returns the innermost, and
+ * for anchors that OVERLAP without matching, the innermost is whichever group
+ * happened to be painted last: wrapText walks into existing marks, so a
+ * resolved trace on "brute force" nests inside an open comment's mark on
+ * "brute force attacks". Clicking the shared words would then open the settled
+ * thread while the live comment's card sat untouched.
+ *
+ * An open comment still needs a decision and a resolved one is a memento, so
+ * the live ancestor wins. The cost is that a trace entirely enclosed by an open
+ * highlight cannot be clicked; it stays visible, and the thread is still
+ * reachable from the rail. Traces that merely start or end inside another
+ * anchor keep the part of themselves that sticks out.
+ */
+function markToAct(target: HTMLElement): HTMLElement | null {
+  const mark = target.closest(COMMENT_MARK_SELECTOR) as HTMLElement | null;
+  if (!mark?.classList.contains('comment-highlight-resolved')) return mark;
+  let ancestor = mark.parentElement?.closest(COMMENT_MARK_SELECTOR) as HTMLElement | null;
+  while (ancestor) {
+    if (!ancestor.classList.contains('comment-highlight-resolved')) return ancestor;
+    ancestor = ancestor.parentElement?.closest(COMMENT_MARK_SELECTOR) as HTMLElement | null;
+  }
+  return mark;
+}
+
 export interface MarkdownViewerHandle {
   getContainer: () => HTMLElement | null;
   scrollToComment: (commentId: string) => void;
@@ -126,9 +166,7 @@ export const MarkdownViewer = memo(
       getContainer: () => containerRef.current,
       scrollToComment: (commentId: string) => {
         if (!containerRef.current) return;
-        const marks = containerRef.current.querySelectorAll(
-          '.comment-highlight, .comment-highlight-sent, .mermaid-comment-highlight',
-        );
+        const marks = containerRef.current.querySelectorAll(COMMENT_MARK_SELECTOR);
         const mark = Array.from(marks).find((m) =>
           (m as HTMLElement).dataset.commentIds?.split(',').includes(commentId),
         );
@@ -271,10 +309,20 @@ export const MarkdownViewer = memo(
       // second comment silently rides along on it. Their contexts differ, so
       // including them keeps the groups apart and lets findMatchRange resolve
       // each one to its own occurrence.
+      // Open and resolved ids are collected apart because a group that has any
+      // open member paints the full highlight, and that mark then answers for
+      // its OPEN comments only. Everything downstream consumes the whole id
+      // list: the click handler and context menu take the first, drag-resize
+      // rewrites the anchor of every one, useCommentTicks emits one tick per
+      // one. A settled id riding along in a mark that paints as live drags a
+      // thread nobody can see into all three. Resolved anchors earn a mark of
+      // their own only where nothing live is already covering the passage,
+      // which is what the pass did before it grouped them at all.
       const highlightGroups = new Map<
         string,
         {
-          ids: string[];
+          openIds: string[];
+          resolvedIds: string[];
           anchor: string;
           plainOffset?: number;
           contextBefore?: string;
@@ -282,7 +330,11 @@ export const MarkdownViewer = memo(
         }
       >();
       for (const comment of comments) {
-        if (enableResolve && getEffectiveStatus(comment) === 'resolved') continue;
+        // Resolved anchors used to be dropped here, which left no trace that a
+        // passage had ever been discussed. They now paint a faint dotted
+        // underline instead (see comment-highlight-resolved) and still get no
+        // margin card, since marginComments filters them out in App.
+        const isResolved = enableResolve === true && getEffectiveStatus(comment) === 'resolved';
         const plainOffset =
           comment.cleanOffset != null ? toPlainOffset(comment.cleanOffset) : undefined;
         // Joined on an explicit NUL escape, never a raw NUL byte in the
@@ -310,13 +362,14 @@ export const MarkdownViewer = memo(
           contextAfter ?? '',
         ].join('\u0000');
         const group = highlightGroups.get(key) || {
-          ids: [],
+          openIds: [],
+          resolvedIds: [],
           anchor: anchorText,
           plainOffset,
           contextBefore,
           contextAfter,
         };
-        group.ids.push(comment.id);
+        (isResolved ? group.resolvedIds : group.openIds).push(comment.id);
         highlightGroups.set(key, group);
       }
 
@@ -324,11 +377,17 @@ export const MarkdownViewer = memo(
 
       for (const {
         anchor,
-        ids,
+        openIds,
+        resolvedIds,
         plainOffset,
         contextBefore,
         contextAfter,
       } of highlightGroups.values()) {
+        // Nothing open on this passage means the trace is the whole story;
+        // otherwise the live comments own the mark and the settled ones sit it
+        // out, exactly as they did before they were painted at all.
+        const allResolved = openIds.length === 0;
+        const ids = allResolved ? resolvedIds : openIds;
         const isActive = ids.includes(activeCommentId || '');
         const allSent =
           sentCommentIds &&
@@ -338,10 +397,18 @@ export const MarkdownViewer = memo(
           container,
           anchor,
           (mark) => {
-            mark.className = allSent ? 'comment-highlight-sent' : 'comment-highlight';
+            mark.className = allResolved
+              ? 'comment-highlight-resolved'
+              : allSent
+                ? 'comment-highlight-sent'
+                : 'comment-highlight';
             mark.dataset.commentIds = ids.join(',');
             if (isActive) {
-              mark.classList.add('comment-highlight-active');
+              // The open active style fills the background, which would undo
+              // the whole point of a trace, so resolved gets its own.
+              mark.classList.add(
+                allResolved ? 'comment-highlight-resolved-active' : 'comment-highlight-active',
+              );
             }
           },
           plainOffset,
@@ -354,6 +421,10 @@ export const MarkdownViewer = memo(
           // `.mermaid-comment-highlight` + `dataset.commentIds`.
           (textEl, matchStart, matchEnd) => {
             if (!textEl.closest('.mermaid-block')) return;
+            // A trace inside a diagram would have to be drawn as a rect over
+            // the label, which is not faint by any reading. Resolved anchors
+            // stay unpainted in diagrams, exactly as before this change.
+            if (allResolved) return;
             textEl.classList.add('mermaid-comment-highlight');
             if (isActive) {
               textEl.classList.add('mermaid-comment-highlight-active');
@@ -388,9 +459,20 @@ export const MarkdownViewer = memo(
       // 4. Headless Chromium does NOT reproduce these issues — can't verify headlessly.
       // Solution: keep the <mark> but swap class styles for inline styles.
       for (const mark of container.querySelectorAll(
-        '.mermaid-block mark.comment-highlight, .mermaid-block mark.comment-highlight-sent, .mermaid-block mark.comment-highlight-active',
+        '.mermaid-block mark.comment-highlight, .mermaid-block mark.comment-highlight-sent, .mermaid-block mark.comment-highlight-active, .mermaid-block mark.comment-highlight-resolved',
       )) {
         const el = mark as HTMLElement;
+        // A resolved anchor inside a diagram paints nothing (quirk 2 rules out
+        // the underline), which leaves a mark that is invisible and still a
+        // click target: it would open a popover from blank-looking label text
+        // and put a density tick where there is no trace to jump to. Diagrams
+        // keep the pre-trace behaviour, so strip what makes it interactive
+        // rather than only what makes it visible.
+        if (el.classList.contains('comment-highlight-resolved')) {
+          el.classList.remove('comment-highlight-resolved', 'comment-highlight-resolved-active');
+          delete el.dataset.commentIds;
+          continue;
+        }
         const isActive = el.classList.contains('comment-highlight-active');
         el.classList.remove(
           'comment-highlight',
@@ -525,9 +607,7 @@ export const MarkdownViewer = memo(
         return;
       }
 
-      const mark = (e.target as HTMLElement).closest(
-        '.comment-highlight, .comment-highlight-sent, .mermaid-comment-highlight',
-      ) as HTMLElement | null;
+      const mark = markToAct(e.target as HTMLElement);
       if (mark?.dataset.commentIds) {
         const ids = mark.dataset.commentIds.split(',');
         onHighlightClick(ids[0]);
@@ -538,9 +618,7 @@ export const MarkdownViewer = memo(
       if (!onCtxMenu) return;
 
       // Check if right-click is on a comment highlight
-      const mark = (e.target as HTMLElement).closest(
-        '.comment-highlight, .comment-highlight-sent, .mermaid-comment-highlight',
-      ) as HTMLElement | null;
+      const mark = markToAct(e.target as HTMLElement);
       if (mark?.dataset.commentIds) {
         e.preventDefault();
         const ids = mark.dataset.commentIds.split(',');

--- a/src/hooks/useCommentTicks.test.tsx
+++ b/src/hooks/useCommentTicks.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, cleanup } from '@testing-library/react';
+import type { RefObject } from 'react';
+import { useCommentTicks } from './useCommentTicks';
+import type { MdComment } from '../types';
+
+// jsdom has no ResizeObserver; the hook's late-reflow effect constructs one.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function comment(overrides: Partial<MdComment> & { id: string }): MdComment {
+  return {
+    anchor: 'an anchor',
+    text: 'A comment',
+    author: 'Dennis',
+    timestamp: '2026-08-07T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * A scroll container holding one painted mark per id. Every rect is zero in
+ * jsdom, which is fine: these tests are about which kind each tick gets, not
+ * where it lands.
+ */
+function mountContainer(ids: string[]): RefObject<HTMLElement | null> {
+  const container = document.createElement('div');
+  const prose = document.createElement('div');
+  container.appendChild(prose);
+  for (const id of ids) {
+    const mark = document.createElement('mark');
+    mark.dataset.commentIds = id;
+    prose.appendChild(mark);
+  }
+  document.body.appendChild(container);
+  return { current: container };
+}
+
+function kindsFor(comments: MdComment[]): Record<string, string> {
+  const ref = mountContainer(comments.map((c) => c.id));
+  const { result } = renderHook(() => useCommentTicks(ref, comments, true, 1));
+  return Object.fromEntries(result.current.map((t) => [t.id, t.kind]));
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+  vi.unstubAllGlobals();
+});
+
+describe('useCommentTicks tick kind', () => {
+  // Only addReply/appendReply clear expectsReply, so an ask the reviewer
+  // settles without answering keeps the flag forever. Testing it before
+  // status paints the accent tick reserved for questions still waiting on
+  // someone, which contradicts the banner (selectAgentAsks filters asks to
+  // open comments) and the trace's own premise that a settled anchor is
+  // quiet. Unreachable until resolved anchors started painting a mark for
+  // measureAnchorTops to find, which is why it shipped.
+  it('paints a settled agent ask as resolved, not as a pending ask', () => {
+    const kinds = kindsFor([
+      comment({ id: 'settled-ask', expectsReply: true, status: 'resolved' }),
+    ]);
+    expect(kinds['settled-ask']).toBe('resolved');
+  });
+
+  it('still paints an unanswered ask on an open comment as an ask', () => {
+    const kinds = kindsFor([comment({ id: 'live-ask', expectsReply: true })]);
+    expect(kinds['live-ask']).toBe('ask');
+  });
+
+  it('distinguishes the three kinds in one pass', () => {
+    const kinds = kindsFor([
+      comment({ id: 'plain' }),
+      comment({ id: 'asking', expectsReply: true }),
+      comment({ id: 'done', status: 'resolved' }),
+      // The legacy boolean spelling of resolved, via getEffectiveStatus.
+      comment({ id: 'done-legacy', resolved: true, expectsReply: true }),
+    ]);
+    expect(kinds).toEqual({
+      plain: 'open',
+      asking: 'ask',
+      done: 'resolved',
+      'done-legacy': 'resolved',
+    });
+  });
+
+  it('skips comments with no painted mark to measure', () => {
+    const ref = mountContainer(['painted']);
+    const comments = [comment({ id: 'painted' }), comment({ id: 'unpainted' })];
+    const { result } = renderHook(() => useCommentTicks(ref, comments, true, 1));
+    expect(result.current.map((t) => t.id)).toEqual(['painted']);
+  });
+});

--- a/src/hooks/useCommentTicks.ts
+++ b/src/hooks/useCommentTicks.ts
@@ -40,11 +40,14 @@ export function useCommentTicks(
     for (const c of comments) {
       const top = anchorTops.get(c.id);
       if (top === undefined) continue;
-      const kind: TickKind = c.expectsReply
-        ? 'ask'
-        : getEffectiveStatus(c) === 'resolved'
-          ? 'resolved'
-          : 'open';
+      // Resolved outranks expectsReply. Only a reply clears that flag, so an
+      // ask the reviewer settled without answering still carries it, and the
+      // accent tick is reserved for questions still waiting on someone. This
+      // matches selectAgentAsks, which filters asks to open comments for the
+      // same reason. It only became reachable once resolved anchors started
+      // painting a mark for measureAnchorTops to find.
+      const kind: TickKind =
+        getEffectiveStatus(c) === 'resolved' ? 'resolved' : c.expectsReply ? 'ask' : 'open';
       next.push({
         id: c.id,
         y01: Math.min(Math.max(top / scrollHeight, 0), 1),

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -38,6 +38,21 @@ interface TabInfo {
   rawMarkdown: string;
 }
 
+/**
+ * Why a comment-focus request was made. Declared once: App owns the state and
+ * this hook is handed the setter, and the two copies had already drifted
+ * ('highlight' was added to App's union only).
+ *
+ * Only 'highlight' leaves DOM focus where it is. It means the reviewer clicked
+ * a highlight in the prose (or its density tick) while reading, and the card
+ * they want is being scrolled into view beside the text; moving focus there
+ * would take the caret, the space bar and a screen reader out of the passage
+ * mid-sentence. The rest are deliberate requests to go to a card: 'reveal'
+ * opened a surface to hold it, 'jump' came from the palette or an agent ask,
+ * 'creation' just wrote it.
+ */
+export type CommentFocusOrigin = 'creation' | 'jump' | 'highlight' | 'reveal';
+
 export interface UseCommentsParams {
   rawMarkdown: string | undefined;
   rawMarkdownRef: RefObject<string | undefined>;
@@ -52,7 +67,7 @@ export interface UseCommentsParams {
   showToast: ShowToast;
   clearSelection: () => void;
   setAutoExpandForm: Dispatch<SetStateAction<boolean>>;
-  requestCommentFocus: (commentId: string, origin?: 'creation' | 'jump') => void;
+  requestCommentFocus: (commentId: string, origin?: CommentFocusOrigin) => void;
 }
 
 export function useComments(params: UseCommentsParams) {

--- a/src/hooks/useContextMenuItems.ts
+++ b/src/hooks/useContextMenuItems.ts
@@ -41,7 +41,7 @@ export interface UseContextMenuItemsParams {
    * sidebarVisible, so bare `setSidebarVisible(true)` would strand the
    * request until some later surface mount fired it unprompted.
    */
-  ensureCommentSurface: () => void;
+  ensureCommentSurface: (commentId?: string) => void;
   selectionRef: RefObject<SelectionInfo | null>;
   lockSelection: () => void;
   setAutoExpandForm: Dispatch<SetStateAction<boolean>>;
@@ -139,32 +139,48 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
         const comment = comments.find((c) => c.id === commentId);
         if (!comment) return;
 
+        const isResolved = enableResolve && getEffectiveStatus(comment) === 'resolved';
+
+        // A resolved comment can be reopened, deleted or copied, but not edited
+        // or replied to: every card surface hides both affordances while the
+        // thread is settled (see CommentCard's isResolved gates). Resolved
+        // anchors became right-clickable when they started painting a trace,
+        // so offering the items here would be the only place in the app that
+        // promises an action nothing can carry out.
+        const threadItems: ContextMenuEntry[] = isResolved
+          ? []
+          : [
+              {
+                label: 'Edit',
+                onClick: () => {
+                  setActiveCommentId(commentId);
+                  ensureCommentSurface(commentId);
+                  triggerEdit(commentId);
+                },
+              },
+              {
+                label: 'Reply',
+                onClick: () => {
+                  setActiveCommentId(commentId);
+                  ensureCommentSurface(commentId);
+                  triggerReply(commentId);
+                },
+              },
+            ];
+
         const resolveItems: ContextMenuEntry[] = enableResolve
           ? [
-              { type: 'divider' as const },
-              getEffectiveStatus(comment) === 'resolved'
+              // No leading rule when Edit/Reply are absent: it would open the
+              // menu on a divider.
+              ...(threadItems.length ? [{ type: 'divider' as const }] : []),
+              isResolved
                 ? { label: 'Reopen', onClick: () => handleUnresolve(commentId) }
                 : { label: 'Resolve', onClick: () => handleResolve(commentId) },
             ]
           : [];
 
         const items: ContextMenuEntry[] = [
-          {
-            label: 'Edit',
-            onClick: () => {
-              setActiveCommentId(commentId);
-              ensureCommentSurface();
-              triggerEdit(commentId);
-            },
-          },
-          {
-            label: 'Reply',
-            onClick: () => {
-              setActiveCommentId(commentId);
-              ensureCommentSurface();
-              triggerReply(commentId);
-            },
-          },
+          ...threadItems,
           ...resolveItems,
           { type: 'divider' as const },
           {
@@ -185,7 +201,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
             label: 'Jump to Sidebar',
             onClick: () => {
               setActiveCommentId(commentId);
-              ensureCommentSurface();
+              ensureCommentSurface(commentId);
             },
           },
         ];

--- a/src/hooks/useDragHandles.ts
+++ b/src/hooks/useDragHandles.ts
@@ -265,8 +265,15 @@ export function useDragHandles({
         const caret = caretFromPoint(e.clientX, e.clientY);
         if (!caret || !container.contains(caret.node)) return;
 
-        // Don't allow dragging into another comment's mark
-        const parentMark = (caret.node.parentElement as Element)?.closest?.('mark');
+        // Don't allow dragging into another comment's mark. A resolved
+        // anchor's trace is not one: it is a memento of a settled thread, and
+        // overlapping it is what the drag did freely for as long as resolved
+        // comments painted nothing at all. Counting it here turns the trace
+        // into an invisible wall the drag stops dead against, with only a 1px
+        // dotted underline on screen to explain why.
+        const parentMark = (caret.node.parentElement as Element)?.closest?.(
+          'mark:not(.comment-highlight-resolved)',
+        );
         if (
           parentMark &&
           !drag.markEls.some((m) => m.contains(caret.node)) &&

--- a/src/index.css
+++ b/src/index.css
@@ -962,6 +962,64 @@ mark.comment-highlight-active {
   outline: 1px solid var(--theme-comment-ring);
 }
 
+/* A resolved anchor keeps a trace, not a highlight: the conversation is over,
+   so nothing about it should compete with the prose or with the open comments
+   still asking for a decision. No fill, no ink change, just a dotted rule
+   under the words that were discussed. Resolved comments have no margin card
+   (App filters them out of marginComments), so clicking a trace opens the
+   single-thread popover instead.
+
+   Kept in the comment ink rather than a neutral, so a trace still reads as
+   belonging to the comment system. Deriving it from each theme's own ink is
+   what lets one declaration hold for all eight; a fixed neutral could not,
+   since the faintest ink that whispers on a light ground disappears on a dark
+   one.
+
+   Quiet through coverage, not through opacity. Fading the ink costs legibility
+   per pixel, and costs it fastest on a light ground: the base underline at 42%
+   measures 1.38:1 against white, under the 3:1 floor that applies once a mark
+   is also a control, and no opacity reaches that floor because the base ink
+   itself only manages 2.15:1 at full strength. The ACTIVE ink does clear 3:1
+   in all eight themes (3.01:1 in the tightest, Sepia), so one hairline of it
+   at full strength is both more legible and less present than two pixels of a
+   wash. Measured against real prose in every theme, not picked from a palette.
+
+   Hover and active move the weight, not the colour, since full strength is
+   already spent at rest. 1px to 2px stays under the open highlight's 3px solid
+   plus fill, so a settled thread never reads as a live one. */
+.prose mark.comment-highlight-resolved,
+mark.comment-highlight-resolved {
+  background-color: transparent;
+  color: inherit;
+  text-decoration: underline dotted 1px var(--theme-comment-underline-active);
+  text-underline-offset: 3px;
+  cursor: pointer;
+  transition: text-decoration-thickness 0.15s ease;
+}
+
+/* The active selector names both classes the mark actually carries, so it
+   outranks the base rule on specificity rather than on being declared later.
+   A tie would let any equal-weight rule inserted between the two silently
+   flatten the active trace back to a hairline. */
+.prose mark.comment-highlight-resolved:hover,
+mark.comment-highlight-resolved:hover,
+.prose mark.comment-highlight-resolved.comment-highlight-resolved-active,
+mark.comment-highlight-resolved.comment-highlight-resolved-active {
+  text-decoration-thickness: 2px;
+}
+
+/* Inside a diagram the mark lives in an SVG foreignObject, where a CSS
+   text-decoration stops the label from wrapping (see the Mermaid quirks note
+   in MarkdownViewer). Diagrams keep the pre-trace behaviour: nothing painted.
+   The post-render pass strips these classes outright, so this only has to hold
+   for the window before it runs. Scoped tighter than the .prose rule it
+   overrides so that source order is not what decides the tie. */
+.prose .mermaid-block mark.comment-highlight-resolved,
+.mermaid-block mark.comment-highlight-resolved {
+  text-decoration: none;
+  cursor: auto;
+}
+
 /* Smooth scrolling for the viewer */
 .overflow-y-auto {
   scroll-behavior: smooth;

--- a/src/lib/copy-selection-html.test.ts
+++ b/src/lib/copy-selection-html.test.ts
@@ -439,6 +439,18 @@ describe('buildRangeHtml', () => {
     expect(html).toContain('found');
   });
 
+  it('unwraps the resolved trace marks too', () => {
+    // A resolved anchor is still app chrome, not document content: copying a
+    // settled passage has to paste the prose, not a <mark> carrying the trace.
+    const container = mount(
+      '<p><mark class="comment-highlight-resolved">settled</mark> and <mark class="comment-highlight-resolved comment-highlight-resolved-active">current</mark></p>',
+    );
+    const html = buildRangeHtml(rangeAcross(container, 'p'), container) ?? '';
+    expect(html).not.toContain('<mark');
+    expect(html).toContain('settled');
+    expect(html).toContain('current');
+  });
+
   it('strips viewer chrome that overlaps the selection', () => {
     const container = mount('<p>kept<span data-drag-handle>handle</span> also kept</p>');
     const html = buildRangeHtml(rangeAcross(container, 'p'), container) ?? '';

--- a/src/lib/copy-selection-html.ts
+++ b/src/lib/copy-selection-html.ts
@@ -10,7 +10,7 @@
 
 /** Highlight wrappers the app paints. None of them are document content. */
 const APP_MARK_SELECTOR =
-  'mark.selection-highlight, mark.comment-highlight, mark.comment-highlight-sent, mark.comment-highlight-active, mark.search-highlight, mark.search-highlight-active';
+  'mark.selection-highlight, mark.comment-highlight, mark.comment-highlight-sent, mark.comment-highlight-active, mark.comment-highlight-resolved, mark.comment-highlight-resolved-active, mark.search-highlight, mark.search-highlight-active';
 
 /** List containers whose items must stay wrapped to paste as a list. */
 const LIST_TAGS = new Set(['UL', 'OL']);


### PR DESCRIPTION
Resolved comments were dropped from the highlight pass entirely, so a passage that had been discussed and settled looked exactly like one nobody had ever read. The record existed only in List density's Resolved filter, which is the wrong place to notice it: you notice it while reading the prose, not while auditing the list.

Resolved anchors now paint a dotted hairline under the words that were discussed, in each theme's own active comment ink at full strength, with no fill and no ink change. Quiet through coverage rather than through opacity. Full reasoning on the contrast maths is in the commit message.

## What painting a mark where there was none pulled in

A trace is a real DOM mark, so every mechanism keyed off marks started seeing resolved comments for the first time. Most of this PR is that blast radius:

- Resolved comments reach the density strip as their own tick colour. A settled agent ask outranks its `expectsReply` flag, so it no longer paints the amber tick reserved for questions still waiting on someone.
- Anchored density gives a resolved comment no margin card, so clicking its trace opens the single-thread popover instead of a dead click. Jump to Sidebar falls back to the drawer and takes the popover with it, so the two never stack.
- Overlapping anchors nest, because `wrapText` walks into marks that are already painted. `markToAct` resolves clicks and right-clicks to the nearest open ancestor, so a live highlight keeps its own clicks rather than handing them to a settled thread nested inside it.
- Drag-resize can cross a trace. The "don't drag into another comment's mark" guard counted traces as walls, which froze the drag against a 1px dotted underline with nothing on screen to explain it.
- The trace is suppressed inside Mermaid blocks, where a `text-decoration` on a `<mark>` stops foreignObject labels from wrapping.

## Focus behaviour

Highlight clicks now scroll the rail card into view without taking DOM focus. Routing every prose click through a focus request moved focus onto a `tabIndex={-1}` card, which sent the next space or PageDown to the rail and lifted a screen reader out of the passage being read. Requests that name the card deliberately (context menu, palette, agent asks, creation) still focus it, via a new `'reveal'` origin on `CommentFocusOrigin`.

## Testing

Every regression test here was run against its own fix reverted, and each failed for the reason it documents. Three were rewritten after the first version passed in both states:

- The drag test measured the trace before `hover()` scrolled the page, so it ran against stale coordinates and produced a runaway whole-paragraph anchor that satisfied the original assertion either way.
- The raw-view test left through the toolbar button, whose mousedown dismisses the popover on the way past and hides the bug entirely. It uses the command palette now, which is pure keyboard.
- The drag repro only works with the pointer released in the middle of the trace. At its right edge, and on any single move that clears it, the caret resolves outside the mark and the guard never fires. That is noted in the test so it does not get simplified away later.

Gates: `tsc -b` clean, eslint clean, prettier clean, 1764 unit tests, 347 e2e tests.

AGENTS.md is updated for the trace, the tick kinds, the popover open and close conditions, focus origins, `markToAct`, and the drag guard. Two known limits are documented rather than fixed: a resolved comment sharing an anchor with an open one gets no trace or tick, and the fullscreen diagram modal still paints resolved labels as live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011dLCtycYS5sGWCMaC4FaxA
