### PR TITLE
Ask for folder access instead of reporting it as an error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ An optional MCP stdio server lets AI agents request human review and wait for fe
 - `src/components/RenderedDiffView.tsx`: rendered prose view of the diff overlay
 - `src/components/ReviewBanner.tsx`: review session banner (send batch, finish, cancel)
 - `src/components/PanelToolbar.tsx`: shared per-panel toolbar (search, view-mode, copy, handoff, diff controls)
+- `src/components/AccessRequest.tsx`: the folder-permission ask shown when a path is outside the allowed roots
 - `src/components/Tooltip.tsx`: portal-based tooltip with snappy delay + scrubbing grace period
 - `src/hooks/useComments.ts`: comment actions, handoff prompt generation, workflow logic
 - `src/hooks/useReviewSession.ts`: polling and heartbeat for active review sessions
@@ -445,6 +446,77 @@ The open-file button is sticky at the right edge of the tab strip, so it overlay
 whichever tab ends there. The strip carries a `scroll-pr-10` that must stay at or
 above that button's `w-9`, otherwise the browser parks the active tab underneath
 it when scrolling the tab into view.
+
+### Folder permission requests
+Opening a file outside the allowed roots is a consent moment, not a failure, and
+`AccessRequest.tsx` is the only place that says so. The document area renders it
+over the sheet (`variant="page"`), the explorer renders the quieter
+`variant="panel"` when a browse is refused, and the toolbar stays out of it
+whenever the card is up. Three surfaces shouting the same absolute path in
+`text-danger` was the state this replaced; if a fourth surface ever needs to
+report a refused folder, give it a variant here rather than its own copy.
+
+**The card covers the document, it does not replace it.** It is an
+`absolute inset-0` overlay inside the viewer's relative wrapper, and the viewer
+tree stays mounted behind it. Swapping it in as a sibling branch looks tidier
+and breaks two things: `usePageGeometry` observes `containerRef.current` in an
+effect keyed `[containerRef, enabled]`, neither of which changes when the card
+clears, so unmounting the scroll container leaves its ResizeObserver attached to
+a detached node and the sheet stops tracking the window for the rest of the
+session; and the viewers are what report the search match count, so a denied tab
+kept the previous document's count over a card with no text. Both are pinned by
+the resize assertion in `e2e/error-states.spec.ts`.
+
+Two conditions gate it, and they are not the same one:
+- `showAccessRequest` (App) is `errorKind === 'access-denied' && !rawMarkdown`.
+  The `!rawMarkdown` term is load-bearing: `reloadFile` keeps the loaded content
+  on failure, so a directory that rotates out from under an open file 403s a tab
+  the user is still reading. The card must not cover a document it cannot give
+  back. Those tabs keep their content and the toolbar reports the refusal with
+  its own compact Allow button, so exactly one surface ever owns the ask.
+- `accessDeniedDir` may be null (`?file=~`, a Windows drive-relative path, both
+  of which `getParentDir` answers with `''`). Null names no folder but still
+  renders the card: the picker works from the active file either way, and a
+  refusal nobody reports is a blank sheet with no way out.
+
+The card leads with the folder's basename and puts the path under it through
+`middleTruncatePath`, which elides whole segments rather than cutting names in
+half, with the untruncated path in the `title`. The CSS `truncate` on that line
+is an overflow guard for a panel dragged to its 160px minimum, not the
+shortener. Agent scratchpad directories are the common case and their paths are
+both long and generated, so a raw path wraps to four lines and still says
+nothing.
+
+The button opens the native picker (`POST /api/pick-folder`). Keep the native
+dialog: it is the local consent flow that `trustedRoots` depends on (see the
+security notes above), so an in-app one-click grant would move the filesystem
+boundary from "the user answered an OS dialog" to "something reached the
+server". The picker opens pointed at the refused folder, which is what keeps
+the extra step cheap, and the card's hint tells the user they can pick a parent
+to allow more at once.
+
+`handleTrustFolder` owns that call for every surface, and three things follow
+from the fact that two cards can be on screen at once:
+- It resolves `true` only on an actual grant. Callers refetch on `true` alone,
+  so a cancelled dialog does not spend a retry on a folder that is still
+  refused, and the re-entrancy guard reports `false` rather than a phantom
+  success to whichever surface did not get the dialog.
+- `trustFolderPending` is shared, not per-surface. A second button that stays
+  enabled while another owns the dialog invites a click the guard then swallows.
+- `grantNonce` bumps on every completed grant so the explorer re-browses after a
+  grant made from the document card. Without it the panel sits on a refusal that
+  no longer applies, offering to re-pick a folder that is already trusted.
+
+If the card is still up after a completed grant, the picked folder did not
+contain the file; `grantMissed` swaps the hint for a line that says so, because
+repeating the ask word for word reads as a dead button.
+
+An access-denied tab's dot in `TabBar` is neutral rather than red for the same
+reason the copy changed: the user can resolve it by answering a prompt. It is
+`content-muted`, not `content-faint`, which falls under the 3:1 non-text
+contrast minimum, and the tab's `title` carries the reason in words since a 6px
+dot cannot. Background tabs opened by session restore never render the card at
+all, so that dot is their only signal.
 
 ### Review banner
 When a review session is active, a sticky banner appears at the top with one row

