### PR TITLE
Surface new replies on collapsed anchored cards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -608,9 +608,20 @@ the sendable-only map. Inline code in prose renders neutral (`--theme-text`
 on `--theme-bg-inset`), never the crimson accent:
 
 - **Anchored** (default): cards align to their document anchors. Cards are
-  compact by default (anchor text, comment preview, reply count); the active
+  compact by default (anchor text, comment preview, reply summary); the active
   card (selected by clicking its highlight or the card itself) expands to the
-  full thread view with all actions, including Reply. A connector line runs
+  full thread view with all actions, including Reply. A compact card's replies
+  collapse to a clickable disclosure line naming who replied ("2 replies from
+  Claude and Dennis", `data-testid="reply-summary"`); clicking it activates the
+  card, which is what expands the thread. Replies that arrived from outside the
+  app since the reader last opened that card are tracked per file path by
+  `useUnreadReplies` (session-only, never persisted) and fed in as
+  `unreadReplyIds`; when a card has any, the line counts and attributes only
+  those, reading "1 new reply from Claude" in the accent color with
+  `data-unread="true"`. Both watcher paths mark them (the active tab's
+  `onExternalChange` and the multiplexed background-tab SSE handler, which is
+  the case that matters most since no toast fires there). Activating a comment
+  marks its replies read in either density. A connector line runs
   from the anchor to the active (or hovered) card along the rail's left edge.
   Cards never overlap: they resolve top-down by anchor position, and the
   active card gets priority to sit at its anchor, compressing cards above it

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -618,10 +618,19 @@ on `--theme-bg-inset`), never the crimson accent:
   `useUnreadReplies` (session-only, never persisted) and fed in as
   `unreadReplyIds`; when a card has any, the line counts and attributes only
   those, reading "1 new reply from Claude" in the accent color with
-  `data-unread="true"`. Both watcher paths mark them (the active tab's
-  `onExternalChange` and the multiplexed background-tab SSE handler, which is
-  the case that matters most since no toast fires there). Activating a comment
-  marks its replies read in either density. A connector line runs
+  `data-unread="true"`. The line names at most two authors and counts the rest
+  ("3 replies from Claude, Dennis +1"); the author dots come from the same cap,
+  so every dot belongs to a name on the line. All three paths that take content
+  from disk mark arriving replies, through `applyExternalContent` in App: the
+  active tab's `onExternalChange`, the multiplexed background-tab SSE handler
+  (the case that matters most, since no toast fires there), and an explicit
+  reload. None of them mark anything while a tab's first fetch is still in
+  flight, since with no prior content to diff against the file's whole reply
+  history would look new. Activating a comment marks its replies read, in
+  either density. Only anchored density surfaces the unread state, because
+  it is the only one that hides reply text; List density renders every reply
+  in full but does not clear the marks by itself, so a reply read there stays
+  marked until the reader opens that comment. A connector line runs
   from the anchor to the active (or hovered) card along the rail's left edge.
   Cards never overlap: they resolve top-down by anchor position, and the
   active card gets priority to sit at its anchor, compressing cards above it

--- a/bin/open-launch-cli.test.ts
+++ b/bin/open-launch-cli.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawn } from 'child_process';
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { delimiter, join } from 'path';
 
@@ -40,13 +48,27 @@ function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<number | null> 
   });
 }
 