--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -23,39 +23,37 @@ test.afterAll(() => {
 // ---------------------------------------------------------------------------
 
 test.describe('Error states', () => {
-  test('opening a non-existent file shows an error', async ({ page }) => {
+  // Anything under /tmp is outside the e2e webServer's cwd, so resolveAndValidate
+  // 403s before the file is ever stat'd and before the .md check. These paths
+  // therefore land on the permission card, NOT on a 404 or an unsupported-type
+  // error, and asserting "some problem was reported" would pass even with those
+  // server branches deleted. Assert the card specifically; the 404 and 400
+  // branches are the server's own tests to cover.
+  const accessCard = (page: import('@playwright/test').Page) => page.getByTestId('access-request');
+
+  test('a non-existent file under a denied root shows the permission card', async ({ page }) => {
     await page.goto('/?file=/tmp/nonexistent-file-abc123.md');
 
-    // The toolbar should show an error message (rendered with text-danger class)
-    const errorText = page.locator('.text-danger').first();
-    await expect(errorText).toBeVisible({ timeout: 10_000 });
-    const text = await errorText.textContent();
-    // Error message should indicate an access or load problem (the new
-    // friendly copy replaces "denied" with an "allow ..." prompt; both
-    // are valid).
-    expect(text?.toLowerCase()).toMatch(/not found|not readable|error|denied|allow/);
+    await expect(accessCard(page)).toBeVisible({ timeout: 10_000 });
+    // The heading uses a typographic apostrophe, so match around it.
+    await expect(accessCard(page)).toContainText(/read this folder/);
+    await expect(accessCard(page).getByTestId('access-request-allow')).toBeVisible();
   });
 
-  test('opening a non-.md file shows an error', async ({ page }) => {
+  test('a non-.md file under a denied root shows the permission card', async ({ page }) => {
     // Create a temporary .txt file
     const txtFile = '/tmp/md-redline-test-error.txt';
     writeFileSync(txtFile, 'This is a plain text file.');
 
     await page.goto(`/?file=${txtFile}`);
 
-    // The toolbar should show an error about unsupported file type
-    const errorText = page.locator('.text-danger').first();
-    await expect(errorText).toBeVisible({ timeout: 10_000 });
-    const text = await errorText.textContent();
-    // Should indicate either an unsupported-file error OR an access-denied
-    // prompt (the latter fires first because /tmp is outside cwd).
-    expect(text?.toLowerCase()).toMatch(/\.md|not supported|supported|error|denied|allow/);
+    await expect(accessCard(page)).toBeVisible({ timeout: 10_000 });
   });
 
   test('app does not crash on error — navigation still works', async ({ page }) => {
     // Load a bad file first
     await page.goto('/?file=/tmp/nonexistent-file-abc123.md');
-    await expect(page.locator('.text-danger').first()).toBeVisible({ timeout: 10_000 });
+    await expect(accessCard(page)).toBeVisible({ timeout: 10_000 });
 
     // Now open a valid file via the file opener
     await page.locator('button[title="Open file"]').click();
@@ -68,29 +66,27 @@ test.describe('Error states', () => {
     });
   });
 
-  test('access-denied error shows the Allow access button', async ({ page }) => {
+  test('access-denied shows the permission card in the document area', async ({ page }) => {
     // /tmp is outside the e2e webServer's cwd, so this file (even if it
     // existed) would 403 with Access denied. We don't need it to exist; the
     // 403 fires before stat.
     const outOfRootFile = '/tmp/md-redline-e2e-trust-prompt-test.md';
     await page.goto(`/?file=${encodeURIComponent(outOfRootFile)}`);
 
-    // The toolbar should show the friendly permission prompt.
-    const errorText = page.locator('.text-danger').first();
-    await expect(errorText).toBeVisible({ timeout: 10_000 });
-    const text = await errorText.textContent();
-    expect(text?.toLowerCase()).toContain('allow');
+    // The document area owns the ask: the folder's name, the reason, and the button.
+    const card = page.getByTestId('access-request');
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    await expect(card).toContainText('tmp');
+    await expect(card.getByTestId('access-request-allow')).toBeVisible();
 
-    // The Allow access button must be visible alongside the prompt. Both
-    // the toolbar and the file explorer can render trust buttons in this
-    // scenario (since /tmp is denied for both file load and dir browse);
-    // scope to the toolbar's button by using its <span class="text-danger">
-    // parent (the explorer wraps its error in a <div>, not a <span>).
-    const trustButton = page.locator('span.text-danger button', { hasText: 'Allow access' });
-    await expect(trustButton).toBeVisible({ timeout: 5_000 });
+    // And no surface repeats it as a red error strip. Scoped by role rather
+    // than by the toolbar's height utility, which the card's own icon box also
+    // happens to carry.
+    await expect(page.locator('.text-danger')).toHaveCount(0);
+    await expect(page.getByTestId('toolbar-allow-access')).toHaveCount(0);
   });
 
-  test('clicking Allow access retries access-denied tabs after grant', async ({ page }) => {
+  test('allowing the folder retries access-denied tabs after grant', async ({ page }) => {
     const testFile = '/tmp/md-redline-e2e-trust-retry-test.md';
     let fileFetchCount = 0;
 
@@ -131,11 +127,9 @@ test.describe('Error states', () => {
     // Navigate to the test file. Real server returns 403 (first /api/file call).
     await page.goto(`/?file=${encodeURIComponent(testFile)}`);
 
-    // Wait for the access-denied error and the trust button. Both the
-    // toolbar and the file explorer render trust buttons here; we scope
-    // to the toolbar's button via its <span class="text-danger"> parent
-    // (the explorer wraps its error in a <div>, not a <span>).
-    const trustButton = page.locator('span.text-danger button', { hasText: 'Allow access' });
+    // Wait for the permission card. The explorer renders its own quieter
+    // version of the same ask, so scope to the document area's card.
+    const trustButton = page.getByTestId('access-request').getByTestId('access-request-allow');
     await expect(trustButton).toBeVisible({ timeout: 10_000 });
 
     // Click the button → /api/pick-folder (mocked) → retryAllAccessDenied → second /api/file (mocked).
@@ -148,6 +142,26 @@ test.describe('Error states', () => {
 
     // The error and trust button should be gone after the successful retry.
     await expect(trustButton).toBeHidden();
+
+    // The document that comes back has to have LIVE geometry. The card covers
+    // the viewer rather than replacing it because usePageGeometry observes the
+    // scroll container once, with deps that do not change when the card
+    // clears: replacing the container left the ResizeObserver attached to a
+    // detached node, so the sheet kept whatever width it measured before the
+    // refusal and stopped tracking the window for the rest of the session.
+    //
+    // Resize and assert the width follows. The rendered width alone proves
+    // nothing here — the stale value is a plausible one, and the sheet's
+    // `max-width: calc(100% - 24px)` makes even a dead layout appear to
+    // respond — so read the inline width usePageGeometry actually sets.
+    const sheet = page.locator('[data-doc-page]');
+    await expect(sheet).toBeVisible();
+    const widthStyle = () => sheet.evaluate((el) => (el as HTMLElement).style.width);
+    const before = await widthStyle();
+    expect(before).not.toBe('');
+
+    await page.setViewportSize({ width: 900, height: 720 });
+    await expect.poll(widthStyle).not.toBe(before);
 
     // Sanity check the route handler ran twice.
     expect(fileFetchCount).toBeGreaterThanOrEqual(2);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { Toolbar } from './components/Toolbar';
 import { TabBar } from './components/TabBar';
 import { FileExplorer } from './components/FileExplorer';
 import { FileOpener } from './components/FileOpener';
+import { AccessRequest } from './components/AccessRequest';
 import { DragHandles } from './components/DragHandles';
 import { RawView, type RawViewHandle } from './components/RawView';
 import { RenderedDiffView, type RenderedDiffViewHandle } from './components/RenderedDiffView';
@@ -237,21 +238,35 @@ export default function App() {
   );
 
   const trustFolderInFlightRef = useRef(false);
+  // Mirrors the ref for rendering. The ref stays because the re-entrancy guard
+  // has to be synchronous; state alone would let a double click through before
+  // React re-renders the disabled button.
+  const [trustFolderPending, setTrustFolderPending] = useState(false);
+  // Bumped once per completed grant. The explorer watches it so a grant made
+  // from the document area re-browses the panel too: both surfaces are usually
+  // refused by the same folder, and only one of them can own the picker call.
+  const [grantNonce, setGrantNonce] = useState(0);
+  // True once a grant has completed while the permission card is still up,
+  // which means the picked folder did not cover the file.
+  const [sawGrant, setSawGrant] = useState(false);
+  /**
+   * Opens the native picker for `defaultPathOverride` (or the active file's
+   * parent) and retries every access-denied tab if the user picks something.
+   * Resolves true only when a folder was actually granted, so callers can tell
+   * a cancelled dialog from a successful one and skip a refetch that is
+   * guaranteed to be refused again.
+   */
   const handleTrustFolder = useCallback(
-    async (defaultPathOverride?: string) => {
-      if (trustFolderInFlightRef.current) return;
+    async (defaultPathOverride?: string | null): Promise<boolean> => {
+      // A second surface can be showing the same ask while this one owns the
+      // dialog. Report failure rather than success: the caller has not been
+      // granted anything, and treating this as a grant sends it off to refetch
+      // against a directory that is still refused.
+      if (trustFolderInFlightRef.current) return false;
       trustFolderInFlightRef.current = true;
+      setTrustFolderPending(true);
       try {
-        // Only accept string overrides. The Toolbar binds this directly to a
-        // button onClick, which passes a SyntheticEvent as the first arg —
-        // we need to ignore it and fall back to deriving from activeFilePath.
-        const overrideDir = typeof defaultPathOverride === 'string' ? defaultPathOverride : null;
-        let hint: string | null = null;
-        if (overrideDir) {
-          hint = overrideDir;
-        } else if (activeFilePath) {
-          hint = getParentDir(activeFilePath) || null;
-        }
+        const hint = defaultPathOverride ?? (activeFilePath ? getParentDir(activeFilePath) : '');
         const url = hint
           ? `/api/pick-folder?defaultPath=${encodeURIComponent(hint)}`
           : '/api/pick-folder';
@@ -266,13 +281,18 @@ export default function App() {
         if (!res.ok || data.cancelled || !data.path) {
           // Cancelled, failed, or returned no path. Leave the existing error
           // in place; the user can click the button again or close the tab.
-          return;
+          return false;
         }
         await retryAllAccessDenied();
+        setGrantNonce((n) => n + 1);
+        setSawGrant(true);
+        return true;
       } catch {
         // Network or parse error. Leave the existing error in place.
+        return false;
       } finally {
         trustFolderInFlightRef.current = false;
+        setTrustFolderPending(false);
       }
     },
     [activeFilePath, retryAllAccessDenied],
@@ -2559,11 +2579,25 @@ export default function App() {
     ],
   );
 
-  // The directory the trust prompt would grant if the user clicks. For the
-  // toolbar's access-denied state, this is the parent dir of the active tab's
-  // file. Computed here so the Toolbar can render the path in its prompt.
+  // The folder the permission card names, or null when the active file's path
+  // has no derivable parent (`?file=~`, a Windows drive-relative path). Null
+  // does not suppress the card: the picker still works from the active file,
+  // and a refusal nobody reports is a blank sheet with no way out.
   const accessDeniedDir =
     errorKind === 'access-denied' && activeFilePath ? getParentDir(activeFilePath) || null : null;
+
+  // The card replaces the document, so it may only do that when there is no
+  // document to replace. `reloadFile` keeps the loaded content on failure, so
+  // a directory that rotates away under an open file 403s a tab the user is
+  // still reading; taking that over would hide their work behind a card with
+  // no dismiss. Those tabs keep their content and report through the toolbar.
+  const showAccessRequest = errorKind === 'access-denied' && !rawMarkdown;
+
+  // If the card is still up after a completed grant, the folder the user picked
+  // does not contain the file. See `sawGrant` above.
+  useEffect(() => {
+    if (!showAccessRequest) setSawGrant(false);
+  }, [showAccessRequest]);
 
   // Optimistic sent IDs: updated immediately when a batch is sent, before
   // the server round-trip completes. Merged with the server's sentCommentIds
@@ -2716,6 +2750,8 @@ export default function App() {
                     onClose={() => setExplorerVisible(false)}
                     onContextMenu={handleExplorerContextMenu}
                     onTrustFolder={handleTrustFolder}
+                    trustPending={trustFolderPending}
+                    grantNonce={grantNonce}
                     hideHeader
                   />
                 ) : (
@@ -2839,14 +2875,13 @@ export default function App() {
         <Toolbar
           error={error}
           errorKind={errorKind}
-          accessDeniedDir={accessDeniedDir}
-          homeDir={homeDir}
+          accessRequestShown={showAccessRequest}
+          onTrustFolder={() => handleTrustFolder(accessDeniedDir)}
           isLoading={isLoading}
           commentsSurfaceVisible={railShown || drawerOpen}
           author={author}
           onAuthorChange={setAuthor}
           onToggleSidebar={toggleCommentsSurface}
-          onTrustFolder={handleTrustFolder}
           tabs={
             <TabBar
               embedded
@@ -2955,168 +2990,188 @@ export default function App() {
                     ) : undefined
                   }
                 />
-                {viewMode === 'raw' ? (
-                  <RawView
-                    ref={rawViewRef}
-                    scrollContainerRef={containerRef}
-                    rawMarkdown={rawMarkdown}
-                    searchQuery={showSearch ? searchQuery : undefined}
-                    searchActiveIndex={activeSearchIndex}
-                    onSearchCount={handleSearchCount}
-                    activeCommentId={activeCommentId}
-                    diffSnapshot={currentSnapshot}
-                    diffEnabled={diffEnabled}
-                    diffLines={diffLines}
-                    oldCleanToRawLine={oldCleanToRawLine}
-                    newCleanToRawLine={newCleanToRawLine}
-                  />
-                ) : (
-                  <div className="relative flex-1 min-h-0">
-                    <div ref={containerRef} className="h-full overflow-y-auto pt-3 relative">
-                      <div
-                        ref={pageRef}
-                        data-doc-page
-                        className="doc-sheet bg-surface mx-auto relative pt-6 pb-[50vh] motion-safe:transition-[width] motion-safe:duration-150"
-                        style={{
-                          width: geometry.pageWidth,
-                          maxWidth: 'calc(100% - 24px)',
-                          minHeight: railShown
-                            ? `max(100%, ${marginLayout.layerHeight + 120}px)`
-                            : '100%',
-                        }}
-                      >
+                {/* A refused folder covers the document rather than leaving a
+                    blank sheet behind an error strip: the ask belongs on the
+                    surface the user is looking at. It covers rather than
+                    replaces because the viewer and the scroll container carry
+                    state that only re-derives on mount — usePageGeometry
+                    observes containerRef once, and the viewers are what report
+                    the search match count — so unmounting them here left the
+                    document rail-less and the search count stale once the
+                    grant landed. */}
+                <div className="relative flex-1 min-h-0 flex flex-col">
+                  {showAccessRequest && (
+                    <AccessRequest
+                      dir={accessDeniedDir}
+                      homeDir={homeDir}
+                      pending={trustFolderPending}
+                      grantMissed={sawGrant}
+                      onAllow={() => handleTrustFolder(accessDeniedDir)}
+                    />
+                  )}
+                  {viewMode === 'raw' ? (
+                    <RawView
+                      ref={rawViewRef}
+                      scrollContainerRef={containerRef}
+                      rawMarkdown={rawMarkdown}
+                      searchQuery={showSearch ? searchQuery : undefined}
+                      searchActiveIndex={activeSearchIndex}
+                      onSearchCount={handleSearchCount}
+                      activeCommentId={activeCommentId}
+                      diffSnapshot={currentSnapshot}
+                      diffEnabled={diffEnabled}
+                      diffLines={diffLines}
+                      oldCleanToRawLine={oldCleanToRawLine}
+                      newCleanToRawLine={newCleanToRawLine}
+                    />
+                  ) : (
+                    <div className="relative flex-1 min-h-0">
+                      <div ref={containerRef} className="h-full overflow-y-auto pt-3 relative">
                         <div
-                          className="motion-safe:transition-[width] motion-safe:duration-150"
-                          style={{ marginLeft: PAD_L, width: geometry.colWidth }}
+                          ref={pageRef}
+                          data-doc-page
+                          className="doc-sheet bg-surface mx-auto relative pt-6 pb-[50vh] motion-safe:transition-[width] motion-safe:duration-150"
+                          style={{
+                            width: geometry.pageWidth,
+                            maxWidth: 'calc(100% - 24px)',
+                            minHeight: railShown
+                              ? `max(100%, ${marginLayout.layerHeight + 120}px)`
+                              : '100%',
+                          }}
                         >
-                          {diffEnabled && currentSnapshot && diffLines ? (
-                            // key on activeFilePath forces a remount when the user
-                            // switches files while the diff overlay is on, so the
-                            // mount-time auto-scroll-to-first-chunk fires for each
-                            // file's diff. Without this, the [] effect in
-                            // RenderedDiffView only runs for the first file viewed.
-                            <RenderedDiffView
-                              key={activeFilePath ?? ''}
-                              ref={renderedDiffRef}
-                              rawMarkdown={rawMarkdown}
-                              diffSnapshot={currentSnapshot}
-                              diffLines={diffLines}
+                          <div
+                            className="motion-safe:transition-[width] motion-safe:duration-150"
+                            style={{ marginLeft: PAD_L, width: geometry.colWidth }}
+                          >
+                            {diffEnabled && currentSnapshot && diffLines ? (
+                              // key on activeFilePath forces a remount when the user
+                              // switches files while the diff overlay is on, so the
+                              // mount-time auto-scroll-to-first-chunk fires for each
+                              // file's diff. Without this, the [] effect in
+                              // RenderedDiffView only runs for the first file viewed.
+                              <RenderedDiffView
+                                key={activeFilePath ?? ''}
+                                ref={renderedDiffRef}
+                                rawMarkdown={rawMarkdown}
+                                diffSnapshot={currentSnapshot}
+                                diffLines={diffLines}
+                              />
+                            ) : (
+                              <>
+                                {viewerNeedsTheme ? (
+                                  <ThemedMarkdownViewer
+                                    ref={viewerRef}
+                                    html={html}
+                                    cleanMarkdown={cleanMarkdown}
+                                    comments={comments}
+                                    activeCommentId={activeCommentId}
+                                    selectionText={selection?.text ?? null}
+                                    selectionOffset={selection?.offset ?? null}
+                                    onHighlightClick={handleHighlightClickWithPopover}
+                                    // Fragment arg is intentionally ignored in v1; openTab
+                                    // takes only the path. See spec §3 non-goals.
+                                    onLocalLinkClick={openTab}
+                                    onContextMenu={handleViewerContextMenu}
+                                    enableResolve={settings.enableResolve}
+                                    searchQuery={showSearch ? searchQuery : undefined}
+                                    searchActiveIndex={activeSearchIndex}
+                                    onSearchCount={handleSearchCount}
+                                    sentCommentIds={sentCommentIds}
+                                    mermaidSvgMap={mermaidSvgMap}
+                                    onOpenMermaidFullscreen={handleOpenMermaidFullscreen}
+                                    onHighlightsPainted={handleHighlightsPainted}
+                                  />
+                                ) : (
+                                  <MarkdownViewer
+                                    ref={viewerRef}
+                                    html={html}
+                                    cleanMarkdown={cleanMarkdown}
+                                    comments={comments}
+                                    activeCommentId={activeCommentId}
+                                    selectionText={selection?.text ?? null}
+                                    selectionOffset={selection?.offset ?? null}
+                                    onHighlightClick={handleHighlightClickWithPopover}
+                                    // Fragment arg is intentionally ignored in v1; openTab
+                                    // takes only the path. See spec §3 non-goals.
+                                    onLocalLinkClick={openTab}
+                                    onContextMenu={handleViewerContextMenu}
+                                    enableResolve={settings.enableResolve}
+                                    searchQuery={showSearch ? searchQuery : undefined}
+                                    searchActiveIndex={activeSearchIndex}
+                                    onSearchCount={handleSearchCount}
+                                    sentCommentIds={sentCommentIds}
+                                    mermaidSvgMap={mermaidSvgMap}
+                                    onOpenMermaidFullscreen={handleOpenMermaidFullscreen}
+                                    onHighlightsPainted={handleHighlightsPainted}
+                                  />
+                                )}
+                                <DragHandles
+                                  startPos={handlePositions?.start ?? null}
+                                  endPos={handlePositions?.end ?? null}
+                                  onMouseDown={onHandleMouseDown}
+                                />
+                              </>
+                            )}
+                          </div>
+                          {railShown && (
+                            <CommentsRail
+                              density={railDensity}
+                              scrollRef={containerRef as RefObject<HTMLElement | null>}
+                              layout={marginLayout}
+                              anchoredComments={marginComments}
+                              allComments={comments}
+                              activeCommentId={activeCommentId}
+                              missingAnchors={missingAnchors}
+                              sentCommentIds={sentCommentIds}
+                              onActivate={handleSidebarActivate}
+                              onReply={handleReply}
+                              onResolve={settings.enableResolve ? handleResolve : undefined}
+                              onUnresolve={settings.enableResolve ? handleUnresolve : undefined}
+                              onDelete={handleDelete}
+                              onEdit={handleEdit}
+                              onEditReply={handleEditReply}
+                              onDeleteReply={handleDeleteReply}
+                              onBulkDelete={handleBulkDelete}
+                              onBulkResolve={handleBulkResolve}
+                              onBulkDeleteResolved={handleBulkDeleteResolved}
+                              onContextMenu={handleSidebarContextMenu}
+                              selectionText={selection?.text ?? null}
+                              selectionOffset={selection?.offset ?? null}
+                              onReanchorToSelection={handleReanchorToSelection}
+                              requestedEditor={requestedEditor}
+                              requestedFocus={requestedCommentFocus}
+                              onFocusHandled={() => setRequestedCommentFocus(null)}
+                              unreadReplyIds={unreadReplyIds}
                             />
-                          ) : (
-                            <>
-                              {viewerNeedsTheme ? (
-                                <ThemedMarkdownViewer
-                                  ref={viewerRef}
-                                  html={html}
-                                  cleanMarkdown={cleanMarkdown}
-                                  comments={comments}
-                                  activeCommentId={activeCommentId}
-                                  selectionText={selection?.text ?? null}
-                                  selectionOffset={selection?.offset ?? null}
-                                  onHighlightClick={handleHighlightClickWithPopover}
-                                  // Fragment arg is intentionally ignored in v1; openTab
-                                  // takes only the path. See spec §3 non-goals.
-                                  onLocalLinkClick={openTab}
-                                  onContextMenu={handleViewerContextMenu}
-                                  enableResolve={settings.enableResolve}
-                                  searchQuery={showSearch ? searchQuery : undefined}
-                                  searchActiveIndex={activeSearchIndex}
-                                  onSearchCount={handleSearchCount}
-                                  sentCommentIds={sentCommentIds}
-                                  mermaidSvgMap={mermaidSvgMap}
-                                  onOpenMermaidFullscreen={handleOpenMermaidFullscreen}
-                                  onHighlightsPainted={handleHighlightsPainted}
-                                />
-                              ) : (
-                                <MarkdownViewer
-                                  ref={viewerRef}
-                                  html={html}
-                                  cleanMarkdown={cleanMarkdown}
-                                  comments={comments}
-                                  activeCommentId={activeCommentId}
-                                  selectionText={selection?.text ?? null}
-                                  selectionOffset={selection?.offset ?? null}
-                                  onHighlightClick={handleHighlightClickWithPopover}
-                                  // Fragment arg is intentionally ignored in v1; openTab
-                                  // takes only the path. See spec §3 non-goals.
-                                  onLocalLinkClick={openTab}
-                                  onContextMenu={handleViewerContextMenu}
-                                  enableResolve={settings.enableResolve}
-                                  searchQuery={showSearch ? searchQuery : undefined}
-                                  searchActiveIndex={activeSearchIndex}
-                                  onSearchCount={handleSearchCount}
-                                  sentCommentIds={sentCommentIds}
-                                  mermaidSvgMap={mermaidSvgMap}
-                                  onOpenMermaidFullscreen={handleOpenMermaidFullscreen}
-                                  onHighlightsPainted={handleHighlightsPainted}
-                                />
-                              )}
-                              <DragHandles
-                                startPos={handlePositions?.start ?? null}
-                                endPos={handlePositions?.end ?? null}
-                                onMouseDown={onHandleMouseDown}
-                              />
-                            </>
                           )}
+                          {popoverCommentId &&
+                            !railCanShowThread(popoverCommentId) &&
+                            (() => {
+                              const c = comments.find((x) => x.id === popoverCommentId);
+                              if (!c) return null;
+                              return (
+                                <CommentPopover
+                                  comment={c}
+                                  pageRef={pageRef as RefObject<HTMLElement | null>}
+                                  onClose={() => setPopoverCommentId(null)}
+                                  sent={sentCommentIds.includes(c.id)}
+                                  anchorMissing={missingAnchors.has(c.id)}
+                                  onReply={handleReply}
+                                  onResolve={settings.enableResolve ? handleResolve : undefined}
+                                  onUnresolve={settings.enableResolve ? handleUnresolve : undefined}
+                                  onDelete={handleDelete}
+                                  onEdit={handleEdit}
+                                  onEditReply={handleEditReply}
+                                  onDeleteReply={handleDeleteReply}
+                                />
+                              );
+                            })()}
                         </div>
-                        {railShown && (
-                          <CommentsRail
-                            density={railDensity}
-                            scrollRef={containerRef as RefObject<HTMLElement | null>}
-                            layout={marginLayout}
-                            anchoredComments={marginComments}
-                            allComments={comments}
-                            activeCommentId={activeCommentId}
-                            missingAnchors={missingAnchors}
-                            sentCommentIds={sentCommentIds}
-                            onActivate={handleSidebarActivate}
-                            onReply={handleReply}
-                            onResolve={settings.enableResolve ? handleResolve : undefined}
-                            onUnresolve={settings.enableResolve ? handleUnresolve : undefined}
-                            onDelete={handleDelete}
-                            onEdit={handleEdit}
-                            onEditReply={handleEditReply}
-                            onDeleteReply={handleDeleteReply}
-                            onBulkDelete={handleBulkDelete}
-                            onBulkResolve={handleBulkResolve}
-                            onBulkDeleteResolved={handleBulkDeleteResolved}
-                            onContextMenu={handleSidebarContextMenu}
-                            selectionText={selection?.text ?? null}
-                            selectionOffset={selection?.offset ?? null}
-                            onReanchorToSelection={handleReanchorToSelection}
-                            requestedEditor={requestedEditor}
-                            requestedFocus={requestedCommentFocus}
-                            onFocusHandled={() => setRequestedCommentFocus(null)}
-                            unreadReplyIds={unreadReplyIds}
-                          />
-                        )}
-                        {popoverCommentId &&
-                          !railCanShowThread(popoverCommentId) &&
-                          (() => {
-                            const c = comments.find((x) => x.id === popoverCommentId);
-                            if (!c) return null;
-                            return (
-                              <CommentPopover
-                                comment={c}
-                                pageRef={pageRef as RefObject<HTMLElement | null>}
-                                onClose={() => setPopoverCommentId(null)}
-                                sent={sentCommentIds.includes(c.id)}
-                                anchorMissing={missingAnchors.has(c.id)}
-                                onReply={handleReply}
-                                onResolve={settings.enableResolve ? handleResolve : undefined}
-                                onUnresolve={settings.enableResolve ? handleUnresolve : undefined}
-                                onDelete={handleDelete}
-                                onEdit={handleEdit}
-                                onEditReply={handleEditReply}
-                                onDeleteReply={handleDeleteReply}
-                              />
-                            );
-                          })()}
                       </div>
+                      <DensityStrip ticks={commentTicks} onJump={handleDensityJump} />
                     </div>
-                    <DensityStrip ticks={commentTicks} onJump={handleDensityJump} />
-                  </div>
-                )}
+                  )}
+                </div>
               </div>
             </div>
           </div>

--- a/src/components/AccessRequest.test.tsx
+++ b/src/components/AccessRequest.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { AccessRequest } from './AccessRequest';
+
+afterEach(cleanup);
+
+const DEEP_DIR =
+  '/private/tmp/claude-503/-Users-dennisju-dev-buela-product-management-designer-jd/1a7f55ac-00f8-4f15-a8b2-4b820badf2a2/scratchpad';
+
+describe('AccessRequest', () => {
+  it('leads with the folder name, not the absolute path', () => {
+    render(<AccessRequest dir={DEEP_DIR} onAllow={vi.fn()} />);
+    expect(screen.getByText('scratchpad')).toBeTruthy();
+    // The raw path never appears in full; it is elided and kept in the tooltip
+    // so a four-line wall of path cannot come back.
+    expect(screen.queryByText(DEEP_DIR)).toBeNull();
+    expect(screen.getByTitle(DEEP_DIR)).toBeTruthy();
+  });
+
+  it('tilde-shortens the displayed path', () => {
+    render(
+      <AccessRequest dir="/Users/dennisju/dev/notes" homeDir="/Users/dennisju" onAllow={vi.fn()} />,
+    );
+    expect(screen.getByTitle('/Users/dennisju/dev/notes').textContent).toBe('~/dev/notes');
+  });
+
+  it('calls onAllow when the button is clicked', () => {
+    const onAllow = vi.fn();
+    render(<AccessRequest dir={DEEP_DIR} onAllow={onAllow} />);
+    fireEvent.click(screen.getByTestId('access-request-allow'));
+    expect(onAllow).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button and says what it is waiting on while pending', () => {
+    render(<AccessRequest dir={DEEP_DIR} pending onAllow={vi.fn()} />);
+    const button = screen.getByTestId('access-request-allow') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.textContent).toMatch(/waiting/i);
+  });
+
+  it('renders the panel variant without the page copy', () => {
+    render(<AccessRequest dir={DEEP_DIR} variant="panel" onAllow={vi.fn()} />);
+    expect(screen.getByTestId('access-request-panel')).toBeTruthy();
+    expect(screen.queryByTestId('access-request')).toBeNull();
+    expect(screen.queryByText(/system dialog/i)).toBeNull();
+    expect(screen.getByTestId('access-request-panel-allow')).toBeTruthy();
+  });
+
+  it('gives each variant its own button testid, since both mount together', () => {
+    // The document card and the explorer panel are routinely refused by the
+    // same folder and render at once; a shared testid makes every unscoped
+    // Playwright lookup a strict-mode violation.
+    render(
+      <>
+        <AccessRequest dir={DEEP_DIR} onAllow={vi.fn()} />
+        <AccessRequest dir={DEEP_DIR} variant="panel" onAllow={vi.fn()} />
+      </>,
+    );
+    expect(screen.getAllByTestId('access-request-allow')).toHaveLength(1);
+    expect(screen.getAllByTestId('access-request-panel-allow')).toHaveLength(1);
+  });
+
+  it('still asks when the folder cannot be named', () => {
+    // `?file=~` has no derivable parent. Suppressing the card there left a
+    // blank sheet with no message and no button.
+    render(<AccessRequest dir={null} onAllow={vi.fn()} />);
+    expect(screen.getByTestId('access-request')).toBeTruthy();
+    expect(screen.getByTestId('access-request-allow')).toBeTruthy();
+  });
+
+  it('says the grant missed instead of repeating itself word for word', () => {
+    render(<AccessRequest dir={DEEP_DIR} grantMissed onAllow={vi.fn()} />);
+    expect(screen.getByText(/does not cover this file/i)).toBeTruthy();
+    expect(screen.queryByText(/Opens a system dialog/i)).toBeNull();
+  });
+
+  it('announces itself, since it replaced the toolbar strip that used to', () => {
+    render(<AccessRequest dir={DEEP_DIR} onAllow={vi.fn()} />);
+    const card = screen.getByTestId('access-request');
+    expect(card.getAttribute('role')).toBe('status');
+    expect(card.getAttribute('aria-live')).toBe('polite');
+  });
+});

--- a/src/components/AccessRequest.tsx
+++ b/src/components/AccessRequest.tsx
@@ -1,0 +1,131 @@
+import { FolderIcon } from './icons';
+import { getPathBasename, middleTruncatePath, tildeShortenPath } from '../lib/path-utils';
+
+interface Props {
+  /**
+   * Absolute path of the folder md-redline was refused, or null when the tab's
+   * path has no derivable parent (`?file=~`, a Windows drive-relative path).
+   * The ask still has to appear in that case; it just cannot name the folder.
+   */
+  dir: string | null;
+  /** User's home directory; used to tilde-shorten the displayed path. */
+  homeDir?: string;
+  /** True while the native picker is open, so the button can stop inviting clicks. */
+  pending?: boolean;
+  /**
+   * Set after a grant that did not clear this refusal, which in practice means
+   * the user picked a folder that does not contain the file. Without it the
+   * card reappears word for word and reads as a dead button.
+   */
+  grantMissed?: boolean;
+  onAllow: () => void;
+  /**
+   * 'page' owns the document area and is the primary ask. 'panel' is the
+   * explorer's version: the same words, deliberately quieter, so two surfaces
+   * refusing the same folder read as one request with a footnote rather than
+   * two competing calls to action.
+   */
+  variant?: 'page' | 'panel';
+}
+
+const PENDING_LABEL = 'Waiting for the system dialog…';
+const ALLOW_LABEL = 'Allow this folder…';
+const MISSED_NOTE = 'That folder does not cover this file. Try one further up.';
+
+export function AccessRequest({
+  dir,
+  homeDir = '',
+  pending,
+  grantMissed,
+  onAllow,
+  variant = 'page',
+}: Props) {
+  const displayPath = dir ? tildeShortenPath(dir, homeDir) : '';
+  const folderName = dir ? getPathBasename(dir) || displayPath : 'This folder';
+
+  if (variant === 'panel') {
+    return (
+      <div
+        data-testid="access-request-panel"
+        role="status"
+        className="flex-1 flex flex-col items-center justify-center gap-2 px-4 text-center"
+      >
+        <FolderIcon className="w-6 h-6 text-content-faint" />
+        <div className="min-w-0 w-full">
+          <div className="text-xs font-medium text-content">Folder not allowed</div>
+          {dir && (
+            // The budget is set for the panel's default width, where the
+            // elision is what the user reads; `truncate` is the overflow guard
+            // for a panel dragged to its 160px minimum. Budgeting for the
+            // minimum instead threw away the head at every normal width.
+            <div className="mt-0.5 text-[11px] text-content-muted truncate" title={dir}>
+              {middleTruncatePath(displayPath, 26)}
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onAllow}
+          disabled={pending}
+          data-testid="access-request-panel-allow"
+          className="text-[11px] font-medium text-primary-text px-2 py-1 rounded hover:bg-tint-primary transition-colors disabled:opacity-50 disabled:hover:bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          {pending ? PENDING_LABEL : ALLOW_LABEL}
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    // role=status + aria-live: this replaced the toolbar strip that used to
+    // announce the refusal, and swapping the document region for a card is
+    // silent to a screen reader on its own.
+    <div
+      data-testid="access-request"
+      role="status"
+      aria-live="polite"
+      className="absolute inset-0 z-20 overflow-y-auto bg-surface-secondary flex justify-center px-6 pt-[14vh] pb-8"
+    >
+      <div className="w-full max-w-xs flex flex-col items-center text-center">
+        <div className="w-11 h-11 rounded-xl bg-surface-inset border border-border-subtle flex items-center justify-center">
+          <FolderIcon className="w-5 h-5 text-content-muted" />
+        </div>
+
+        <h2 className="mt-4 text-sm font-semibold text-content">
+          md-redline can&rsquo;t read this folder
+        </h2>
+        <p className="mt-1.5 text-xs leading-relaxed text-content-secondary">
+          It only opens files in folders you have allowed. Allowing this one is remembered for next
+          time.
+        </p>
+
+        {dir && (
+          <div className="mt-4 w-full rounded-lg border border-border-subtle bg-surface-inset px-3 py-2.5 text-left">
+            <div className="text-xs font-medium text-content truncate" title={folderName}>
+              {folderName}
+            </div>
+            <div className="mt-0.5 text-[11px] text-content-muted truncate" title={dir}>
+              {middleTruncatePath(displayPath)}
+            </div>
+          </div>
+        )}
+
+        <button
+          type="button"
+          onClick={onAllow}
+          disabled={pending}
+          data-testid="access-request-allow"
+          className="mt-4 px-3.5 py-1.5 rounded-md bg-primary text-on-primary text-xs font-medium hover:bg-primary-hover transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+        >
+          {pending ? PENDING_LABEL : ALLOW_LABEL}
+        </button>
+
+        <p className="mt-2.5 text-[11px] leading-relaxed text-content-muted">
+          {grantMissed
+            ? MISSED_NOTE
+            : 'Opens a system dialog. Choose a parent folder to allow everything inside it.'}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/FileExplorer.tsx
+++ b/src/components/FileExplorer.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { getApiErrorMessage, readJsonResponse, type ApiErrorPayload } from '../lib/http';
-import { getParentDir, getPathBasename, tildeShortenPath } from '../lib/path-utils';
+import { getParentDir, getPathBasename } from '../lib/path-utils';
+import { AccessRequest } from './AccessRequest';
 
 interface BrowseResult {
   dir: string;
@@ -45,7 +46,23 @@ interface Props {
   onClose: () => void;
   onContextMenu?: (info: ExplorerContextMenuInfo) => void;
   hideHeader?: boolean;
-  onTrustFolder?: (deniedDir: string) => Promise<void>;
+  /** Resolves true only when a folder was actually granted. */
+  onTrustFolder?: (deniedDir: string) => Promise<boolean>;
+  /**
+   * True while any surface owns the native picker. Shared rather than local so
+   * this panel's button does not keep inviting clicks while the document
+   * area's dialog is up; a click that lands then is swallowed by the app's
+   * re-entrancy guard and spends this panel's retry on a still-denied folder.
+   */
+  trustPending?: boolean;
+  /**
+   * Bumped by the app on every completed grant, including grants made from
+   * the document area's card. Both surfaces are usually refused by the same
+   * folder, so the panel has to re-browse on someone else's grant or it sits
+   * on a stale refusal whose only affordance reopens the picker for a folder
+   * that is already trusted.
+   */
+  grantNonce?: number;
 }
 
 export function FileExplorer({
@@ -61,6 +78,8 @@ export function FileExplorer({
   onContextMenu: onCtxMenu,
   hideHeader,
   onTrustFolder,
+  trustPending,
+  grantNonce = 0,
 }: Props) {
   const [data, setData] = useState<BrowseResult | null>(null);
   const [loading, setLoading] = useState(false);
@@ -123,6 +142,18 @@ export function FileExplorer({
     };
   }, [browse, initialDir, revealNonce]);
 
+  // Retry a refused browse when a grant lands anywhere in the app, which covers
+  // the grant made from the document area's card. Gated on this panel actually
+  // being refused so an unrelated grant does not re-fetch a healthy listing.
+  const deniedDirRef = useRef<string | null>(null);
+  deniedDirRef.current = errorKind === 'access-denied' ? accessDeniedDir : null;
+  const firstGrantNonceRef = useRef(grantNonce);
+  useEffect(() => {
+    if (grantNonce === firstGrantNonceRef.current) return;
+    const denied = deniedDirRef.current;
+    if (denied !== null) browse(denied);
+  }, [grantNonce, browse]);
+
   // Keep the open file visible when the listing changes or a reveal lands, so
   // it is not stranded below the fold in a long directory. A revealed file that
   // is not the active one gets a brief flash so the eye can find it.
@@ -167,6 +198,13 @@ export function FileExplorer({
     const timer = window.setTimeout(() => setFlashPath(null), 1600);
     return () => window.clearTimeout(timer);
   }, [flashPath]);
+
+  // One boolean rather than a predicate and its hand-written negation below,
+  // which desync into either a blank panel or two stacked error states the
+  // moment one of the five terms is edited.
+  const showAccessRequest = Boolean(
+    error && !data && errorKind === 'access-denied' && onTrustFolder && accessDeniedDir,
+  );
 
   const dirName = getPathBasename(data?.dir || '') || data?.dir || 'Files';
 
@@ -230,28 +268,25 @@ export function FileExplorer({
         </div>
       )}
 
-      {/* Error */}
-      {error && !data && (
-        <div className="flex-1 flex flex-col items-center justify-center text-xs text-danger px-3 text-center gap-2">
-          <span className="break-all" title={accessDeniedDir ?? undefined}>
-            {errorKind === 'access-denied' && accessDeniedDir
-              ? `Allow md-redline to read ${tildeShortenPath(accessDeniedDir, homeDir)}?`
-              : errorKind === 'access-denied'
-                ? 'Allow md-redline to read this folder?'
-                : error}
-          </span>
-          {errorKind === 'access-denied' && onTrustFolder && accessDeniedDir && (
-            <button
-              type="button"
-              onClick={async () => {
-                await onTrustFolder(accessDeniedDir);
-                browse(accessDeniedDir);
-              }}
-              className="px-2 py-0.5 rounded border border-danger/50 text-danger hover:bg-danger/10 transition-colors text-[11px] font-medium"
-            >
-              Allow access
-            </button>
-          )}
+      {/* A refused folder is a permission ask, not a failure, so it gets the
+          same card as the document area rather than red error text. */}
+      {showAccessRequest && (
+        <AccessRequest
+          variant="panel"
+          dir={accessDeniedDir}
+          homeDir={homeDir}
+          pending={trustPending}
+          onAllow={async () => {
+            // Only re-browse on an actual grant. A cancelled dialog leaves the
+            // folder exactly as refused as it was, so refetching costs a round
+            // trip and a card flash that reads like the grant failed.
+            if (await onTrustFolder!(accessDeniedDir!)) browse(accessDeniedDir!);
+          }}
+        />
+      )}
+      {error && !data && !showAccessRequest && (
+        <div className="flex-1 flex items-center justify-center text-xs text-danger px-3 text-center">
+          <span className="break-all">{error}</span>
         </div>
       )}
 

--- a/src/components/FileOpener.tsx
+++ b/src/components/FileOpener.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { RecentFile } from '../hooks/useRecentFiles';
 import { getApiErrorMessage, readJsonResponse, type ApiErrorPayload } from '../lib/http';
+import { FolderIcon } from './icons';
 
 interface Props {
   open: boolean;
@@ -197,19 +198,10 @@ export function FileOpener({
                   : 'text-content hover:bg-tint'
               }`}
             >
-              <svg
+              <FolderIcon
                 className={`w-4 h-4 shrink-0 ${selectedIndex === SYSTEM_INDEX ? 'text-primary-text' : 'text-content-muted'}`}
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
                 strokeWidth={2}
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776"
-                />
-              </svg>
+              />
               System file picker...
             </button>
           </div>

--- a/src/components/TabBar.tsx
+++ b/src/components/TabBar.tsx
@@ -4,6 +4,23 @@ import { getPathBasename } from '../lib/path-utils';
 interface Tab {
   filePath: string;
   error: string | null;
+  errorKind?: 'access-denied' | 'generic' | null;
+}
+
+// A tab waiting on a folder permission is not a failed tab, so its marker is
+// neutral. Red stays for the errors the user cannot resolve by answering a
+// prompt. Muted rather than faint: this dot is the only signal a background
+// denied tab gets, and faint sits under the 3:1 non-text contrast minimum.
+function errorDotClass(tab: Tab): string {
+  return tab.errorKind === 'access-denied' ? 'bg-content-muted' : 'bg-danger';
+}
+
+// The dot is 6px and unlabelled, so the tab's tooltip has to carry the meaning.
+function tabTitle(tab: Tab): string {
+  if (!tab.error) return tab.filePath;
+  const reason =
+    tab.errorKind === 'access-denied' ? 'Folder not allowed yet' : `Failed to load: ${tab.error}`;
+  return `${tab.filePath}\n${reason}`;
 }
 
 export interface TabContextMenuInfo {
@@ -248,7 +265,7 @@ export function TabBar({
                         : 'bg-surface text-content font-medium border-b-primary'
                       : 'border-b-transparent text-content-secondary hover:text-content hover:bg-tint'
                   }`}
-                  title={tab.filePath}
+                  title={tabTitle(tab)}
                 >
                   <span className="truncate">{fileName}</span>
                   {count > 0 ? (
@@ -269,7 +286,9 @@ export function TabBar({
                       {resolvedCount}
                     </span>
                   ) : null}
-                  {tab.error && <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" />}
+                  {tab.error && (
+                    <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${errorDotClass(tab)}`} />
+                  )}
                   <span
                     role="button"
                     onClick={(e) => {
@@ -386,7 +405,7 @@ export function TabBar({
                         className={`w-full px-3 py-2 flex items-center gap-2 text-left transition-colors ${
                           isActive ? 'bg-surface-inset' : 'hover:bg-tint'
                         }`}
-                        title={tab.filePath}
+                        title={tabTitle(tab)}
                       >
                         <span
                           className={`w-1.5 h-1.5 rounded-full shrink-0 ${isActive ? 'bg-primary' : 'bg-transparent'}`}
@@ -415,7 +434,9 @@ export function TabBar({
                           </span>
                         ) : null}
                         {tab.error && (
-                          <span className="w-1.5 h-1.5 rounded-full bg-danger shrink-0" />
+                          <span
+                            className={`w-1.5 h-1.5 rounded-full shrink-0 ${errorDotClass(tab)}`}
+                          />
                         )}
                       </button>
                     );

--- a/src/components/Toolbar.test.tsx
+++ b/src/components/Toolbar.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { Toolbar } from './Toolbar';
+
+afterEach(cleanup);
+
+function renderToolbar(overrides: Partial<React.ComponentProps<typeof Toolbar>> = {}) {
+  return render(
+    <Toolbar
+      error={null}
+      errorKind={null}
+      accessRequestShown={false}
+      onTrustFolder={vi.fn()}
+      isLoading={false}
+      commentsSurfaceVisible={false}
+      author="Dennis"
+      onAuthorChange={vi.fn()}
+      onToggleSidebar={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('Toolbar status', () => {
+  it('reports a generic error', () => {
+    renderToolbar({ error: 'File not found', errorKind: 'generic' });
+    expect(screen.getByText('File not found')).toBeTruthy();
+  });
+
+  it('says nothing about access-denied while the document area shows the card', () => {
+    renderToolbar({
+      error: 'Access denied: path outside allowed directories',
+      errorKind: 'access-denied',
+      accessRequestShown: true,
+    });
+    expect(screen.queryByTestId('toolbar-allow-access')).toBeNull();
+    expect(screen.queryByText(/access denied/i)).toBeNull();
+  });
+
+  it('reports access-denied when the card declined to take over', () => {
+    // A tab that kept its content through a failed reload: the card must not
+    // cover the document, so the toolbar is the only surface left to report it.
+    const onTrustFolder = vi.fn();
+    renderToolbar({
+      error: 'Access denied: cannot resolve path',
+      errorKind: 'access-denied',
+      accessRequestShown: false,
+      onTrustFolder,
+    });
+    expect(screen.getByText(/lost access/i)).toBeTruthy();
+    fireEvent.click(screen.getByTestId('toolbar-allow-access'));
+    expect(onTrustFolder).toHaveBeenCalledTimes(1);
+  });
+
+  it('never shows the raw server message for access-denied', () => {
+    renderToolbar({
+      error: 'Access denied: path outside allowed directories',
+      errorKind: 'access-denied',
+    });
+    expect(screen.queryByText(/outside allowed directories/)).toBeNull();
+  });
+
+  it('shows the loading indicator', () => {
+    renderToolbar({ isLoading: true });
+    expect(screen.getByText('Loading...')).toBeTruthy();
+  });
+});

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,6 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
 import { getPrimaryModifierLabel } from '../lib/platform';
-import { tildeShortenPath } from '../lib/path-utils';
 import { IconButton } from './IconButton';
 
 export type ViewMode = 'rendered' | 'raw';
@@ -8,10 +7,15 @@ export type ViewMode = 'rendered' | 'raw';
 interface Props {
   error: string | null;
   errorKind: 'access-denied' | 'generic' | null;
-  /** When errorKind is 'access-denied', the directory the trust click would grant. */
-  accessDeniedDir: string | null;
-  /** User's home directory; used to tilde-shorten the path in the trust prompt. */
-  homeDir: string;
+  /**
+   * True when the document area is showing the permission card, which is the
+   * usual access-denied case. The toolbar then says nothing: repeating the ask
+   * in a strip too narrow for an absolute path was the whole problem. It still
+   * reports a refusal the card declines to take over, which is a tab that kept
+   * its content through a failed reload.
+   */
+  accessRequestShown: boolean;
+  onTrustFolder: () => void;
   isLoading: boolean;
   /** Whether a comments surface is actually on screen (rail or drawer), which
    * is what the toggle button's active state reflects. Not the same as the
@@ -21,21 +25,19 @@ interface Props {
   author: string;
   onAuthorChange: (name: string) => void;
   onToggleSidebar: () => void;
-  onTrustFolder: () => void;
   tabs?: React.ReactNode;
 }
 
 export function Toolbar({
   error,
   errorKind,
-  accessDeniedDir,
-  homeDir,
+  accessRequestShown,
+  onTrustFolder,
   isLoading,
   commentsSurfaceVisible,
   author,
   onAuthorChange,
   onToggleSidebar,
-  onTrustFolder,
   tabs,
 }: Props) {
   const [editingAuthor, setEditingAuthor] = useState(false);
@@ -66,26 +68,22 @@ export function Toolbar({
           so the active tab still merges into the sheet below. */}
       {tabs && <div className="flex-1 min-w-0 self-stretch flex items-end pt-1.5">{tabs}</div>}
 
-      {/* Center spacer with status */}
+      {/* Center spacer with status. */}
       <div className="flex items-center gap-2 min-w-0 shrink">
-        {error && (
-          <span className="text-xs text-danger font-medium flex items-center gap-2 min-w-0">
-            <span className="truncate" title={accessDeniedDir ?? undefined}>
-              {errorKind === 'access-denied'
-                ? accessDeniedDir
-                  ? `Allow md-redline to read ${tildeShortenPath(accessDeniedDir, homeDir)}?`
-                  : 'Allow md-redline to read this folder?'
-                : error}
-            </span>
-            {errorKind === 'access-denied' && (
-              <button
-                type="button"
-                onClick={() => onTrustFolder()}
-                className="shrink-0 px-2 py-0.5 rounded border border-danger/50 text-danger hover:bg-danger/10 transition-colors text-[11px] font-medium"
-              >
-                Allow access
-              </button>
-            )}
+        {error && errorKind !== 'access-denied' && (
+          <span className="text-xs text-danger font-medium truncate">{error}</span>
+        )}
+        {errorKind === 'access-denied' && !accessRequestShown && (
+          <span className="text-xs text-content-secondary flex items-center gap-2 min-w-0">
+            <span className="truncate">Lost access to this file&rsquo;s folder</span>
+            <button
+              type="button"
+              onClick={onTrustFolder}
+              data-testid="toolbar-allow-access"
+              className="shrink-0 px-2 py-0.5 rounded text-primary-text hover:bg-tint-primary transition-colors text-[11px] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+            >
+              Allow&hellip;
+            </button>
           </span>
         )}
         {isLoading && <span className="text-xs text-content-muted">Loading...</span>}

--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -1,0 +1,29 @@
+/**
+ * Icons shared across more than one component. Anything used in a single place
+ * stays inline at its call site; this file exists so the same glyph is not
+ * transcribed twice and left to drift.
+ */
+
+export function FolderIcon({
+  className,
+  strokeWidth = 1.5,
+}: {
+  className: string;
+  strokeWidth?: number;
+}) {
+  return (
+    <svg
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={strokeWidth}
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.75 9.776c.112-.017.227-.026.344-.026h15.812c.117 0 .232.009.344.026m-16.5 0a2.25 2.25 0 00-1.883 2.542l.857 6a2.25 2.25 0 002.227 1.932H19.05a2.25 2.25 0 002.227-1.932l.857-6a2.25 2.25 0 00-1.883-2.542m-16.5 0V6A2.25 2.25 0 016 3.75h3.879a1.5 1.5 0 011.06.44l2.122 2.12a1.5 1.5 0 001.06.44H18A2.25 2.25 0 0120.25 9v.776"
+      />
+    </svg>
+  );
+}

--- a/src/lib/path-utils.test.ts
+++ b/src/lib/path-utils.test.ts
@@ -1,5 +1,74 @@
 import { describe, expect, it } from 'vitest';
-import { getParentDir, getPathBasename, tildeShortenPath } from './path-utils';
+import { getParentDir, getPathBasename, middleTruncatePath, tildeShortenPath } from './path-utils';
+
+describe('middleTruncatePath', () => {
+  it('leaves a path that already fits alone', () => {
+    expect(middleTruncatePath('/tmp/notes', 44)).toBe('/tmp/notes');
+  });
+
+  it('elides middle segments and keeps the first and last', () => {
+    const long =
+      '/private/tmp/claude-503/-Users-dennisju-dev-buela-product-management-designer-jd/1a7f55ac-00f8-4f15-a8b2-4b820badf2a2/scratchpad';
+    const out = middleTruncatePath(long, 44);
+    expect(out.startsWith('/private/')).toBe(true);
+    expect(out.endsWith('/scratchpad')).toBe(true);
+    expect(out).toContain('…');
+    expect(out.length).toBeLessThanOrEqual(44);
+  });
+
+  it('keeps as many trailing segments as fit', () => {
+    expect(middleTruncatePath('/aaa/bbb/ccc/ddd/eee/fff', 20)).toBe('/aaa/bbb/…/eee/fff');
+  });
+
+  it('keeps two leading segments so the path stays placeable', () => {
+    const out = middleTruncatePath(
+      '/private/tmp/claude-503/-Users-dennisju-dev-buela-product-management-designer-jd/1a7f55ac-00f8-4f15-a8b2-4b820badf2a2/scratchpad',
+      44,
+    );
+    expect(out).toBe('/private/tmp/…/scratchpad');
+  });
+
+  it('preserves a tilde-shortened prefix', () => {
+    expect(middleTruncatePath('~/dev/some/deeply/nested/place/scratchpad', 24)).toBe(
+      '~/dev/…/place/scratchpad',
+    );
+  });
+
+  it('handles Windows separators', () => {
+    expect(middleTruncatePath('C:\\Users\\dennisju\\dev\\projects\\notes', 20)).toBe(
+      'C:\\Users\\…\\notes',
+    );
+  });
+
+  it('never cuts the final segment, even when it alone overflows', () => {
+    const out = middleTruncatePath('/a/b/an-extremely-long-single-folder-name-here', 20);
+    expect(out).toBe('/…/an-extremely-long-single-folder-name-here');
+  });
+
+  it('drops the head rather than blowing the budget on a long leading segment', () => {
+    const out = middleTruncatePath('/Volumes/My Passport for Mac 4TB/projects/notes', 28);
+    expect(out.length).toBeLessThanOrEqual(28);
+    expect(out.endsWith('/notes')).toBe(true);
+  });
+
+  it('stays within budget when every leading segment is oversized', () => {
+    const out = middleTruncatePath(`/${'a'.repeat(30)}/${'b'.repeat(30)}/c/d`, 28);
+    expect(out.length).toBeLessThanOrEqual(28);
+    expect(out.endsWith('/d')).toBe(true);
+  });
+
+  it('keeps both leading slashes on a UNC path', () => {
+    expect(middleTruncatePath('\\\\fileserver\\share\\team\\docs\\notes', 28)).toBe(
+      '\\\\fileserver\\share\\…\\notes',
+    );
+  });
+
+  it('returns paths with too few segments unchanged', () => {
+    expect(middleTruncatePath('/a-very-long-folder-name-that-overflows', 10)).toBe(
+      '/a-very-long-folder-name-that-overflows',
+    );
+  });
+});
 
 describe('getPathBasename', () => {
   it('returns the basename for POSIX paths', () => {

--- a/src/lib/path-utils.ts
+++ b/src/lib/path-utils.ts
@@ -29,6 +29,46 @@ export function tildeShortenPath(path: string, homeDir: string): string {
 }
 
 /**
+ * Shorten a long path for display by eliding whole directory segments from the
+ * middle: `/private/tmp/…/scratchpad` rather than a hard character cut, which
+ * chops names in half and hides exactly the segment that identifies the folder.
+ * The first and last segments always survive, so the result still reads as
+ * "somewhere under /private/tmp, in scratchpad". Returns the path unchanged
+ * when it already fits or has too few segments to elide anything.
+ */
+export function middleTruncatePath(path: string, maxLength = 44): string {
+  if (!path || path.length <= maxLength) return path;
+  // A path with no forward slash at all is Windows-style; anything else keeps
+  // POSIX separators, including a mixed path, which is legal on Windows.
+  const sep = path.includes('/') ? '/' : '\\';
+  // Preserved verbatim (normalized to one separator style) so a UNC path keeps
+  // both of its leading slashes: `\\fileserver\…` is a different machine from
+  // `\fileserver\…`, and collapsing the prefix would claim the wrong one.
+  const leadingMatch = /^[\\/]+/.exec(path);
+  const leading = leadingMatch ? leadingMatch[0].replace(/[\\/]/g, sep) : '';
+  const segments = path.split(/[\\/]+/).filter(Boolean);
+  if (segments.length < 3) return path;
+
+  // Two leading segments where there is room for them, since `/private/tmp/…`
+  // places the folder in a way `/private/…` does not. The head shrinks too when
+  // it is what blows the budget: `/Volumes/My Passport for Mac 4TB/…` cannot
+  // pay for itself, and a head kept at any cost pushes the result back over
+  // maxLength and hands the overflow to the caller's CSS.
+  for (const headCount of [2, 1, 0]) {
+    if (headCount >= segments.length) continue;
+    const head = segments.slice(0, headCount);
+    // Shrink the tail one segment at a time and stop at the first fit.
+    for (let tailCount = segments.length - headCount - 1; tailCount >= 1; tailCount--) {
+      const candidate = leading + [...head, '…', ...segments.slice(-tailCount)].join(sep);
+      if (candidate.length <= maxLength) return candidate;
+    }
+  }
+  // Even `…/name` overflows, so the final segment alone is over budget. Keep it
+  // whole: half a folder name identifies nothing, and the caller clips.
+  return leading + ['…', segments[segments.length - 1]].join(sep);
+}
+
+/**
  * Directory portion of a path, for both POSIX and Windows separators.
  * Returns an empty string when the path has no directory part, so callers can
  * tell "no parent" from "the root". A POSIX root (`/`) is its own parent; a


### PR DESCRIPTION
Opening a file outside the allowed roots is a consent moment, not a failure. The app said otherwise in three places at once: red `text-danger` copy in the toolbar, the same copy again in the explorer, and the raw absolute path as the headline in both. Agent scratchpad directories are the common case, so that path was long and generated, wrapped to four lines in the explorer, overflowed the 44px toolbar strip, and identified nothing. The document area, the largest surface on screen, said nothing at all.

**Before**

![before](https://github.com/user-attachments/assets/41f23e08-6a28-4af2-b0bf-603065c4c884)

**After**

![after](https://github.com/user-attachments/assets/91072483-82c4-403f-975e-479c54d5cbaa)

`AccessRequest` owns the ask now. The page variant covers the document with the folder's name, why md-redline stopped, and the button. The explorer keeps a deliberately quieter panel variant, so two refused surfaces read as one request with a footnote rather than two competing calls to action.

![dark](https://github.com/user-attachments/assets/c379e21a-fc55-4421-a1a6-1cbcebf33adf)

## It covers the document rather than replacing it

`usePageGeometry` observes the scroll container in an effect keyed `[containerRef, enabled]`, neither of which changes when the card clears. Swapping the container out left the ResizeObserver attached to a detached node, so the sheet stopped tracking the window for the rest of the session. The viewers are also what report the search match count, so a denied tab kept the previous document's count over a card with no text. The e2e resizes after the grant and asserts the width follows; it fails on the replace arrangement and passes on this one.

## It only takes over when there is no document to take over from

`reloadFile` keeps the loaded content on failure, so a directory that rotates out from under an open file 403s a tab the user is still reading. Covering that would hide their work behind a card with no dismiss. Those tabs keep their content, and the toolbar reports the refusal with its own compact button, so exactly one surface ever owns the ask. A refusal with no derivable parent (`?file=~`, a Windows drive-relative path) names no folder but still asks.

## Two cards can be on screen at once

Everything else follows from that. `handleTrustFolder` resolves `true` only on a real grant, so a cancelled dialog does not spend the explorer's retry on a folder that is still refused, and the re-entrancy guard reports failure rather than a phantom success to whichever surface did not get the dialog. Pending state is shared, so the second button stops inviting clicks the guard would swallow. A grant nonce re-browses the explorer after a grant made from the document card. A grant that lands without clearing the refusal says the folder does not cover the file, instead of repeating itself word for word.

## The native picker stays

It is the local consent flow `trustedRoots` depends on. With no auth on the server and `allowedHosts` able to move the trust boundary off the machine, an in-app one-click grant would trade a real boundary for one click. It already opens pointed at the refused folder, and the card says a parent folder can be picked to allow more at once.

## Smaller things

- Paths go through `middleTruncatePath`: whole segments elided, as much head and tail as fits, both leading slashes kept on a UNC path. Cutting on characters hid the one segment that names the folder.
- The card announces itself (`role="status"`), since it replaced the strip that used to.
- An access-denied tab's dot is neutral rather than red, for the same reason the copy changed. It is `content-muted`, not `content-faint`, which sits under the 3:1 non-text contrast minimum, and the tab title carries the reason in words: a background tab restored into a denied root never renders the card, so the dot is its only signal.

## Testing

`tsc -b` and eslint clean, 1806 unit tests, 5 e2e. Two of the existing error-state tests asserted "some problem was reported" against paths that always 403 before the 404 and 400 branches are reached, so they passed on the card's own copy and would have survived deleting those server branches outright; they assert the card now. `Toolbar` had no test file, so its surviving generic-error branch was uncovered, and now has one.

Screenshots are against a synthetic `/private/tmp/mdr-demo` fixture.