-async function waitForFile(path: string, timeoutMs: number): Promise<boolean> {
+// Waits for content, not for the file. The Windows stub writes its marker as
+// `>"marker" <nul set /p "=%~1"`, and the redirect creates the file before
+// set /p puts anything in it. Polling on existence alone returns inside that
+// window, and the caller's readFileSync then reads "" and fails a test that
+// has nothing wrong with it. Every marker these tests wait on carries a URL,
+// so non-empty is the honest signal that the stub actually ran.
+function hasContent(path: string): boolean {
+  try {
+    return statSync(path).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForMarker(path: string, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (existsSync(path)) return true;
+    if (hasContent(path)) return true;
     await new Promise((r) => setTimeout(r, 50));
   }
-  return existsSync(path);
+  return hasContent(path);
 }
 
 // Shadows the platform's own opener on PATH so the no-override default path can
@@ -88,7 +110,7 @@ describe('mdr browser launcher (subprocess)', () => {
     // The launcher is detached, so it writes the marker shortly AFTER the CLI
     // has exited — poll for it. Pre-fix (non-detached on Windows) it never
     // appears because the child was torn down with the parent.
-    const launched = await waitForFile(marker, 5000);
+    const launched = await waitForMarker(marker, 5000);
     expect(launched, 'browser stub never ran: the launcher did not survive CLI exit').toBe(true);
     expect(readFileSync(marker, 'utf8')).toBe(url);
   }, 15_000);
@@ -103,7 +125,7 @@ describe('mdr browser launcher (subprocess)', () => {
     const url = 'http://127.0.0.1:65535/legacy';
     const code = await runCli(['__open', url], cleanEnv({ MDR_BROWSER: stub }));
     expect(code).toBe(0);
-    expect(await waitForFile(marker, 5000)).toBe(true);
+    expect(await waitForMarker(marker, 5000)).toBe(true);
     expect(readFileSync(marker, 'utf8')).toBe(url);
   }, 15_000);
 
@@ -122,7 +144,7 @@ describe('mdr browser launcher (subprocess)', () => {
         cleanEnv({ MD_REDLINE_BROWSER: blank, MDR_BROWSER: stub }),
       );
       expect(code).toBe(0);
-      expect(await waitForFile(marker, 5000)).toBe(true);
+      expect(await waitForMarker(marker, 5000)).toBe(true);
       expect(readFileSync(marker, 'utf8')).toBe(url);
     },
     15_000,
@@ -147,7 +169,7 @@ describe('mdr browser launcher (subprocess)', () => {
       cleanEnv({ MD_REDLINE_BROWSER: wantedStub, MDR_BROWSER: legacyStub }),
     );
     expect(code).toBe(0);
-    expect(await waitForFile(wanted, 5000)).toBe(true);
+    expect(await waitForMarker(wanted, 5000)).toBe(true);
     expect(existsSync(legacy)).toBe(false);
   }, 15_000);
 
@@ -172,7 +194,7 @@ describe('mdr browser launcher (subprocess)', () => {
       const url = 'http://127.0.0.1:65535/default-path';
       const code = await runCli(['__open', url], env);
       expect(code).toBe(0);
-      expect(await waitForFile(marker, 5000)).toBe(true);
+      expect(await waitForMarker(marker, 5000)).toBe(true);
       expect(readFileSync(marker, 'utf8')).toBe(url);
     },
     15_000,

--- a/demo/README.md
+++ b/demo/README.md
@@ -161,7 +161,7 @@ Current stills:
   Password Management so both comment cards show. Both carry an agent (Claude)
   reply; the focused card also has an open reply composer holding an unsent
   draft (so it shows the full comment, agent reply, and in-progress reply),
-  while the other card's reply stays collapsed as a "1 reply" count.
+  while the other card's reply stays collapsed as a "1 reply from Claude" summary line.
   Seeds a restored 3-tab session
   via `localStorage` from the committed `fixtures/hero/*.md` (authentication-spec
   carries the five comments); the frame is composited in-browser around the

--- a/e2e/file-watcher.spec.ts
+++ b/e2e/file-watcher.spec.ts
@@ -258,6 +258,76 @@ test.describe('File watcher - external changes', () => {
     expect(skew).toBeLessThan(5 * 60_000);
   });
 
+  test('an agent reply arriving externally marks the anchored card as new until opened', async ({
+    page,
+  }) => {
+    // The whole point of the unread mark: an anchored card collapses a reply to
+    // a one-line summary, so without it the answer the reviewer handed off for
+    // looks identical to a thread they already read. Only the watcher can
+    // create this state, so it can't be covered below the App level.
+    await openFixture(page);
+    await page.waitForTimeout(1500);
+
+    // A second comment exists only so the first can be un-focused later: a card
+    // goes back to compact when some OTHER card becomes the active one.
+    const marker = (replies?: unknown[]) =>
+      `<!-- @comment${JSON.stringify({
+        id: 'unread-c1',
+        anchor: 'valid credentials',
+        text: 'Should we say "active credentials"?',
+        author: 'Dennis',
+        timestamp: '2025-01-01T00:00:00.000Z',
+        ...(replies ? { replies } : {}),
+      })} -->valid credentials`;
+    const otherMarker = `<!-- @comment${JSON.stringify({
+      id: 'unread-c2',
+      anchor: 'Rate limiting',
+      text: 'Unrelated second comment.',
+      author: 'Dennis',
+      timestamp: '2025-01-01T00:00:00.000Z',
+    })} -->Rate limiting`;
+    const withBoth = (replies?: unknown[]) =>
+      FIXTURE_ORIGINAL.replace('valid credentials', marker(replies)).replace(
+        'Rate limiting',
+        otherMarker,
+      );
+
+    writeFileSync(FIXTURE, withBoth());
+    await expect(page.getByText('Should we say "active credentials"?')).toBeVisible({
+      timeout: 15_000,
+    });
+    // No replies yet, so no summary line at all.
+    await expect(page.getByTestId('reply-summary')).toHaveCount(0);
+
+    writeFileSync(
+      FIXTURE,
+      withBoth([
+        {
+          id: 'unread-r1',
+          text: 'Yes, "active" is more precise.',
+          author: 'Claude',
+          timestamp: '2025-01-01T00:00:00.000Z',
+        },
+      ]),
+    );
+
+    const summary = page.getByTestId('reply-summary');
+    await expect(summary).toHaveText('1 new reply from Claude', { timeout: 15_000 });
+    await expect(summary).toHaveAttribute('data-unread', 'true');
+
+    // Opening the card is what counts as reading it: the thread expands and the
+    // summary line goes away with it.
+    await summary.click();
+    await expect(page.getByText('Yes, "active" is more precise.')).toBeVisible();
+    await expect(page.getByTestId('reply-summary')).toHaveCount(0);
+
+    // Focusing the other card collapses this one again — the reply is now an
+    // ordinary summary, not a second round of "new".
+    await page.locator('[data-comment-card-id="unread-c2"]').click();
+    await expect(summary).toHaveText('1 reply from Claude');
+    await expect(summary).not.toHaveAttribute('data-unread', 'true');
+  });
+
   test('reply with missing timestamp does not render "Invalid Date" on first load', async ({
     page,
   }) => {

--- a/e2e/file-watcher.spec.ts
+++ b/e2e/file-watcher.spec.ts
@@ -321,7 +321,7 @@ test.describe('File watcher - external changes', () => {
     await expect(page.getByText('Yes, "active" is more precise.')).toBeVisible();
     await expect(page.getByTestId('reply-summary')).toHaveCount(0);
 
-    // Focusing the other card collapses this one again — the reply is now an
+    // Focusing the other card collapses this one again: the reply is now an
     // ordinary summary, not a second round of "new".
     await page.locator('[data-comment-card-id="unread-c2"]').click();
     await expect(summary).toHaveText('1 reply from Claude');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { useTabs } from './hooks/useTabs';
 import { useSelection } from './hooks/useSelection';
 import { useRecentFiles } from './hooks/useRecentFiles';
 import { useFileWatcher } from './hooks/useFileWatcher';
+import { useUnreadReplies } from './hooks/useUnreadReplies';
 import { usePageVisible } from './hooks/usePageVisible';
 import { useResizablePanel } from './hooks/useResizablePanel';
 import { useSessionPersistence, loadSession } from './hooks/useSessionPersistence';
@@ -1206,23 +1207,56 @@ export default function App() {
   // Override agent-supplied reply timestamps with the file's mtime. LLM agents
   // can't reliably know "now," so without this they hallucinate timestamps
   // that look like reasonable ISO-8601 strings but are hours stale. Returns
-  // the corrected content (or the original if no override was needed).
+  // the corrected content (or the original if no override was needed) plus the
+  // IDs of the replies that just arrived, which the caller also needs to mark
+  // them unread — computing them here saves the caller a second parse pass.
   const correctReplyTimestamps = useCallback(
-    (oldContent: string, newContent: string, mtime: number | undefined): string => {
+    (
+      oldContent: string,
+      newContent: string,
+      mtime: number | undefined,
+    ): { content: string; newReplyIds: ReadonlySet<string> } => {
       try {
         const { comments: oldComments } = parseComments(oldContent);
         const { comments: newComments } = parseComments(newContent);
         const newReplyIds = findNewReplyIds(oldComments, newComments);
-        if (newReplyIds.size === 0) return newContent;
+        if (newReplyIds.size === 0) return { content: newContent, newReplyIds };
         const fallbackIso =
           mtime != null ? new Date(mtime).toISOString() : new Date().toISOString();
-        return backfillReplyTimestamps(newContent, newReplyIds, fallbackIso);
+        return {
+          content: backfillReplyTimestamps(newContent, newReplyIds, fallbackIso),
+          newReplyIds,
+        };
       } catch {
-        return newContent;
+        return { content: newContent, newReplyIds: new Set<string>() };
       }
     },
     [],
   );
+
+  // Replies an agent added while the reader was elsewhere. Anchored cards
+  // collapse a reply to a one-line summary, so without this the thing the
+  // reader handed off for looks identical to a thread they already read.
+  const { unreadByPath, markRepliesUnread, markRepliesRead } = useUnreadReplies();
+
+  const unreadReplyIds = useMemo(
+    () => new Set(activeFilePath ? (unreadByPath[activeFilePath] ?? []) : []),
+    [unreadByPath, activeFilePath],
+  );
+
+  // Opening a comment is what counts as reading it: activating a card is
+  // exactly what drops it out of compact rendering and puts the reply text on
+  // screen, in both densities. markRepliesRead returns the previous state when
+  // nothing changes, so re-running this on every reparse is free.
+  useEffect(() => {
+    if (!activeFilePath || !activeCommentId) return;
+    const active = comments.find((c) => c.id === activeCommentId);
+    if (!active?.replies?.length) return;
+    markRepliesRead(
+      activeFilePath,
+      active.replies.map((reply) => reply.id),
+    );
+  }, [activeCommentId, activeFilePath, comments, markRepliesRead]);
 
   // File watcher — live reload from server SSE (Feature 8: detect status transitions)
   const onExternalChange = useCallback(
@@ -1286,7 +1320,14 @@ export default function App() {
         // Ignore parse errors — still update the content
       }
 
-      const nextContent = correctReplyTimestamps(rawMarkdownRef.current, content, mtime);
+      const { content: nextContent, newReplyIds } = correctReplyTimestamps(
+        rawMarkdownRef.current,
+        content,
+        mtime,
+      );
+      if (activeFilePath) {
+        markRepliesUnread(activeFilePath, newReplyIds);
+      }
 
       // Update content directly via updateTab (NOT setRawMarkdown which marks
       // dirty:true). External changes already match disk, so dirty must be false.
@@ -1355,6 +1396,7 @@ export default function App() {
     [
       activeFilePath,
       correctReplyTimestamps,
+      markRepliesUnread,
       setDiffEnabled,
       settings.enableResolve,
       showToast,
@@ -1401,7 +1443,15 @@ export default function App() {
         // handler does, so background files don't show stale times when the
         // user switches to them. No toast — background tabs aren't visible.
         const oldContent = snapshot?.rawMarkdown ?? '';
-        const nextContent = correctReplyTimestamps(oldContent, content, mtime);
+        const { content: nextContent, newReplyIds } = correctReplyTimestamps(
+          oldContent,
+          content,
+          mtime,
+        );
+        // The background case is the one that matters most: a handoff answered
+        // on a tab the reader isn't looking at. No toast fires here, so the
+        // unread mark is the only thing that survives until they switch to it.
+        markRepliesUnread(path, newReplyIds);
         updateTab(path, {
           rawMarkdown: nextContent,
           ...(mtime != null ? { mtime } : {}),
@@ -1419,6 +1469,7 @@ export default function App() {
     backgroundPathsKey,
     correctReplyTimestamps,
     getTabSnapshot,
+    markRepliesUnread,
     pageVisible,
     saveFileAt,
     updateTab,
@@ -2818,6 +2869,7 @@ export default function App() {
                             requestedEditor={requestedEditor}
                             requestedFocus={requestedCommentFocus}
                             onFocusHandled={() => setRequestedCommentFocus(null)}
+                            unreadReplyIds={unreadReplyIds}
                           />
                         )}
                         {popoverCommentId &&

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,6 +94,9 @@ import { headingChain } from './lib/heading-chain';
 import { usePageGeometry } from './hooks/usePageGeometry';
 import { PAD_L, DOC_WIDTH_COLS } from './lib/page-geometry';
 
+/** Shared empty result for the "no replies arrived" case. */
+const NO_REPLY_IDS: ReadonlySet<string> = new Set<string>();
+
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 const modKey = isMac ? '\u2318' : 'Ctrl';
 const prevTabShortcut = isMac ? '\u2318\u21e7[' : 'Ctrl+Shift+[';
@@ -113,6 +116,23 @@ export default function App() {
   const showToastRef = useRef<ShowToast | null>(null);
   const onSaveError = useCallback(
     (msg: string) => showToastRef.current?.(`Save failed: ${msg}`, 'error'),
+    [],
+  );
+
+  // useTabs runs before the reply-tracking state below it exists, so the two
+  // hooks it needs are handed over through refs assigned later in this render.
+  const applyExternalContentRef = useRef<
+    ((path: string, priorContent: string, content: string, mtime?: number) => string) | null
+  >(null);
+  const migrateUnreadPathRef = useRef<((fromPath: string, toPath: string) => void) | null>(null);
+  const onReloadedContent = useCallback(
+    (path: string, priorContent: string, content: string, mtime?: number) =>
+      applyExternalContentRef.current?.(path, priorContent, content, mtime) ?? content,
+    [],
+  );
+  const onPathResolved = useCallback(
+    (requestedPath: string, loadedPath: string) =>
+      migrateUnreadPathRef.current?.(requestedPath, loadedPath),
     [],
   );
   const {
@@ -137,7 +157,7 @@ export default function App() {
     getTabSnapshot,
     reloadFile,
     retryAllAccessDenied,
-  } = useTabs({ onSaveError });
+  } = useTabs({ onSaveError, onExternalContent: onReloadedContent, onPathResolved });
 
   // Dirty-tab close guard: when closing tabs that have unsaved changes
   // (e.g. save failed), show a confirmation dialog before discarding.
@@ -1204,31 +1224,41 @@ export default function App() {
     }
   }, [activeFilePath, setDiffEnabled, clearSelection, setActiveCommentId]);
 
-  // Override agent-supplied reply timestamps with the file's mtime. LLM agents
-  // can't reliably know "now," so without this they hallucinate timestamps
-  // that look like reasonable ISO-8601 strings but are hours stale. Returns
-  // the corrected content (or the original if no override was needed) plus the
-  // IDs of the replies that just arrived, which the caller also needs to mark
-  // them unread — computing them here saves the caller a second parse pass.
-  const correctReplyTimestamps = useCallback(
-    (
-      oldContent: string,
-      newContent: string,
-      mtime: number | undefined,
-    ): { content: string; newReplyIds: ReadonlySet<string> } => {
+  // IDs of the replies present in newContent but not in oldContent. Kept
+  // separate from the two things done with them (marking unread, stamping a
+  // timestamp) so a caller that has already parsed both sides can pass its own
+  // result in rather than paying for the parse twice.
+  const findArrivingReplies = useCallback(
+    (oldContent: string, newContent: string): ReadonlySet<string> => {
       try {
         const { comments: oldComments } = parseComments(oldContent);
         const { comments: newComments } = parseComments(newContent);
-        const newReplyIds = findNewReplyIds(oldComments, newComments);
-        if (newReplyIds.size === 0) return { content: newContent, newReplyIds };
+        return findNewReplyIds(oldComments, newComments);
+      } catch {
+        return NO_REPLY_IDS;
+      }
+    },
+    [],
+  );
+
+  // Override agent-supplied reply timestamps with the file's mtime. LLM agents
+  // can't reliably know "now," so without this they hallucinate timestamps
+  // that look like reasonable ISO-8601 strings but are hours stale. Only the
+  // replies that just arrived are stamped; the rest keep whatever the file
+  // says, which is why an unknown prior state must never reach this.
+  const correctReplyTimestamps = useCallback(
+    (
+      newContent: string,
+      arrivingReplyIds: ReadonlySet<string>,
+      mtime: number | undefined,
+    ): string => {
+      if (arrivingReplyIds.size === 0) return newContent;
+      try {
         const fallbackIso =
           mtime != null ? new Date(mtime).toISOString() : new Date().toISOString();
-        return {
-          content: backfillReplyTimestamps(newContent, newReplyIds, fallbackIso),
-          newReplyIds,
-        };
+        return backfillReplyTimestamps(newContent, arrivingReplyIds, fallbackIso);
       } catch {
-        return { content: newContent, newReplyIds: new Set<string>() };
+        return newContent;
       }
     },
     [],
@@ -1237,17 +1267,63 @@ export default function App() {
   // Replies an agent added while the reader was elsewhere. Anchored cards
   // collapse a reply to a one-line summary, so without this the thing the
   // reader handed off for looks identical to a thread they already read.
-  const { unreadByPath, markRepliesUnread, markRepliesRead } = useUnreadReplies();
+  const { unreadByPath, markRepliesUnread, markRepliesRead, migrateUnreadPath } =
+    useUnreadReplies();
+  migrateUnreadPathRef.current = migrateUnreadPath;
+
+  /**
+   * Everything that has to happen to content arriving from disk before it can
+   * land in a tab: work out which replies are new, mark them unread against
+   * that file, and stamp them with a real timestamp. Three paths take external
+   * content (the active tab's watcher, the multiplexed background watcher, and
+   * an explicit reload) and all three need the full sequence, so it lives here
+   * once instead of being remembered at each call site.
+   *
+   * `priorLoaded` is the guard that matters: a tab whose first fetch hasn't
+   * landed has no prior content to diff against, which would make the file's
+   * entire reply history look like it just arrived. That is not only a wrong
+   * unread badge, it would restamp every historical reply with the mtime and
+   * then save that over the file.
+   */
+  const applyExternalContent = useCallback(
+    (
+      path: string,
+      priorContent: string,
+      content: string,
+      mtime: number | undefined,
+      opts: { priorLoaded: boolean; arrivingReplyIds?: ReadonlySet<string> },
+    ): { content: string; arrivingReplyIds: ReadonlySet<string> } => {
+      if (!opts.priorLoaded) return { content, arrivingReplyIds: NO_REPLY_IDS };
+      const arrivingReplyIds = opts.arrivingReplyIds ?? findArrivingReplies(priorContent, content);
+      markRepliesUnread(path, arrivingReplyIds);
+      return {
+        content: correctReplyTimestamps(content, arrivingReplyIds, mtime),
+        arrivingReplyIds,
+      };
+    },
+    [correctReplyTimestamps, findArrivingReplies, markRepliesUnread],
+  );
+
+  // Reload fetches on its own inside useTabs, so it reaches the sequence above
+  // through this ref rather than by threading the callback down. Prior content
+  // of "" means the tab never loaded, so there is nothing to diff against.
+  applyExternalContentRef.current = (path, priorContent, content, mtime) =>
+    applyExternalContent(path, priorContent, content, mtime, {
+      priorLoaded: priorContent.length > 0,
+    }).content;
 
   const unreadReplyIds = useMemo(
     () => new Set(activeFilePath ? (unreadByPath[activeFilePath] ?? []) : []),
     [unreadByPath, activeFilePath],
   );
 
-  // Opening a comment is what counts as reading it: activating a card is
-  // exactly what drops it out of compact rendering and puts the reply text on
-  // screen, in both densities. markRepliesRead returns the previous state when
-  // nothing changes, so re-running this on every reparse is free.
+  // Opening a comment is what counts as reading it, in either density. In
+  // anchored density that is also what puts the reply text on screen, since
+  // activating a card is exactly what drops it out of compact rendering. List
+  // density renders every reply in full regardless, and shows no unread
+  // treatment at all, so a reply read there stays marked until the reader
+  // opens the comment. markRepliesRead returns the previous state when nothing
+  // changes, so re-running this on every reparse is free.
   useEffect(() => {
     if (!activeFilePath || !activeCommentId) return;
     const active = comments.find((c) => c.id === activeCommentId);
@@ -1260,13 +1336,32 @@ export default function App() {
 
   // File watcher — live reload from server SSE (Feature 8: detect status transitions)
   const onExternalChange = useCallback(
-    (content: string, mtime?: number) => {
+    (content: string, mtime: number | undefined, path: string) => {
+      // The event names the file it was raised for, which is not necessarily
+      // the active tab by the time it lands: the callback is re-pointed on
+      // every render while the EventSource is only closed in an effect
+      // cleanup, so an event queued before a tab switch runs after it.
+      // Everything keyed by path uses the event's path; only what the reader
+      // is looking at (toast, diff hint, the active tab's content ref) is
+      // gated on this still being the active tab.
+      const isActiveTab = path === activeFilePath;
+      const snapshot = getTabSnapshot(path);
+      if (!isActiveTab && !snapshot) return;
+      // Once the event turns out to belong to a tab the reader has moved off,
+      // it gets the background handler's rules: never overwrite unsaved local
+      // edits, in memory or (via the debounced save below) on disk.
+      if (!isActiveTab && snapshot?.dirty === true) return;
+      // The active tab's live content lives in the ref, which is ahead of the
+      // snapshot; a background tab has only its snapshot. Either way, content
+      // that hasn't loaded yet is not a baseline to diff against.
+      const priorContent = isActiveTab ? rawMarkdownRef.current : (snapshot?.rawMarkdown ?? '');
+      const priorLoaded = snapshot ? !snapshot.isLoading : priorContent.length > 0;
+
       // Detect comment changes before updating so we can show toast/diff hints.
       let cleanContentChanged = false;
+      let arrivingReplyIds: ReadonlySet<string> = NO_REPLY_IDS;
       try {
-        const { comments: oldComments, cleanMarkdown: oldClean } = parseComments(
-          rawMarkdownRef.current,
-        );
+        const { comments: oldComments, cleanMarkdown: oldClean } = parseComments(priorContent);
         const { comments: newComments, cleanMarkdown: newClean } = parseComments(content);
         cleanContentChanged = oldClean !== newClean;
         const newById = new Map(newComments.map((c) => [c.id, c]));
@@ -1287,60 +1382,63 @@ export default function App() {
             }
           }
         }
-        const newReplyCount = findNewReplyIds(oldComments, newComments).size;
+        // Computed once and handed to applyExternalContent below, which would
+        // otherwise re-parse both sides of the same comparison.
+        arrivingReplyIds = priorLoaded ? findNewReplyIds(oldComments, newComments) : NO_REPLY_IDS;
 
-        // Accumulate across rapid events so the toast coalesces
-        accResolvedRef.current += resolvedCount;
-        accDeletedRef.current += deletedCount;
-        accRepliesRef.current += newReplyCount;
+        // No toast for a file the reader isn't looking at, and none for a tab
+        // whose content hasn't loaded yet, where every count would be the
+        // file's whole history rather than what just changed.
+        if (isActiveTab && priorLoaded) {
+          // Accumulate across rapid events so the toast coalesces
+          accResolvedRef.current += resolvedCount;
+          accDeletedRef.current += deletedCount;
+          accRepliesRef.current += arrivingReplyIds.size;
 
-        const r = accResolvedRef.current;
-        const d = accDeletedRef.current;
-        const rp = accRepliesRef.current;
-        if (r > 0 || d > 0 || rp > 0) {
-          const parts: string[] = [];
-          if (r > 0) parts.push(`${r} resolved`);
-          if (d > 0) parts.push(`${d} addressed`);
-          if (rp > 0) parts.push(`${rp} ${rp > 1 ? 'replies' : 'reply'} added`);
-          const diffAction =
-            cleanContentChanged && currentSnapshotRef.current
-              ? {
-                  label: 'View diff',
-                  // Stay in whatever view the user is in — diff overlay
-                  // works in both raw and rendered now.
-                  onClick: () => {
-                    setDiffEnabled(true);
-                    setDiffPending(false);
-                  },
-                }
-              : undefined;
-          showToast(`${parts.join(', ')} externally`, 'info', diffAction);
+          const r = accResolvedRef.current;
+          const d = accDeletedRef.current;
+          const rp = accRepliesRef.current;
+          if (r > 0 || d > 0 || rp > 0) {
+            const parts: string[] = [];
+            if (r > 0) parts.push(`${r} resolved`);
+            if (d > 0) parts.push(`${d} addressed`);
+            if (rp > 0) parts.push(`${rp} ${rp > 1 ? 'replies' : 'reply'} added`);
+            const diffAction =
+              cleanContentChanged && currentSnapshotRef.current
+                ? {
+                    label: 'View diff',
+                    // Stay in whatever view the user is in — diff overlay
+                    // works in both raw and rendered now.
+                    onClick: () => {
+                      setDiffEnabled(true);
+                      setDiffPending(false);
+                    },
+                  }
+                : undefined;
+            showToast(`${parts.join(', ')} externally`, 'info', diffAction);
+          }
         }
       } catch {
         // Ignore parse errors — still update the content
       }
 
-      const { content: nextContent, newReplyIds } = correctReplyTimestamps(
-        rawMarkdownRef.current,
-        content,
-        mtime,
-      );
-      if (activeFilePath) {
-        markRepliesUnread(activeFilePath, newReplyIds);
-      }
+      const { content: nextContent } = applyExternalContent(path, priorContent, content, mtime, {
+        priorLoaded,
+        arrivingReplyIds,
+      });
 
       // Update content directly via updateTab (NOT setRawMarkdown which marks
       // dirty:true). External changes already match disk, so dirty must be false.
       // Also synchronously update rawMarkdownRef so back-to-back user edits
       // (e.g. add-comment right after SSE) read the latest content, not stale state.
-      rawMarkdownRef.current = nextContent;
-      if (activeFilePath) {
-        updateTab(activeFilePath, {
-          rawMarkdown: nextContent,
-          ...(mtime != null ? { mtime } : {}),
-          dirty: false,
-        });
+      if (isActiveTab) {
+        rawMarkdownRef.current = nextContent;
       }
+      updateTab(path, {
+        rawMarkdown: nextContent,
+        ...(mtime != null ? { mtime } : {}),
+        dirty: false,
+      });
 
       // Persist the corrected timestamps back to disk so reloads see the right
       // values. Debounced to avoid a write-watch-write bounce when an agent
@@ -1353,9 +1451,9 @@ export default function App() {
       // a "Save failed" toast on 409 CONFLICT. Since the agent modifies the
       // file between the SSE event and the debounced save, 409s are expected
       // and benign — the next SSE event will re-trigger the backfill.
-      if (nextContent !== content && activeFilePath) {
+      if (nextContent !== content) {
         if (backfillTimerRef.current) clearTimeout(backfillTimerRef.current);
-        const pathToSave = activeFilePath;
+        const pathToSave = path;
         const contentToSave = nextContent;
         const mtimeToSave = mtime;
         backfillTimerRef.current = setTimeout(async () => {
@@ -1395,8 +1493,8 @@ export default function App() {
     },
     [
       activeFilePath,
-      correctReplyTimestamps,
-      markRepliesUnread,
+      applyExternalContent,
+      getTabSnapshot,
       setDiffEnabled,
       settings.enableResolve,
       showToast,
@@ -1439,19 +1537,19 @@ export default function App() {
         // saveFileAt below). They should resolve the conflict by switching
         // to the tab and reloading explicitly.
         if (snapshot?.dirty === true) return;
-        // Backfill agent-supplied reply timestamps the same way the active-tab
-        // handler does, so background files don't show stale times when the
-        // user switches to them. No toast — background tabs aren't visible.
-        const oldContent = snapshot?.rawMarkdown ?? '';
-        const { content: nextContent, newReplyIds } = correctReplyTimestamps(
-          oldContent,
+        if (!snapshot) return;
+        // Same sequence the active-tab handler runs (stamp the arriving
+        // replies, mark them unread), minus the toast, since background tabs
+        // aren't visible. The background case is the one that matters most: a
+        // handoff answered on a tab the reader isn't looking at, where the
+        // unread mark is the only thing that survives until they switch to it.
+        const { content: nextContent } = applyExternalContent(
+          path,
+          snapshot.rawMarkdown,
           content,
           mtime,
+          { priorLoaded: !snapshot.isLoading },
         );
-        // The background case is the one that matters most: a handoff answered
-        // on a tab the reader isn't looking at. No toast fires here, so the
-        // unread mark is the only thing that survives until they switch to it.
-        markRepliesUnread(path, newReplyIds);
         updateTab(path, {
           rawMarkdown: nextContent,
           ...(mtime != null ? { mtime } : {}),
@@ -1466,10 +1564,9 @@ export default function App() {
 
     return () => es.close();
   }, [
+    applyExternalContent,
     backgroundPathsKey,
-    correctReplyTimestamps,
     getTabSnapshot,
-    markRepliesUnread,
     pageVisible,
     saveFileAt,
     updateTab,
@@ -1494,7 +1591,7 @@ export default function App() {
         .then((data: { content?: string; mtime?: number } | null) => {
           if (!data?.content) return;
           if (data.content !== rawMarkdownRef.current) {
-            onExternalChangeRef.current(data.content, data.mtime);
+            onExternalChangeRef.current(data.content, data.mtime, activeFilePath);
           }
         })
         .catch((err) => {

--- a/src/components/CommentCard.test.tsx
+++ b/src/components/CommentCard.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent, waitFor } from '@testing-library/react';
 import { createElement, type ReactNode } from 'react';
 
 // Mock preferences-client so SettingsContext doesn't hit the network
@@ -135,7 +135,7 @@ describe('anchor quote', () => {
 });
 
 describe('CommentCard: compact mode', () => {
-  it('compact hides the replies thread and shows a count line', async () => {
+  it('compact hides the replies thread and shows a summary line', async () => {
     const withReplies: MdComment = {
       ...baseComment,
       replies: [
@@ -144,7 +144,7 @@ describe('CommentCard: compact mode', () => {
       ],
     };
     renderCard({ comment: withReplies, compact: true });
-    expect(await screen.findByText('2 replies')).toBeTruthy();
+    expect(await screen.findByText('2 replies from Dennis')).toBeTruthy();
     expect(screen.queryByText('First reply')).toBeNull();
     expect(screen.queryByText('Second reply')).toBeNull();
   });
@@ -157,8 +157,90 @@ describe('CommentCard: compact mode', () => {
       ],
     };
     renderCard({ comment: oneReply, compact: true });
-    expect(await screen.findByText('1 reply')).toBeTruthy();
+    expect(await screen.findByText('1 reply from Dennis')).toBeTruthy();
     expect(screen.queryByText('Only reply')).toBeNull();
+  });
+
+  it('names both authors of a two-author thread, and counts the rest beyond that', async () => {
+    const stamp = new Date().toISOString();
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'a', author: 'Claude', timestamp: stamp },
+          { id: 'r2', text: 'b', author: 'Dennis', timestamp: stamp },
+        ],
+      },
+      compact: true,
+    });
+    expect(await screen.findByText('2 replies from Claude and Dennis')).toBeTruthy();
+
+    cleanup();
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'a', author: 'Claude', timestamp: stamp },
+          { id: 'r2', text: 'b', author: 'Dennis', timestamp: stamp },
+          { id: 'r3', text: 'c', author: 'Bianca', timestamp: stamp },
+        ],
+      },
+      compact: true,
+    });
+    expect(await screen.findByText('3 replies from Claude +2')).toBeTruthy();
+  });
+
+  it('the summary counts and attributes only the unread replies', async () => {
+    const stamp = new Date().toISOString();
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'old one', author: 'Dennis', timestamp: stamp },
+          { id: 'r2', text: 'just landed', author: 'Claude', timestamp: stamp },
+        ],
+      },
+      compact: true,
+      unreadReplyIds: new Set(['r2']),
+    });
+    // Not "2 replies": the agent's answer is what the reader came back for, and
+    // folding it into a total is what made it easy to miss.
+    const summary = await screen.findByTestId('reply-summary');
+    expect(summary.textContent).toContain('1 new reply from Claude');
+    expect(summary.getAttribute('data-unread')).toBe('true');
+  });
+
+  it('drops the new emphasis once every reply has been read', async () => {
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'read already', author: 'Claude', timestamp: new Date().toISOString() },
+        ],
+      },
+      compact: true,
+      unreadReplyIds: new Set(['r-from-another-comment']),
+    });
+    const summary = await screen.findByTestId('reply-summary');
+    expect(summary.textContent).toContain('1 reply from Claude');
+    expect(summary.textContent).not.toContain('new');
+    expect(summary.getAttribute('data-unread')).toBeNull();
+  });
+
+  it('the summary line activates the card, which is what expands the thread', async () => {
+    const onActivate = vi.fn();
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'Only reply', author: 'Dennis', timestamp: new Date().toISOString() },
+        ],
+      },
+      compact: true,
+      onActivate,
+    });
+    fireEvent.click(await screen.findByTestId('reply-summary'));
+    expect(onActivate).toHaveBeenCalledWith(baseComment.id);
   });
 
   it('non-compact renders replies as before', async () => {
@@ -170,7 +252,7 @@ describe('CommentCard: compact mode', () => {
     };
     renderCard({ comment: withReplies });
     expect(await screen.findByText('First reply')).toBeTruthy();
-    expect(screen.queryByText('1 reply')).toBeNull();
+    expect(screen.queryByTestId('reply-summary')).toBeNull();
   });
 
   it('compact still renders the reply composer when reply-compose is active', async () => {

--- a/src/components/CommentCard.test.tsx
+++ b/src/components/CommentCard.test.tsx
@@ -187,7 +187,61 @@ describe('CommentCard: compact mode', () => {
       },
       compact: true,
     });
-    expect(await screen.findByText('3 replies from Claude +2')).toBeTruthy();
+    expect(await screen.findByText('3 replies from Claude, Dennis +1')).toBeTruthy();
+  });
+
+  it('renders one author dot per named author, never an unnamed one', async () => {
+    const stamp = new Date().toISOString();
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'a', author: 'Claude', timestamp: stamp },
+          { id: 'r2', text: 'b', author: 'Dennis', timestamp: stamp },
+          { id: 'r3', text: 'c', author: 'Bianca', timestamp: stamp },
+          { id: 'r4', text: 'd', author: 'Sam', timestamp: stamp },
+        ],
+      },
+      compact: true,
+    });
+    const summary = await screen.findByTestId('reply-summary');
+    expect(summary.textContent).toContain('4 replies from Claude, Dennis +2');
+    // Two names on the line, so two dots. A dot for an author the reader
+    // can't see named is a colour with nothing to attach it to.
+    expect(summary.querySelectorAll('span[style*="background-color"]').length).toBe(2);
+  });
+
+  it('the summary tooltip counts the same replies the line does', async () => {
+    const stamp = new Date().toISOString();
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'read already', author: 'Dennis', timestamp: stamp },
+          { id: 'r2', text: 'read already too', author: 'Dennis', timestamp: stamp },
+          { id: 'r3', text: 'just landed', author: 'Claude', timestamp: stamp },
+        ],
+      },
+      compact: true,
+      unreadReplyIds: new Set(['r3']),
+    });
+    const summary = await screen.findByTestId('reply-summary');
+    expect(summary.textContent).toContain('1 new reply from Claude');
+    expect(summary.getAttribute('title')).toBe('Open this comment to read the reply');
+  });
+
+  it('marks the summary as a collapsed disclosure for assistive tech', async () => {
+    renderCard({
+      comment: {
+        ...baseComment,
+        replies: [
+          { id: 'r1', text: 'Only reply', author: 'Dennis', timestamp: new Date().toISOString() },
+        ],
+      },
+      compact: true,
+    });
+    const summary = await screen.findByTestId('reply-summary');
+    expect(summary.getAttribute('aria-expanded')).toBe('false');
   });
 
   it('the summary counts and attributes only the unread replies', async () => {

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -7,7 +7,7 @@ import {
   useCallback,
   type MouseEventHandler,
 } from 'react';
-import type { MdComment, CommentStatus } from '../types';
+import type { MdComment, CommentReply, CommentStatus } from '../types';
 import { getEffectiveStatus } from '../types';
 import { getAuthorColor } from '../hooks/useAuthor';
 import { useAutoResize } from '../hooks/useAutoResize';
@@ -39,10 +39,47 @@ interface Props {
   selectionText?: string | null;
   selectionOffset?: number | null;
   onReanchorToSelection?: (commentId: string, newAnchor: string, hintOffset?: number) => void;
-  /** Margin-notes compact rendering: the replies thread collapses to a count
+  /** Margin-notes compact rendering: the replies thread collapses to a summary
    * line. Editor surfaces (the edit textarea and reply composer) still render
    * when triggered, since the hover action bar is reachable on compact cards. */
   compact?: boolean;
+  /** Reply IDs that arrived from outside the app since the user last opened
+   * this card. Drives the "new" emphasis on the compact summary line, which is
+   * the only place a reply can be present but unread. */
+  unreadReplyIds?: ReadonlySet<string>;
+}
+
+const collapsedChevron = (
+  <svg
+    className="w-3 h-3 shrink-0"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={2.5}
+    aria-hidden="true"
+  >
+    <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
+  </svg>
+);
+
+/**
+ * Distinct authors of a reply list, in first-appearance order. A margin card is
+ * narrow, so the summary line names at most two and counts the rest.
+ */
+function replyAuthors(replies: CommentReply[]): string[] {
+  return [...new Set(replies.map((reply) => reply.author))];
+}
+
+function summarizeReplies(replies: CommentReply[], isNew: boolean): string {
+  const authors = replyAuthors(replies);
+  const who =
+    authors.length === 1
+      ? authors[0]
+      : authors.length === 2
+        ? `${authors[0]} and ${authors[1]}`
+        : `${authors[0]} +${authors.length - 1}`;
+  const noun = replies.length === 1 ? 'reply' : 'replies';
+  return `${replies.length}${isNew ? ' new' : ''} ${noun} from ${who}`;
 }
 
 const STATUS_CONFIG: Record<CommentStatus, { label: string; className: string }> = {
@@ -74,6 +111,7 @@ export const CommentCard = memo(function CommentCard({
   selectionOffset,
   onReanchorToSelection,
   compact = false,
+  unreadReplyIds,
 }: Props) {
   const { settings } = useSettings();
   const COMMENT_MAX_LENGTH = settings.commentMaxLength;
@@ -188,6 +226,12 @@ export const CommentCard = memo(function CommentCard({
   };
 
   const replies = comment.replies || [];
+  // When some replies are unread, the summary line counts and attributes only
+  // those: an agent's answer that just landed is the thing worth returning to,
+  // and burying it in a total ("3 replies") is what made it easy to miss.
+  const unreadReplies = unreadReplyIds ? replies.filter((r) => unreadReplyIds.has(r.id)) : [];
+  const hasUnread = unreadReplies.length > 0;
+  const summaryReplies = hasUnread ? unreadReplies : replies;
   const isEditingReply = editingReplyId !== null;
   const editingReply = editingReplyId
     ? (replies.find((reply) => reply.id === editingReplyId) ?? null)
@@ -616,10 +660,44 @@ export const CommentCard = memo(function CommentCard({
         </div>
       )}
 
+      {/* Collapsed replies summary. Styled as a disclosure rather than a count
+          because clicking it is what expands the thread (activating the card
+          drops compact), and the old muted "1 reply" read as inert metadata
+          next to the very content the reader came back for. */}
       {compact && replies.length > 0 && (
-        <div className="px-3 pb-2 text-xs text-content-muted">
-          {replies.length} {replies.length === 1 ? 'reply' : 'replies'}
-        </div>
+        <button
+          type="button"
+          data-testid="reply-summary"
+          data-unread={hasUnread ? 'true' : undefined}
+          title={
+            replies.length === 1
+              ? 'Open this comment to read the reply'
+              : `Open this comment to read all ${replies.length} replies`
+          }
+          onClick={(e) => {
+            e.stopPropagation();
+            onActivate(comment.id);
+          }}
+          className={`flex w-full items-center gap-1.5 px-3 pb-2 text-xs text-left rounded-b-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring ${
+            hasUnread
+              ? 'font-medium text-primary-text'
+              : 'text-content-muted hover:text-content-secondary'
+          }`}
+        >
+          {collapsedChevron}
+          <span className="flex shrink-0 items-center -space-x-0.5">
+            {replyAuthors(summaryReplies)
+              .slice(0, 3)
+              .map((author) => (
+                <span
+                  key={author}
+                  className="inline-block w-2 h-2 rounded-full ring-1 ring-surface-raised"
+                  style={{ backgroundColor: getAuthorColor(author).text }}
+                />
+              ))}
+          </span>
+          <span className="truncate">{summarizeReplies(summaryReplies, hasUnread)}</span>
+        </button>
       )}
 
       {/* Reply input (shown when replying — trigger is in the action bar

--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -63,21 +63,32 @@ const collapsedChevron = (
 );
 
 /**
- * Distinct authors of a reply list, in first-appearance order. A margin card is
- * narrow, so the summary line names at most two and counts the rest.
+ * A margin card is narrow, so the summary line names at most this many authors
+ * and counts the rest. The author dots render from the same cap, so every dot
+ * belongs to a name the reader can actually see.
  */
+const MAX_NAMED_AUTHORS = 2;
+
+/** Distinct authors of a reply list, in first-appearance order. */
 function replyAuthors(replies: CommentReply[]): string[] {
   return [...new Set(replies.map((reply) => reply.author))];
 }
 
+/** The authors the summary line names, and the dots that stand next to it. */
+function namedReplyAuthors(replies: CommentReply[]): string[] {
+  return replyAuthors(replies).slice(0, MAX_NAMED_AUTHORS);
+}
+
 function summarizeReplies(replies: CommentReply[], isNew: boolean): string {
   const authors = replyAuthors(replies);
+  const named = authors.slice(0, MAX_NAMED_AUTHORS);
+  const rest = authors.length - named.length;
   const who =
-    authors.length === 1
-      ? authors[0]
-      : authors.length === 2
-        ? `${authors[0]} and ${authors[1]}`
-        : `${authors[0]} +${authors.length - 1}`;
+    named.length === 1
+      ? named[0]
+      : rest === 0
+        ? `${named[0]} and ${named[1]}`
+        : `${named.join(', ')} +${rest}`;
   const noun = replies.length === 1 ? 'reply' : 'replies';
   return `${replies.length}${isNew ? ' new' : ''} ${noun} from ${who}`;
 }
@@ -669,16 +680,24 @@ export const CommentCard = memo(function CommentCard({
           type="button"
           data-testid="reply-summary"
           data-unread={hasUnread ? 'true' : undefined}
+          // Always collapsed: this control only exists on a compact card, and
+          // activating the card is what replaces it with the full thread.
+          aria-expanded={false}
           title={
-            replies.length === 1
+            summaryReplies.length === 1
               ? 'Open this comment to read the reply'
-              : `Open this comment to read all ${replies.length} replies`
+              : `Open this comment to read all ${summaryReplies.length} replies`
           }
           onClick={(e) => {
             e.stopPropagation();
             onActivate(comment.id);
           }}
-          className={`flex w-full items-center gap-1.5 px-3 pb-2 text-xs text-left rounded-b-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring ${
+          // Rounds the card's bottom edge, so only when it is the bottom edge:
+          // the reply composer opens below this line on a compact card, and a
+          // rounded corner (and the ring it clips) mid-card reads as a seam.
+          className={`flex w-full items-center gap-1.5 px-3 pb-2 text-xs text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-ring ${
+            !isResolved && isReplying ? '' : 'rounded-b-lg'
+          } ${
             hasUnread
               ? 'font-medium text-primary-text'
               : 'text-content-muted hover:text-content-secondary'
@@ -686,15 +705,13 @@ export const CommentCard = memo(function CommentCard({
         >
           {collapsedChevron}
           <span className="flex shrink-0 items-center -space-x-0.5">
-            {replyAuthors(summaryReplies)
-              .slice(0, 3)
-              .map((author) => (
-                <span
-                  key={author}
-                  className="inline-block w-2 h-2 rounded-full ring-1 ring-surface-raised"
-                  style={{ backgroundColor: getAuthorColor(author).text }}
-                />
-              ))}
+            {namedReplyAuthors(summaryReplies).map((author) => (
+              <span
+                key={author}
+                className="inline-block w-2 h-2 rounded-full ring-1 ring-surface-raised"
+                style={{ backgroundColor: getAuthorColor(author).text }}
+              />
+            ))}
           </span>
           <span className="truncate">{summarizeReplies(summaryReplies, hasUnread)}</span>
         </button>

--- a/src/components/CommentsRail.test.tsx
+++ b/src/components/CommentsRail.test.tsx
@@ -237,16 +237,30 @@ describe('CommentsRail', () => {
       expect(orphan.style.top).toBe('0px');
     });
 
-    it('inactive cards are compact: replies collapse to a count line', async () => {
+    it('inactive cards are compact: replies collapse to a summary line', async () => {
       renderRail();
-      expect(await screen.findByText('1 reply')).toBeTruthy();
+      expect(await screen.findByText('1 reply from Dennis')).toBeTruthy();
       expect(screen.queryByText('A reply')).toBeNull();
     });
 
     it('the active card is not compact: replies render fully', async () => {
       renderRail({ activeCommentId: 'c2' });
       expect(await screen.findByText('A reply')).toBeTruthy();
-      expect(screen.queryByText('1 reply')).toBeNull();
+      expect(screen.queryByTestId('reply-summary')).toBeNull();
+    });
+
+    it('clicking the collapsed summary activates the card that owns it', async () => {
+      const onActivate = vi.fn();
+      renderRail({ onActivate });
+      fireEvent.click(await screen.findByTestId('reply-summary'));
+      expect(onActivate).toHaveBeenCalledWith('c2');
+    });
+
+    it('forwards unread reply IDs so the summary marks them new', async () => {
+      renderRail({ unreadReplyIds: new Set(['r1']) });
+      const summary = await screen.findByTestId('reply-summary');
+      expect(summary.textContent).toContain('1 new reply from Dennis');
+      expect(summary.getAttribute('data-unread')).toBe('true');
     });
 
     it('clicking a card activates the comment', async () => {

--- a/src/components/CommentsRail.tsx
+++ b/src/components/CommentsRail.tsx
@@ -41,6 +41,10 @@ interface CommentsRailProps {
   selectionText?: string | null;
   selectionOffset?: number | null;
   onReanchorToSelection?: (commentId: string, newAnchor: string, hintOffset?: number) => void;
+  /** Replies that arrived externally and have not been opened yet. Only the
+   * anchored density can show one without showing its text, so only its cards
+   * need it. */
+  unreadReplyIds?: ReadonlySet<string>;
 }
 
 /**
@@ -330,6 +334,7 @@ function AnchoredCards({
   onContextMenu,
   requestedEditor,
   onReanchorToSelection,
+  unreadReplyIds,
 }: CommentsRailProps) {
   const [hoveredId, setHoveredId] = useState<string | null>(null);
 
@@ -463,6 +468,7 @@ function AnchoredCards({
               thread={comment}
               active={active}
               compact={!active}
+              unreadReplyIds={unreadReplyIds}
               anchorMissing={
                 layout.orphanIds.includes(comment.id) || missingAnchors.has(comment.id)
               }

--- a/src/components/ThreadCard.tsx
+++ b/src/components/ThreadCard.tsx
@@ -33,6 +33,8 @@ export interface ThreadCardProps {
   onReanchorToSelection?: (commentId: string, newAnchor: string, hintOffset?: number) => void;
   /** Compact rendering for margin notes; forwarded to CommentCard. */
   compact?: boolean;
+  /** Externally-arrived replies not yet opened; forwarded to CommentCard. */
+  unreadReplyIds?: ReadonlySet<string>;
 }
 
 /**
@@ -69,6 +71,7 @@ export function ThreadCard({
   selectionOffset,
   onReanchorToSelection,
   compact,
+  unreadReplyIds,
 }: ThreadCardProps) {
   // Internal editor state used when no external editor management is provided.
   const [internalEditor, setInternalEditor] = useState<SidebarCommentEditorState>(null);
@@ -127,6 +130,7 @@ export function ThreadCard({
         selectionOffset={selectionOffset}
         onReanchorToSelection={onReanchorToSelection}
         compact={compact}
+        unreadReplyIds={unreadReplyIds}
       />
     </div>
   );

--- a/src/hooks/useAuthor.ts
+++ b/src/hooks/useAuthor.ts
@@ -24,8 +24,12 @@ export function hashString(str: string): number {
   return Math.abs(hash);
 }
 
+// Author names reach this from comment markers in the file, so a hand-edited
+// or agent-written marker can hand it something that isn't a string. The
+// parser drops those, but this is a render path with no error boundary above
+// it: one bad value must not be able to blank the app.
 export function getAuthorColor(author: string) {
-  return AUTHOR_COLORS[hashString(author) % AUTHOR_COLORS.length];
+  return AUTHOR_COLORS[hashString(typeof author === 'string' ? author : '') % AUTHOR_COLORS.length];
 }
 
 export function useAuthor() {

--- a/src/hooks/useFileWatcher.ts
+++ b/src/hooks/useFileWatcher.ts
@@ -3,7 +3,13 @@ import { usePageVisible } from './usePageVisible';
 
 interface Options {
   filePath: string | null;
-  onExternalChange: (content: string, mtime?: number) => void;
+  /**
+   * `path` is the file the event is about, not whichever tab is active by the
+   * time it lands. The callback is re-pointed on every render while the
+   * EventSource is torn down in a passive effect cleanup, so an event queued
+   * before a tab switch runs against the new tab's state.
+   */
+  onExternalChange: (content: string, mtime: number | undefined, path: string) => void;
 }
 
 /**
@@ -27,8 +33,8 @@ export function useFileWatcher({ filePath, onExternalChange }: Options) {
 
     es.addEventListener('change', (e) => {
       try {
-        const { content, mtime } = JSON.parse(e.data);
-        callbackRef.current(content, mtime);
+        const { content, mtime, path } = JSON.parse(e.data);
+        callbackRef.current(content, mtime, typeof path === 'string' ? path : filePath);
       } catch {
         // Ignore malformed events
       }

--- a/src/hooks/useTabs.test.ts
+++ b/src/hooks/useTabs.test.ts
@@ -1,9 +1,12 @@
-import { describe, expect, it } from 'vitest';
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import {
   applyLoadedTabState,
   applyPendingTabState,
   findAccessDeniedTabs,
   isAccessDeniedError,
+  useTabs,
   type TabState,
 } from './useTabs';
 
@@ -345,5 +348,69 @@ describe('findAccessDeniedTabs', () => {
 
   it('returns an empty array for an empty map', () => {
     expect(findAccessDeniedTabs(new Map())).toEqual([]);
+  });
+});
+
+describe('useTabs: external content hooks', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubFetch(responses: Array<{ path?: string; content: string; mtime?: number }>) {
+    const queue = [...responses];
+    const fetchMock = vi.fn(async (url: string) => {
+      const next = queue.shift() ?? responses[responses.length - 1];
+      const path = next.path ?? decodeURIComponent(String(url).split('path=')[1] ?? '');
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({ path, content: next.content, mtime: next.mtime ?? 1 }),
+      } as unknown as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    return fetchMock;
+  }
+
+  it('routes reloaded content through onExternalContent before storing it', async () => {
+    // Reload is the third way external content reaches a tab, and the one that
+    // catches up on a reply both watchers missed. Skipping the hook here is
+    // how the unread mark for that reply gets lost.
+    stubFetch([{ content: '# before\n' }, { content: '# after\n' }]);
+    const onExternalContent = vi.fn(() => '# after, stamped\n');
+    const { result } = renderHook(() => useTabs({ onExternalContent }));
+
+    await act(async () => {
+      await result.current.openTab('/notes.md');
+    });
+    await act(async () => {
+      await result.current.reloadFile();
+    });
+
+    expect(onExternalContent).toHaveBeenCalledWith('/notes.md', '# before\n', '# after\n', 1);
+    await waitFor(() => expect(result.current.rawMarkdown).toBe('# after, stamped\n'));
+  });
+
+  it('reports a server-resolved path so path-keyed state can move with the tab', async () => {
+    stubFetch([{ path: '/private/tmp/notes.md', content: '# loaded\n' }]);
+    const onPathResolved = vi.fn();
+    const { result } = renderHook(() => useTabs({ onPathResolved }));
+
+    await act(async () => {
+      await result.current.openTab('/tmp/notes.md');
+    });
+
+    expect(onPathResolved).toHaveBeenCalledWith('/tmp/notes.md', '/private/tmp/notes.md');
+  });
+
+  it('stays quiet when the path came back unchanged', async () => {
+    stubFetch([{ content: '# loaded\n' }]);
+    const onPathResolved = vi.fn();
+    const { result } = renderHook(() => useTabs({ onPathResolved }));
+
+    await act(async () => {
+      await result.current.openTab('/notes.md');
+    });
+
+    expect(onPathResolved).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -137,8 +137,33 @@ export function applyLoadedTabState(
   };
 }
 
-export function useTabs(options?: { onSaveError?: (msg: string) => void }) {
+export function useTabs(options?: {
+  onSaveError?: (msg: string) => void;
+  /**
+   * Applied to content that arrives from disk on an explicit reload, before it
+   * lands in the tab. Reload is a third way external content reaches a tab
+   * (alongside the two watchers), so it has to run the same arriving-reply
+   * bookkeeping. Returns the content to store.
+   */
+  onExternalContent?: (
+    path: string,
+    priorContent: string,
+    content: string,
+    mtime?: number,
+  ) => string;
+  /**
+   * Fired when the server resolves the path we asked for into a different real
+   * path, so state keyed by the requested path can move with the tab.
+   */
+  onPathResolved?: (requestedPath: string, loadedPath: string) => void;
+}) {
   const onSaveError = options?.onSaveError;
+  // Held in refs so a caller passing inline callbacks doesn't churn the
+  // identity of every callback below them.
+  const onExternalContentRef = useRef(options?.onExternalContent);
+  onExternalContentRef.current = options?.onExternalContent;
+  const onPathResolvedRef = useRef(options?.onPathResolved);
+  onPathResolvedRef.current = options?.onPathResolved;
   const [tabOrder, setTabOrder] = useState<string[]>([]);
   const [tabData, setTabData] = useState<Map<string, TabState>>(new Map());
   const [activeFilePath, setActiveFilePath] = useState<string | null>(null);
@@ -218,6 +243,9 @@ export function useTabs(options?: { onSaveError?: (msg: string) => void }) {
 
   const applyLoadedResponse = useCallback(
     (requestedPath: string, loadedPath: string, content: string) => {
+      if (requestedPath !== loadedPath) {
+        onPathResolvedRef.current?.(requestedPath, loadedPath);
+      }
       const next = applyLoadedTabState(
         tabDataRef.current,
         tabOrderRef.current,
@@ -561,13 +589,20 @@ export function useTabs(options?: { onSaveError?: (msg: string) => void }) {
     if (!activeFilePath) return;
     updateTab(activeFilePath, { isLoading: true, error: null });
     try {
+      const priorContent = tabDataRef.current.get(activeFilePath)?.rawMarkdown ?? '';
       const res = await fetch(`/api/file?path=${encodeURIComponent(activeFilePath)}`);
       const data = await readJsonResponse<FileResponse>(res);
       if (!res.ok || !data) {
         throw new Error(getApiErrorMessage(res, data, 'Failed to reload file'));
       }
+      // A reply can reach the client for the first time here: the tab was
+      // hidden, and both the SSE stream and the visibility-restore fetch
+      // missed it. Without this hook that reply would never be marked unread.
+      const content =
+        onExternalContentRef.current?.(activeFilePath, priorContent, data.content, data.mtime) ??
+        data.content;
       updateTab(activeFilePath, {
-        rawMarkdown: data.content,
+        rawMarkdown: content,
         isLoading: false,
         lastSaved: new Date(),
         error: null,

--- a/src/hooks/useUnreadReplies.test.ts
+++ b/src/hooks/useUnreadReplies.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useUnreadReplies } from './useUnreadReplies';
+
+describe('useUnreadReplies', () => {
+  it('accumulates unread replies per file path', () => {
+    const { result } = renderHook(() => useUnreadReplies());
+
+    act(() => result.current.markRepliesUnread('/a.md', ['r1']));
+    act(() => result.current.markRepliesUnread('/a.md', ['r2']));
+    act(() => result.current.markRepliesUnread('/b.md', ['r3']));
+
+    expect(result.current.unreadByPath['/a.md']).toEqual(['r1', 'r2']);
+    expect(result.current.unreadByPath['/b.md']).toEqual(['r3']);
+  });
+
+  it('clears only the replies that were read, leaving the rest unread', () => {
+    const { result } = renderHook(() => useUnreadReplies());
+
+    act(() => result.current.markRepliesUnread('/a.md', ['r1', 'r2', 'r3']));
+    act(() => result.current.markRepliesRead('/a.md', ['r2']));
+
+    expect(result.current.unreadByPath['/a.md']).toEqual(['r1', 'r3']);
+  });
+
+  it('keeps the same state object when nothing actually changes', () => {
+    // App re-runs markRepliesRead on every reparse of the active comment, so a
+    // no-op has to be referentially stable or it re-renders the whole tree on
+    // each keystroke an agent writes.
+    const { result } = renderHook(() => useUnreadReplies());
+
+    act(() => result.current.markRepliesUnread('/a.md', ['r1']));
+    const afterMark = result.current.unreadByPath;
+
+    act(() => result.current.markRepliesUnread('/a.md', ['r1']));
+    act(() => result.current.markRepliesUnread('/a.md', []));
+    act(() => result.current.markRepliesRead('/a.md', ['r-elsewhere']));
+    act(() => result.current.markRepliesRead('/never-seen.md', ['r1']));
+
+    expect(result.current.unreadByPath).toBe(afterMark);
+  });
+
+  it('deduplicates a reply seen twice, so a redelivered SSE event does not double it', () => {
+    const { result } = renderHook(() => useUnreadReplies());
+
+    act(() => result.current.markRepliesUnread('/a.md', ['r1', 'r1']));
+    act(() => result.current.markRepliesUnread('/a.md', ['r1', 'r2']));
+
+    expect(result.current.unreadByPath['/a.md']).toEqual(['r1', 'r2']);
+  });
+});

--- a/src/hooks/useUnreadReplies.test.ts
+++ b/src/hooks/useUnreadReplies.test.ts
@@ -41,6 +41,33 @@ describe('useUnreadReplies', () => {
     expect(result.current.unreadByPath).toBe(afterMark);
   });
 
+  it('moves marks to the resolved path when the server normalizes it', () => {
+    // The CLI hands its argument through unnormalized, so the first tab of a
+    // session routinely opens under a relative or symlinked path and gets
+    // re-keyed once the server answers. A mark left behind under the old key
+    // is unreachable: nothing ever looks it up again.
+    const { result } = renderHook(() => useUnreadReplies());
+
+    act(() => result.current.markRepliesUnread('./notes.md', ['r1']));
+    act(() => result.current.markRepliesUnread('/real/notes.md', ['r2']));
+    act(() => result.current.migrateUnreadPath('./notes.md', '/real/notes.md'));
+
+    expect(result.current.unreadByPath['./notes.md']).toBeUndefined();
+    expect(result.current.unreadByPath['/real/notes.md']).toEqual(['r2', 'r1']);
+  });
+
+  it('leaves state alone when the path did not actually change', () => {
+    const { result } = renderHook(() => useUnreadReplies());
+
+    act(() => result.current.markRepliesUnread('/a.md', ['r1']));
+    const before = result.current.unreadByPath;
+
+    act(() => result.current.migrateUnreadPath('/a.md', '/a.md'));
+    act(() => result.current.migrateUnreadPath('/never-seen.md', '/b.md'));
+
+    expect(result.current.unreadByPath).toBe(before);
+  });
+
   it('deduplicates a reply seen twice, so a redelivered SSE event does not double it', () => {
     const { result } = renderHook(() => useUnreadReplies());
 

--- a/src/hooks/useUnreadReplies.ts
+++ b/src/hooks/useUnreadReplies.ts
@@ -1,8 +1,8 @@
 import { useCallback, useState } from 'react';
 
 /**
- * Session-scoped record of replies that arrived from outside the app — an agent
- * writing to the file, typically — and that the reader has not opened yet.
+ * Session-scoped record of replies that arrived from outside the app (an agent
+ * writing to the file, typically) and that the reader has not opened yet.
  *
  * Keyed by file path, because the common shape of a handoff is that the agent
  * answers on a background tab while the reader works elsewhere; each tab has to
@@ -39,5 +39,23 @@ export function useUnreadReplies() {
     });
   }, []);
 
-  return { unreadByPath, markRepliesUnread, markRepliesRead };
+  /**
+   * Re-key a file's unread set when the server resolves the path we asked for
+   * into its real one (relative paths, `~`, symlinked parents). Marks recorded
+   * against the pre-resolution key are looked up under the resolved key
+   * afterwards, so without this they are silently unreachable.
+   */
+  const migrateUnreadPath = useCallback((fromPath: string, toPath: string) => {
+    if (fromPath === toPath) return;
+    setUnreadByPath((prev) => {
+      const moving = prev[fromPath];
+      if (!moving) return prev;
+      const next = { ...prev };
+      delete next[fromPath];
+      next[toPath] = [...new Set([...(prev[toPath] ?? []), ...moving])];
+      return next;
+    });
+  }, []);
+
+  return { unreadByPath, markRepliesUnread, markRepliesRead, migrateUnreadPath };
 }

--- a/src/hooks/useUnreadReplies.ts
+++ b/src/hooks/useUnreadReplies.ts
@@ -1,0 +1,43 @@
+import { useCallback, useState } from 'react';
+
+/**
+ * Session-scoped record of replies that arrived from outside the app — an agent
+ * writing to the file, typically — and that the reader has not opened yet.
+ *
+ * Keyed by file path, because the common shape of a handoff is that the agent
+ * answers on a background tab while the reader works elsewhere; each tab has to
+ * accumulate its own set to still be able to say "new" when the reader switches
+ * to it.
+ *
+ * Deliberately not persisted. "New since you last looked" is a fact about this
+ * session, not about the document, so a reload starting everything as read is
+ * the correct behaviour rather than a limitation.
+ */
+export function useUnreadReplies() {
+  const [unreadByPath, setUnreadByPath] = useState<Record<string, string[]>>({});
+
+  const markRepliesUnread = useCallback((filePath: string, replyIds: Iterable<string>) => {
+    const incoming = [...replyIds];
+    if (incoming.length === 0) return;
+    setUnreadByPath((prev) => {
+      const next = new Set(prev[filePath] ?? []);
+      const sizeBefore = next.size;
+      for (const id of incoming) next.add(id);
+      if (next.size === sizeBefore) return prev;
+      return { ...prev, [filePath]: [...next] };
+    });
+  }, []);
+
+  const markRepliesRead = useCallback((filePath: string, replyIds: Iterable<string>) => {
+    setUnreadByPath((prev) => {
+      const current = prev[filePath];
+      if (!current || current.length === 0) return prev;
+      const read = new Set(replyIds);
+      const kept = current.filter((id) => !read.has(id));
+      if (kept.length === current.length) return prev;
+      return { ...prev, [filePath]: kept };
+    });
+  }, []);
+
+  return { unreadByPath, markRepliesUnread, markRepliesRead };
+}

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -81,6 +81,27 @@ describe('parseComments', () => {
     expect(result.cleanMarkdown).toBe('Some text');
   });
 
+  it('drops replies missing the fields every render path assumes', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // A hand-edit or a confused agent can leave a reply with no author. It
+    // used to reach getAuthorColor, which hashes it, and take down the app.
+    const raw =
+      '<!-- @comment{"id":"c1","anchor":"hello","text":"why?","author":"Dennis","timestamp":"2024-01-01T00:00:00.000Z","replies":[{"id":"r1","text":"no author here"},{"id":"r2","text":"fine","author":"Claude","timestamp":"2024-01-01T00:00:00.000Z"}]} -->hello';
+    const result = parseComments(raw);
+    expect(result.comments).toHaveLength(1);
+    expect(result.comments[0].replies?.map((r) => r.id)).toEqual(['r2']);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('keeps a comment whose replies are all well-formed untouched', () => {
+    const replies = [
+      { id: 'r1', text: 'a', author: 'Claude', timestamp: '2024-01-01T00:00:00.000Z' },
+    ];
+    const result = parseComments(`${marker({ id: 'c1', anchor: 'hello', replies })}hello`);
+    expect(result.comments[0].replies).toEqual(replies);
+  });
+
   it('ignores placeholder markers inside inline code spans', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const raw = 'Docs: `<!-- @comment{...} -->` explains the format.';

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -191,6 +191,37 @@ function getStandaloneStripEnd(
   return isStartOfLine && rawMarkdown[markerEnd] === '\n' ? markerEnd + 1 : markerEnd;
 }
 
+/**
+ * Replies come from whatever wrote the file, so a hand-edit or a confused
+ * agent can leave one with no author or text. Every render path assumes those
+ * are strings (author colors hash them, bylines print them), so drop the
+ * malformed ones at the parse boundary instead of letting one bad reply take
+ * down a card. Warns for the same reason a malformed marker does: the loss
+ * should be visible. A dropped reply survives in the file until something
+ * rewrites that marker, at which point it is gone for good.
+ */
+function validReplies(replies: unknown[], commentId: string): CommentReply[] {
+  const kept: CommentReply[] = [];
+  for (const reply of replies) {
+    const candidate = reply as CommentReply | null;
+    if (
+      candidate !== null &&
+      typeof candidate === 'object' &&
+      typeof candidate.id === 'string' &&
+      typeof candidate.text === 'string' &&
+      typeof candidate.author === 'string'
+    ) {
+      kept.push(candidate);
+    } else {
+      console.warn(
+        `[comment-parser] dropping malformed reply on comment ${commentId}; id, text and author must all be strings`,
+        reply,
+      );
+    }
+  }
+  return kept;
+}
+
 function collectCommentRegions(rawMarkdown: string): CommentMarkerRegion[] {
   const fencedRanges = getCodeBlockRanges(rawMarkdown);
   const inlineRanges = getInlineCodeRanges(rawMarkdown, fencedRanges);
@@ -212,7 +243,9 @@ function collectCommentRegions(rawMarkdown: string): CommentMarkerRegion[] {
         typeof data.author === 'string' &&
         (!data.replies || Array.isArray(data.replies))
       ) {
-        parsedComment = data;
+        parsedComment = data.replies
+          ? { ...data, replies: validReplies(data.replies, data.id) }
+          : data;
       }
     } catch (err) {
       // Inside inline code, a literal `{...}` placeholder is documentation


### PR DESCRIPTION
An anchored card collapses its thread to a one-line count, so a reply an agent
wrote while you were elsewhere looked identical to a thread you had already
read. That is exactly the case the handoff flow produces.

## What changed

The collapsed summary is now a disclosure that names who replied ("2 replies
from Claude and Dennis") rather than inert metadata, and clicking it activates
the card, which is what expands the thread.

Replies that arrive from outside the app since you last opened a card are
tracked per file path by `useUnreadReplies` (session only, never persisted).
When a card has any, the line counts and attributes only those, reading "1 new
reply from Claude" in the accent color. Opening the comment clears it.

All three paths that take content from disk run the same bookkeeping through
`applyExternalContent` in App: the active tab's watcher, the multiplexed
background-tab watcher (the case that matters most, since no toast fires
there), and an explicit reload.

## Review pass

The second commit is a fix pass over the first:

- The SSE event's own path is threaded through `useFileWatcher` instead of
  reading whichever tab is active when the event lands, so an event queued
  across a tab switch updates the file it belongs to. A raced event also no
  longer clears the dirty flag on a tab with unsaved edits.
- Nothing is marked or stamped while a tab's first fetch is in flight. With no
  prior content to diff against, the file's whole reply history looked new,
  which would have restamped every historical reply with the mtime and saved
  that over the file.
- Unread marks move with a tab when the server resolves the requested path into
  its real one, which the CLI's unnormalized argument makes routine on the first
  tab of a session.
- The parser drops replies missing `id`, `text` or `author`. One malformed reply
  reaching the author-color hash took down the whole app once collapsed cards
  started reading reply authors on load.
- The summary names two authors and counts the rest ("3 replies from Claude,
  Dennis +1"), with the dots derived from the same cap so every dot belongs to a
  name on the line. The tooltip counts what the line counts, the control reports
  itself as a collapsed disclosure, and it only rounds the card's bottom corners
  when it is actually the bottom edge.

## Known gap

List density renders every reply in full and shows no unread treatment, so a
reply read there stays marked until you open that comment. Clearing it
accurately needs viewport tracking; the cheap alternatives all clear too much,
and losing the pointer to what is new is worse than a stale badge. Documented in
AGENTS.md.

## Verification

`tsc -b`, eslint and prettier clean. 1763 unit tests and 335 e2e tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011v7vNmGMvrvx1T5bjFR9sv