### PR TITLE
Harden the filesystem write paths, and put bin/ under static checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,10 +43,15 @@ An optional MCP stdio server lets AI agents request human review and wait for fe
 - `server/routes/review-sessions.ts`: HTTP routes for review session endpoints
 - `server/mcp-stdio/`: MCP stdio server (handler, client, server, types, validate)
 - `server/update-check.ts`: daily npm registry check for a newer published version, cached via preferences
-- `server/fs-retry.ts`: `atomicWriteFile` (temp + rename, temp removed on failure) and the
+- `bin/fs-atomic.js`: `atomicWriteFile` (temp + rename, temp removed on failure) and the
   transient-error retry both the document save paths and preferences write through. Windows
   bounces filesystem calls with EPERM/EACCES/EBUSY while a scanner or indexer holds a handle;
-  every write of a user-visible file should go through `atomicWriteFile` rather than a bare rename
+  every write of a user-visible file should go through `atomicWriteFile` rather than a bare rename.
+  The retry is gated to `win32`: POSIX reports those same codes for permanent conditions, where
+  the loop only delays the error. `server/fs-retry.ts` re-exports it for server-side importers
+- `bin/file-lock.js`: `acquireFileLock`, the O_EXCL cross-process lock every writer of
+  `.md-redline.json` takes around a read-modify-write. Shared so `mdr --restrict` and the server
+  cannot interleave; its attempt budget derives from `FS_RETRY_BUDGET_MS`
 - `bin/version-compare.js`: strict x.y.z version compare shared by the server's update checker and the CLI
 - `src/lib/comment-parser.ts`: parse, insert, edit, delete, reply, resolve, anchor updates
 - `src/markdown/pipeline.ts`: markdown -> sanitized HTML pipeline
@@ -269,6 +274,14 @@ not from a compiler flag: `bin/version-compare.js` has been shared between the C
 and `server/update-check.ts` the same way since before this module existed, and
 `allowJs` would have typed every future `bin/` import as unchecked `any`.
 
+`bin/fs-atomic.js` and `bin/file-lock.js` live there for the same reason, and it
+matters more for them: the CLI writes `.md-redline.json` (`mdr --restrict`) and
+Claude Desktop's MCP config, both of which another process also writes. A second
+copy of the retry would drift, and a second copy of the lock would not be a lock
+at all, since two writers taking different locks are not serialized against each
+other. `server/fs-retry.ts` re-exports the first; `server/preferences.ts` imports
+the second directly.
+
 `MD_REDLINE_REGISTRY_URL` and `MD_REDLINE_BASE_URL` keep a plain `??` by choice:
 both are development or background-only, and a blank value fails visibly at the
 first fetch rather than quietly doing the wrong thing. `NO_UPDATE_NOTIFIER` and
@@ -309,6 +322,12 @@ The undocumented `mdr __port` prints the API port the CLI resolved and exits, wh
 is the only way to observe it: that value only seeds the fallback scan inside
 `findServerPort`, and `--stop` would kill whatever it found. The same test file uses
 it to prove the CLI agrees with the server and `vite.config.ts`.
+The undocumented `mdr __first-launch` prints whether this invocation counts as a
+first launch and exits, for the same reason: the answer is otherwise one line of
+welcome text in the middle of a real startup. `bin/prefs-cli.test.ts` uses it to
+pin the distinction that matters, which is that only ENOENT means "first launch".
+An unreadable prefs file is a returning user whose file we cannot read, and
+greeting them with the trust disclosure on every run is both wrong and alarming.
 
 **CLI stale-server upgrade**: on every plain `mdr` invocation,
 `ensureServerRunning()` in `bin/md-redline` asks the running server for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,11 +47,19 @@ An optional MCP stdio server lets AI agents request human review and wait for fe
   transient-error retry both the document save paths and preferences write through. Windows
   bounces filesystem calls with EPERM/EACCES/EBUSY while a scanner or indexer holds a handle;
   every write of a user-visible file should go through `atomicWriteFile` rather than a bare rename.
-  The retry is gated to `win32`: POSIX reports those same codes for permanent conditions, where
-  the loop only delays the error. `server/fs-retry.ts` re-exports it for server-side importers
+  It also carries the destination's mode onto the replacement, so a save never relaxes 0600 to
+  0644. The retry gate is per-errno, NOT per-platform: EBUSY is contention everywhere (SMB, NFS,
+  and the FUSE/FileProvider mounts behind Dropbox, Google Drive and iCloud all return it), while
+  EPERM/EACCES are retried only on `win32`, because on POSIX they mean a permanent permission
+  condition. `server/fs-retry.ts` re-exports it for server-side importers
 - `bin/file-lock.js`: `acquireFileLock`, the O_EXCL cross-process lock every writer of
   `.md-redline.json` takes around a read-modify-write. Shared so `mdr --restrict` and the server
-  cannot interleave; its attempt budget derives from `FS_RETRY_BUDGET_MS`
+  cannot interleave; its attempt budget derives from `FS_RETRY_BUDGET_MS`. Exhausting that budget
+  throws `LockContentionError`; any other throw is a filesystem error with its errno intact, and
+  callers word their advice from that difference
+- `bin/home-dir.js`: `resolveHomeDir` (`MD_REDLINE_HOME` or the OS home), which decides where
+  `.md-redline.json` lives. Shared because a CLI resolving it differently from the server locks
+  and writes a file the server never reads
 - `bin/version-compare.js`: strict x.y.z version compare shared by the server's update checker and the CLI
 - `src/lib/comment-parser.ts`: parse, insert, edit, delete, reply, resolve, anchor updates
 - `src/markdown/pipeline.ts`: markdown -> sanitized HTML pipeline
@@ -274,13 +282,34 @@ not from a compiler flag: `bin/version-compare.js` has been shared between the C
 and `server/update-check.ts` the same way since before this module existed, and
 `allowJs` would have typed every future `bin/` import as unchecked `any`.
 
-`bin/fs-atomic.js` and `bin/file-lock.js` live there for the same reason, and it
-matters more for them: the CLI writes `.md-redline.json` (`mdr --restrict`) and
-Claude Desktop's MCP config, both of which another process also writes. A second
-copy of the retry would drift, and a second copy of the lock would not be a lock
-at all, since two writers taking different locks are not serialized against each
-other. `server/fs-retry.ts` re-exports the first; `server/preferences.ts` imports
-the second directly.
+`bin/fs-atomic.js`, `bin/file-lock.js` and `bin/home-dir.js` live there for the
+same reason, and it matters more for them: the CLI writes `.md-redline.json`
+(`mdr --restrict`, and the trust disclosure reads it) while the server rewrites
+it on every boot. A second copy of the retry would drift, and a second copy of
+the lock would not be a lock at all, since two writers taking different locks
+are not serialized against each other. `resolveHomeDir` is in the same set for a
+sharper reason: a lock is only shared if both sides compute the same PATH, and
+under `MD_REDLINE_HOME` a CLI using bare `homedir()` locked and wrote a file the
+server never read, then reported success. `server/fs-retry.ts` re-exports the
+first, `server/env.ts` the third; `server/preferences.ts` imports the second
+directly.
+
+The lock covers `.md-redline.json` only. Claude Desktop's MCP config gets the
+atomic write, which is what keeps a bounced or interrupted write from
+truncating every other MCP server out of it, but NOT the lock: Claude Desktop
+does not take ours, so a read-modify-write there still races that app. Nothing
+in this repo can fix that; `mdr mcp install` is a one-shot the user runs
+deliberately, which is what keeps the window small.
+
+**`bin/` is checked by `tsconfig.bin.json` (`checkJs`) and its own eslint block.**
+It has no build step, so before those existed eslint matched none of it and
+exited 0 having checked nothing, which reads exactly like passing, and `tsc`
+never saw it at all. A call to an undefined function survived both gates. The
+config is deliberately looser than `tsconfig.node.json` (no `strict`, no
+`noImplicitAny`) because the older modules here predate it and were written
+untyped; `fs-atomic.js` and `file-lock.js` carry JSDoc types so they are checked
+as thoroughly as they were when they were TypeScript. `bin/md-redline` itself is
+extensionless and so still invisible to `tsc`; its tests are the gate there.
 
 `MD_REDLINE_REGISTRY_URL` and `MD_REDLINE_BASE_URL` keep a plain `??` by choice:
 both are development or background-only, and a blank value fails visibly at the
@@ -322,12 +351,19 @@ The undocumented `mdr __port` prints the API port the CLI resolved and exits, wh
 is the only way to observe it: that value only seeds the fallback scan inside
 `findServerPort`, and `--stop` would kill whatever it found. The same test file uses
 it to prove the CLI agrees with the server and `vite.config.ts`.
-The undocumented `mdr __first-launch` prints whether this invocation counts as a
-first launch and exits, for the same reason: the answer is otherwise one line of
-welcome text in the middle of a real startup. `bin/prefs-cli.test.ts` uses it to
-pin the distinction that matters, which is that only ENOENT means "first launch".
-An unreadable prefs file is a returning user whose file we cannot read, and
-greeting them with the trust disclosure on every run is both wrong and alarming.
+The undocumented `mdr __first-launch` prints which trust disclosure this
+invocation would print (`seeded`, `unreadable` or `configured`) and exits, for
+the same reason: the answer is otherwise a line or two of text in the middle of
+a real startup. `bin/prefs-cli.test.ts` pins all three.
+
+The three-way split exists because the two obvious answers are both wrong. A
+returning user should not be greeted as a newcomer, but staying silent when the
+prefs file is UNREADABLE hides something they need: `createApp`'s first-launch
+branch fires on `trustedRoots === undefined`, an unreadable file is
+indistinguishable from that, and the branch applies the home-directory seed in
+memory even though it refuses to persist it. So a user who ran `mdr --restrict`
+gets home trust back for that session, silently, which is exactly what they opted
+out of. `unreadable` says so in its own words rather than welcoming them.
 
 **CLI stale-server upgrade**: on every plain `mdr` invocation,
 `ensureServerRunning()` in `bin/md-redline` asks the running server for

--- a/bin/file-lock.d.ts
+++ b/bin/file-lock.d.ts
@@ -1,4 +1,15 @@
 export const LOCK_SUFFIX: string;
 export const LOCK_STALE_MS: number;
 export const LOCK_MAX_WAIT_MS: number;
+
+/**
+ * Thrown when the attempt budget runs out, as opposed to a filesystem error,
+ * which is rethrown with its errno intact.
+ */
+export class LockContentionError extends Error {
+  constructor(lockPath: string, cause?: unknown);
+  readonly code: 'ELOCKBUSY';
+  readonly lockPath: string;
+}
+
 export function acquireFileLock(filePath: string): Promise<() => Promise<void>>;

--- a/bin/file-lock.d.ts
+++ b/bin/file-lock.d.ts
@@ -1,0 +1,4 @@
+export const LOCK_SUFFIX: string;
+export const LOCK_STALE_MS: number;
+export const LOCK_MAX_WAIT_MS: number;
+export function acquireFileLock(filePath: string): Promise<() => Promise<void>>;

--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -31,6 +31,27 @@ export const LOCK_MAX_WAIT_MS = 15 * FS_RETRY_BUDGET_MS;
 const LOCK_MAX_ATTEMPTS = Math.ceil(LOCK_MAX_WAIT_MS / LOCK_RETRY_BASE_MS);
 
 /**
+ * Thrown when the attempt budget runs out, as opposed to a filesystem error,
+ * which is rethrown with its errno intact. Callers word their advice from this
+ * distinction: waiting helps for contention and never helps for a permission
+ * problem, and an untyped throw made every permanent condition look like the
+ * former. `cause` carries the last errno seen, when there was one.
+ */
+export class LockContentionError extends Error {
+  /**
+   * @param {string} lockPath
+   * @param {unknown} [cause]
+   */
+  constructor(lockPath, cause) {
+    super(`Could not acquire lock at ${lockPath} after ${LOCK_MAX_WAIT_MS}ms`);
+    this.name = 'LockContentionError';
+    this.code = 'ELOCKBUSY';
+    this.lockPath = lockPath;
+    if (cause !== undefined) this.cause = cause;
+  }
+}
+
+/**
  * Acquire a cross-process lock on `filePath` before performing a
  * read-modify-write, and return the release closure. An in-process promise
  * chain only serializes within one Node process; two `mdr` invocations, or the
@@ -39,9 +60,15 @@ const LOCK_MAX_ATTEMPTS = Math.ceil(LOCK_MAX_WAIT_MS / LOCK_RETRY_BASE_MS);
  *
  * Implementation: O_EXCL sentinel file. If the lock is older than
  * LOCK_STALE_MS we treat it as abandoned (the holder crashed) and steal it.
+ *
+ * @param {string} filePath
+ * @returns {Promise<() => Promise<void>>} release closure
+ * @throws {LockContentionError} when the attempt budget runs out. Any other
+ *   throw is a filesystem error with its errno intact.
  */
 export async function acquireFileLock(filePath) {
   const lockPath = `${filePath}${LOCK_SUFFIX}`;
+  let lastErr;
   for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
     let fd;
     try {
@@ -49,6 +76,7 @@ export async function acquireFileLock(filePath) {
     } catch (err) {
       const code = err?.code;
       if (code !== 'EEXIST') {
+        lastErr = err;
         // The lock file is created and removed on every write, which makes it
         // the same scanner bait as the temp file. Back off on the transient
         // codes instead of failing the whole write.
@@ -57,18 +85,36 @@ export async function acquireFileLock(filePath) {
         continue;
       }
       // Lock exists. If it's stale (holder crashed), steal it.
+      let lockStat;
       try {
-        const lockStat = await stat(lockPath);
-        if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
-          try {
-            await unlink(lockPath);
-          } catch {
-            /* someone else just released it */
+        lockStat = await stat(lockPath);
+      } catch (statErr) {
+        // ENOENT means the lock vanished between the EEXIST and the stat, so
+        // the path is free right now and there is nothing to wait for.
+        if (statErr?.code === 'ENOENT') continue;
+        // Anything else is a condition that does NOT clear on its own at this
+        // speed: a dangling symlink at the lock path (open reports EEXIST
+        // while stat follows the link and fails), an unreadable directory, or
+        // a scanner bouncing the stat on Windows. Retrying with no delay burns
+        // the entire attempt budget in a couple of milliseconds and reports
+        // contention for something that is not contention.
+        lastErr = statErr;
+        await sleep(LOCK_RETRY_BASE_MS);
+        continue;
+      }
+      if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
+        try {
+          await unlink(lockPath);
+        } catch (unlinkErr) {
+          // ENOENT is the benign race: someone else released it first.
+          if (unlinkErr?.code !== 'ENOENT') {
+            // We cannot remove an abandoned lock, so the recovery path this
+            // branch exists for will not fire. Back off rather than spinning,
+            // and keep the errno so the caller can say what is actually wrong.
+            lastErr = unlinkErr;
+            await sleep(LOCK_RETRY_BASE_MS);
           }
-          continue;
         }
-      } catch {
-        // Lock vanished between EEXIST and stat — retry immediately.
         continue;
       }
       // Backoff with a small random jitter to avoid thundering herd.
@@ -114,5 +160,5 @@ export async function acquireFileLock(filePath) {
       }
     };
   }
-  throw new Error(`Could not acquire lock at ${lockPath}`);
+  throw new LockContentionError(lockPath, lastErr);
 }

--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -1,0 +1,118 @@
+/**
+ * Cross-process advisory lock for read-modify-write cycles on a shared file.
+ *
+ * In `bin/` for the same reason `fs-atomic.js` is: the CLI writes the user's
+ * `.md-redline.json` too, and a lock only works if every writer takes the same
+ * one. The server reaches it through `server/preferences.ts`.
+ *
+ * Types live in `file-lock.d.ts`.
+ */
+
+import { open, stat, unlink } from 'fs/promises';
+
+import { FS_RETRY_BUDGET_MS, isTransientFsError, retryTransient, sleep } from './fs-atomic.js';
+
+export const LOCK_SUFFIX = '.lock';
+
+/** Older than this and the holder is assumed to have crashed. */
+export const LOCK_STALE_MS = 30_000;
+
+const LOCK_RETRY_BASE_MS = 25;
+
+/**
+ * How long a writer waits for the lock before giving up. A holder is running a
+ * full read-modify-write, and every syscall in it can itself spend
+ * FS_RETRY_BUDGET_MS bouncing off a scanner, so this is expressed as a
+ * multiple of that budget rather than picked independently. Tuning the retry
+ * budget now moves this with it instead of leaving it silently stale.
+ */
+export const LOCK_MAX_WAIT_MS = 15 * FS_RETRY_BUDGET_MS;
+
+const LOCK_MAX_ATTEMPTS = Math.ceil(LOCK_MAX_WAIT_MS / LOCK_RETRY_BASE_MS);
+
+/**
+ * Acquire a cross-process lock on `filePath` before performing a
+ * read-modify-write, and return the release closure. An in-process promise
+ * chain only serializes within one Node process; two `mdr` invocations, or the
+ * CLI and the server, would otherwise race the read+write cycle and lose one
+ * side.
+ *
+ * Implementation: O_EXCL sentinel file. If the lock is older than
+ * LOCK_STALE_MS we treat it as abandoned (the holder crashed) and steal it.
+ */
+export async function acquireFileLock(filePath) {
+  const lockPath = `${filePath}${LOCK_SUFFIX}`;
+  for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
+    let fd;
+    try {
+      fd = await open(lockPath, 'wx');
+    } catch (err) {
+      const code = err?.code;
+      if (code !== 'EEXIST') {
+        // The lock file is created and removed on every write, which makes it
+        // the same scanner bait as the temp file. Back off on the transient
+        // codes instead of failing the whole write.
+        if (!isTransientFsError(err)) throw err;
+        await sleep(LOCK_RETRY_BASE_MS);
+        continue;
+      }
+      // Lock exists. If it's stale (holder crashed), steal it.
+      try {
+        const lockStat = await stat(lockPath);
+        if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
+          try {
+            await unlink(lockPath);
+          } catch {
+            /* someone else just released it */
+          }
+          continue;
+        }
+      } catch {
+        // Lock vanished between EEXIST and stat — retry immediately.
+        continue;
+      }
+      // Backoff with a small random jitter to avoid thundering herd.
+      await sleep(LOCK_RETRY_BASE_MS + Math.floor(Math.random() * LOCK_RETRY_BASE_MS));
+      continue;
+    }
+
+    // The lock file exists and is ours from here. Anything that fails before
+    // we return the release closure has to remove it, or the next attempt
+    // deadlocks against our own orphan: it is far too young for the
+    // stale-steal branch above, so the loop burns every remaining attempt and
+    // then blocks all writers until LOCK_STALE_MS elapses.
+    let writeErr;
+    try {
+      await fd.writeFile(`${process.pid}`);
+    } catch (err) {
+      writeErr = err;
+    }
+    // Close before unlinking: Windows refuses to remove a file that still has
+    // an open handle, which would defeat the cleanup below. The pid is only a
+    // debugging aid (staleness is decided by mtime), so a failed close on the
+    // success path is not worth failing the write over.
+    await fd.close().catch(() => {});
+    if (writeErr) {
+      await unlink(lockPath).catch(() => {});
+      if (!isTransientFsError(writeErr)) throw writeErr;
+      await sleep(LOCK_RETRY_BASE_MS);
+      continue;
+    }
+
+    return async () => {
+      try {
+        await retryTransient(() => unlink(lockPath));
+      } catch (err) {
+        if (err?.code === 'ENOENT') return;
+        // An orphaned lock blocks every writer, in this process and any other
+        // mdr instance, until it ages out. Never silent.
+        console.error(
+          `Could not release the lock at ${lockPath}; writes are ` +
+            `blocked until it ages out after ${LOCK_STALE_MS}ms:`,
+          err,
+        );
+      }
+    };
+  }
+  throw new Error(`Could not acquire lock at ${lockPath}`);
+}

--- a/bin/fs-atomic.d.ts
+++ b/bin/fs-atomic.d.ts
@@ -1,0 +1,8 @@
+export const FS_MAX_ATTEMPTS: number;
+export const FS_RETRY_BASE_MS: number;
+export const FS_RETRY_BUDGET_MS: number;
+export function isTransientFsError(err: unknown): boolean;
+export function sleep(ms: number): Promise<void>;
+export function retryTransient<T>(op: () => Promise<T>): Promise<T>;
+export function retryTransientSync<T>(op: () => T): T;
+export function atomicWriteFile(path: string, content: string): Promise<void>;

--- a/bin/fs-atomic.js
+++ b/bin/fs-atomic.js
@@ -11,7 +11,7 @@
  * Types live in `fs-atomic.d.ts`.
  */
 
-import { open, readFile, rename, unlink } from 'fs/promises';
+import { chmod, open, readFile, rename, stat, unlink } from 'fs/promises';
 import { randomBytes } from 'crypto';
 
 // Windows bounces filesystem calls with these codes while another handle is
@@ -30,30 +30,46 @@ export const FS_RETRY_BASE_MS = 10;
 export const FS_RETRY_BUDGET_MS =
   ((FS_MAX_ATTEMPTS * (FS_MAX_ATTEMPTS - 1)) / 2) * FS_RETRY_BASE_MS;
 
-const TRANSIENT_FS_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
+/**
+ * Contention, on every platform. A handle is open on the path right now and
+ * will not be shortly: a scanner or indexer on Windows, and on POSIX the
+ * network and cloud-sync filesystems md-redline documents actually live on
+ * (SMB, NFS, and the FUSE and FileProvider mounts behind Dropbox, Google Drive
+ * and iCloud), which return it while the provider holds or hydrates a file.
+ */
+const CONTENTION_FS_CODES = new Set(['EBUSY']);
 
 /**
- * Windows is the only platform where these codes mean "try again". POSIX
- * reports the same three for conditions that are permanent by construction: an
- * unwritable directory, a sticky bit, a macOS `uchg` flag, a denied
- * Files-and-Folders grant. There, every attempt fails identically, so the loop
- * buys nothing and costs the caller its full budget before surfacing the error
- * the user actually needs to see. Reproduced on Darwin against a locked
- * document, on the app's highest-frequency write path.
+ * Contention on Windows, permission on POSIX. Windows AV and sync clients
+ * bounce calls with these while they hold a handle, so retrying clears them.
+ * POSIX reports the same two only for conditions that are permanent by
+ * construction: an unwritable directory, a sticky bit, a macOS `uchg` flag, a
+ * denied Files-and-Folders grant. There, every attempt fails identically and
+ * the loop only delays the error the user needs to see. Reproduced on Darwin
+ * against a `uchg` document, on the app's highest-frequency write path.
  *
- * Read per call rather than captured at module load, so the tests can exercise
- * both sides on whichever platform they run.
+ * Gating by errno rather than by platform matters: a blanket win32 check would
+ * also stop retrying EBUSY above, which is genuinely transient everywhere.
  */
-function platformRetriesTransientCodes() {
-  return process.platform === 'win32';
-}
+const WINDOWS_ONLY_TRANSIENT_FS_CODES = new Set(['EPERM', 'EACCES']);
 
+/**
+ * @param {unknown} err
+ * @returns {boolean}
+ */
 export function isTransientFsError(err) {
-  if (!platformRetriesTransientCodes()) return false;
-  const code = err?.code;
-  return !!code && TRANSIENT_FS_CODES.has(code);
+  const code = /** @type {NodeJS.ErrnoException} */ (err)?.code;
+  if (!code) return false;
+  if (CONTENTION_FS_CODES.has(code)) return true;
+  // Read per call rather than captured at module load, so the tests can
+  // exercise both sides on whichever platform they run.
+  return process.platform === 'win32' && WINDOWS_ONLY_TRANSIENT_FS_CODES.has(code);
 }
 
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
 export function sleep(ms) {
   return new Promise((res) => setTimeout(res, ms));
 }
@@ -61,7 +77,11 @@ export function sleep(ms) {
 /**
  * Run a filesystem call, retrying the transient failures above. Every other
  * code (EXDEV, ENOSPC, ENOENT) is a real failure and rethrows on the first
- * attempt, as does everything off Windows (see isTransientFsError).
+ * attempt, as do EPERM and EACCES off Windows (see isTransientFsError).
+ *
+ * @template T
+ * @param {() => Promise<T>} op
+ * @returns {Promise<T>}
  */
 export async function retryTransient(op) {
   let lastErr;
@@ -82,6 +102,10 @@ export async function retryTransient(op) {
  * preferences before the event loop is doing anything else. Atomics.wait is
  * the only way to sleep without yielding; blocking for at most 100ms once at
  * boot beats losing the user's trusted roots to a scanner.
+ *
+ * @template T
+ * @param {() => T} op
+ * @returns {T}
  */
 export function retryTransientSync(op) {
   let lastErr;
@@ -107,9 +131,19 @@ export function retryTransientSync(op) {
  *
  * Both the create and the rename are retried, because both are calls Windows
  * bounces: the create because AV hooks file creation, the rename because it
- * touches the destination the user just had open. On any failure the temp file
- * is removed rather than left in the user's folder, where it would show up in
- * Explorer and in `git status`.
+ * touches the destination the user just had open.
+ *
+ * On any failure the temp file is removed, so it does not sit in the user's
+ * folder showing up in Explorer and in `git status`. That cleanup is single
+ * attempt and its own errors are swallowed, which means the same interference
+ * that failed the save can also leave the `.tmp` behind: a deliberate trade,
+ * since the worst case is one stray file and the alternative is more machinery
+ * on the path where something is already going wrong. It is the one syscall
+ * here that is neither retried nor reported.
+ *
+ * @param {string} tmpPath
+ * @param {string} content
+ * @returns {Promise<void>}
  */
 async function writeTempFile(tmpPath, content) {
   // Creating the temp file is bounceable for the same reason the rename is:
@@ -144,6 +178,12 @@ async function writeTempFile(tmpPath, content) {
   if (failure) throw failure;
 }
 
+/**
+ * @param {string} tmpPath
+ * @param {string} path
+ * @param {string} content
+ * @returns {Promise<void>}
+ */
 async function renameIntoPlace(tmpPath, path, content) {
   let attempted = false;
   await retryTransient(async () => {
@@ -165,10 +205,43 @@ async function renameIntoPlace(tmpPath, path, content) {
   });
 }
 
+/**
+ * Carry the destination's permission bits over to the replacement.
+ *
+ * A temp file is created at the default 0600-and-umask, so without this a
+ * rename silently RELAXES the mode of anything the user or another tool had
+ * tightened: a 0600 file comes back 0644. That matters most for the file this
+ * module does not own, Claude Desktop's MCP config, because it holds every
+ * other server's `env` block and those routinely carry API tokens.
+ *
+ * Best effort in both directions. No destination yet (the ordinary create) and
+ * there is nothing to copy; a chmod that fails leaves the default, which is
+ * never more permissive than what a fresh file would have got anyway, and is
+ * not worth failing an otherwise good save over.
+ *
+ * @param {string} tmpPath
+ * @param {string} path
+ * @returns {Promise<void>}
+ */
+async function inheritMode(tmpPath, path) {
+  try {
+    const existing = await stat(path);
+    await chmod(tmpPath, existing.mode & 0o7777);
+  } catch {
+    /* no destination, or a filesystem without modes (Windows) */
+  }
+}
+
+/**
+ * @param {string} path
+ * @param {string} content
+ * @returns {Promise<void>}
+ */
 export async function atomicWriteFile(path, content) {
   const tmpPath = `${path}.${randomBytes(6).toString('hex')}.tmp`;
   try {
     await writeTempFile(tmpPath, content);
+    await inheritMode(tmpPath, path);
     await renameIntoPlace(tmpPath, path, content);
   } catch (err) {
     await unlink(tmpPath).catch(() => {});

--- a/bin/fs-atomic.js
+++ b/bin/fs-atomic.js
@@ -61,7 +61,7 @@ export function sleep(ms) {
 /**
  * Run a filesystem call, retrying the transient failures above. Every other
  * code (EXDEV, ENOSPC, ENOENT) is a real failure and rethrows on the first
- * attempt, as does everything off Windows — see isTransientFsError.
+ * attempt, as does everything off Windows (see isTransientFsError).
  */
 export async function retryTransient(op) {
   let lastErr;

--- a/bin/fs-atomic.js
+++ b/bin/fs-atomic.js
@@ -1,0 +1,177 @@
+/**
+ * Crash-safe file writes and the Windows transient-failure retry.
+ *
+ * Lives in `bin/` rather than `server/` because the CLI is plain JS shipped as
+ * is and cannot import a `.ts` module, while the server can import this
+ * through `server/fs-retry.ts` (the same arrangement `server/env.ts` has with
+ * `bin/ports.js`). Both sides therefore share one implementation instead of
+ * two that drift: the CLI writes the user's prefs file and Claude Desktop's
+ * MCP config, both of which the server or another tool may also be writing.
+ *
+ * Types live in `fs-atomic.d.ts`.
+ */
+
+import { open, readFile, rename, unlink } from 'fs/promises';
+import { randomBytes } from 'crypto';
+
+// Windows bounces filesystem calls with these codes while another handle is
+// open on the path: a virus scanner mid-scan, the search indexer, a sync
+// client like OneDrive or Dropbox. They clear on their own within a few
+// milliseconds. 5 attempts spread over 100ms of linear backoff (10+20+30+40)
+// cover the window without stalling a real failure.
+export const FS_MAX_ATTEMPTS = 5;
+export const FS_RETRY_BASE_MS = 10;
+/**
+ * Wall-clock a hopeless call can spend inside retryTransient: the sum of the
+ * linear backoffs between attempts. Exported so callers that hand-roll their
+ * own contention loop can size themselves against it instead of drifting apart
+ * silently.
+ */
+export const FS_RETRY_BUDGET_MS =
+  ((FS_MAX_ATTEMPTS * (FS_MAX_ATTEMPTS - 1)) / 2) * FS_RETRY_BASE_MS;
+
+const TRANSIENT_FS_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
+
+/**
+ * Windows is the only platform where these codes mean "try again". POSIX
+ * reports the same three for conditions that are permanent by construction: an
+ * unwritable directory, a sticky bit, a macOS `uchg` flag, a denied
+ * Files-and-Folders grant. There, every attempt fails identically, so the loop
+ * buys nothing and costs the caller its full budget before surfacing the error
+ * the user actually needs to see. Reproduced on Darwin against a locked
+ * document, on the app's highest-frequency write path.
+ *
+ * Read per call rather than captured at module load, so the tests can exercise
+ * both sides on whichever platform they run.
+ */
+function platformRetriesTransientCodes() {
+  return process.platform === 'win32';
+}
+
+export function isTransientFsError(err) {
+  if (!platformRetriesTransientCodes()) return false;
+  const code = err?.code;
+  return !!code && TRANSIENT_FS_CODES.has(code);
+}
+
+export function sleep(ms) {
+  return new Promise((res) => setTimeout(res, ms));
+}
+
+/**
+ * Run a filesystem call, retrying the transient failures above. Every other
+ * code (EXDEV, ENOSPC, ENOENT) is a real failure and rethrows on the first
+ * attempt, as does everything off Windows — see isTransientFsError.
+ */
+export async function retryTransient(op) {
+  let lastErr;
+  for (let attempt = 1; attempt <= FS_MAX_ATTEMPTS; attempt++) {
+    try {
+      return await op();
+    } catch (err) {
+      lastErr = err;
+      if (!isTransientFsError(err)) throw err;
+      if (attempt < FS_MAX_ATTEMPTS) await sleep(FS_RETRY_BASE_MS * attempt);
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Synchronous twin of retryTransient, for the startup path that reads
+ * preferences before the event loop is doing anything else. Atomics.wait is
+ * the only way to sleep without yielding; blocking for at most 100ms once at
+ * boot beats losing the user's trusted roots to a scanner.
+ */
+export function retryTransientSync(op) {
+  let lastErr;
+  for (let attempt = 1; attempt <= FS_MAX_ATTEMPTS; attempt++) {
+    try {
+      return op();
+    } catch (err) {
+      lastErr = err;
+      if (!isTransientFsError(err)) throw err;
+      if (attempt < FS_MAX_ATTEMPTS) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, FS_RETRY_BASE_MS * attempt);
+      }
+    }
+  }
+  throw lastErr;
+}
+
+/**
+ * Write `content` to `path` via a temp file and a rename, so a crash mid-write
+ * cannot leave a half-written file. The temp name carries a random suffix so a
+ * stale or adversarial `.tmp` cannot block writes, and O_EXCL keeps it from
+ * following a symlink.
+ *
+ * Both the create and the rename are retried, because both are calls Windows
+ * bounces: the create because AV hooks file creation, the rename because it
+ * touches the destination the user just had open. On any failure the temp file
+ * is removed rather than left in the user's folder, where it would show up in
+ * Explorer and in `git status`.
+ */
+async function writeTempFile(tmpPath, content) {
+  // Creating the temp file is bounceable for the same reason the rename is:
+  // Windows AV and sync clients hook file creation, and this is the first
+  // syscall of every save. Only the open retries. The write and the close are
+  // not idempotent against a file that now exists, and re-running them would
+  // need the O_EXCL create dropped, which is what keeps a symlink planted at
+  // tmpPath from being followed.
+  //
+  // A create that bounces AFTER the file lands makes the next attempt fail
+  // EEXIST, which is permanent and ends the save. That is the intended
+  // outcome: the caller removes the orphan, the destination is untouched, and
+  // the user retries. Recovering the file instead would mean unlinking a path
+  // this process cannot prove it owns.
+  const fd = await retryTransient(() => open(tmpPath, 'wx'));
+  let failure;
+  try {
+    await fd.writeFile(content, 'utf-8');
+  } catch (err) {
+    failure = err;
+  } finally {
+    try {
+      await fd.close();
+    } catch (closeErr) {
+      // close surfaces deferred write errors, so a failure here means the temp
+      // file is not trustworthy either way. It must not REPLACE an earlier
+      // error though: the write's own code is what decides whether this is
+      // worth retrying, and a close error can carry a different one.
+      failure ??= closeErr;
+    }
+  }
+  if (failure) throw failure;
+}
+
+async function renameIntoPlace(tmpPath, path, content) {
+  let attempted = false;
+  await retryTransient(async () => {
+    const firstAttempt = !attempted;
+    attempted = true;
+    try {
+      await rename(tmpPath, path);
+    } catch (err) {
+      // rename is not idempotent, and retrying re-probes a temp file whose
+      // fate may have changed: an attempt that reported failure can still have
+      // moved the file, and a sync client can consume the temp file between
+      // attempts. Both leave a later attempt failing with ENOENT for a write
+      // that already landed. Confirm by content rather than reporting a save
+      // that succeeded as failed, and never on the first attempt, where ENOENT
+      // means the temp file genuinely never existed.
+      if (firstAttempt || err?.code !== 'ENOENT') throw err;
+      if ((await readFile(path, 'utf-8').catch(() => null)) !== content) throw err;
+    }
+  });
+}
+
+export async function atomicWriteFile(path, content) {
+  const tmpPath = `${path}.${randomBytes(6).toString('hex')}.tmp`;
+  try {
+    await writeTempFile(tmpPath, content);
+    await renameIntoPlace(tmpPath, path, content);
+  } catch (err) {
+    await unlink(tmpPath).catch(() => {});
+    throw err;
+  }
+}

--- a/bin/home-dir.d.ts
+++ b/bin/home-dir.d.ts
@@ -1,0 +1,1 @@
+export function resolveHomeDir(env?: NodeJS.ProcessEnv): string;

--- a/bin/home-dir.js
+++ b/bin/home-dir.js
@@ -1,0 +1,29 @@
+/**
+ * Where `.md-redline.json` lives.
+ *
+ * In `bin/` for the same reason `ports.js` is: the CLI reads and writes that
+ * file too (`mdr --restrict`, the first-launch disclosure) and cannot import a
+ * `.ts` module. Both sides resolving it separately is not a style problem, it
+ * is a correctness one. With MD_REDLINE_HOME set, a CLI using bare `homedir()`
+ * locks and writes a file the server never reads, then reports success, and
+ * the cross-process lock the two are supposed to share is taken on two
+ * different paths.
+ *
+ * Types live in `home-dir.d.ts`. `server/env.ts` re-exports this.
+ */
+
+import { homedir } from 'os';
+
+/**
+ * Blank counts as unset. A plain `??` kept an empty string, and an empty base
+ * directory is not an obvious failure: `.md-redline.json` then resolves
+ * against the current working directory, so trusted roots and the update-check
+ * cache get written wherever the user happened to launch from and silently
+ * fail to persist across launches.
+ *
+ * @param {NodeJS.ProcessEnv} [env]
+ * @returns {string}
+ */
+export function resolveHomeDir(env = process.env) {
+  return env.MD_REDLINE_HOME?.trim() || homedir();
+}

--- a/bin/md-redline
+++ b/bin/md-redline
@@ -2,13 +2,15 @@
 
 import { spawn } from 'child_process';
 import { readdirSync, statSync } from 'fs';
-import { mkdir, readFile, stat, unlink, writeFile } from 'fs/promises';
+import { mkdir, readFile, stat, unlink } from 'fs/promises';
 import { homedir, tmpdir } from 'os';
 import { dirname, join, resolve } from 'path';
 import process from 'process';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 import { createRequire } from 'module';
+import { acquireFileLock } from './file-lock.js';
+import { atomicWriteFile, retryTransient } from './fs-atomic.js';
 import { resolveApiPort } from './ports.js';
 
 import { checkServer, gracefulShutdown, killPort } from './server-control.js';
@@ -64,9 +66,20 @@ function printHelp() {
 
 async function isFirstLaunch() {
   const prefsPath = join(homedir(), '.md-redline.json');
+  let raw;
   try {
-    const raw = await readFile(prefsPath, 'utf8');
+    raw = await retryTransient(() => readFile(prefsPath, 'utf8'));
+  } catch (err) {
+    // ENOENT is the only error that means "first launch". Anything else is a
+    // prefs file that exists and could not be read — a scanner holding it, a
+    // permission problem — and greeting a returning user with the trust
+    // disclosure on every run is both wrong and alarming. Stay quiet.
+    return err.code === 'ENOENT';
+  }
+  try {
     const parsed = JSON.parse(raw);
+    // Garbage or a non-object: the server quarantines it on boot and starts
+    // fresh with default trust, so the disclosure is accurate.
     if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return true;
     return parsed.trustedRoots === undefined;
   } catch {
@@ -277,18 +290,54 @@ async function stopServer(quiet = false) {
 
 async function enableRestrictedMode() {
   const prefsPath = join(homedir(), '.md-redline.json');
+
+  // The server takes this same lock around its own read-modify-write of the
+  // prefs file. Without it, `mdr --restrict` racing a booting server either
+  // clobbers the trust settings it promises not to touch, or has its own write
+  // swallowed by the server's rename and silently fails to restrict anything.
+  let release;
   try {
-    await stat(prefsPath);
-    console.error(`Refusing to overwrite existing ${prefsPath}.`);
-    console.error('Restricted mode would clobber your trust settings.');
-    console.error('Edit the file manually to set trustedRoots: [].');
+    release = await acquireFileLock(prefsPath);
+  } catch (err) {
+    // A filesystem error carries an errno; running out of attempts does not.
+    // The two need different advice, and telling someone with an unwritable
+    // home directory to wait for another process is a dead end.
+    if (err.code) {
+      console.error(`Could not lock ${prefsPath} (${err.code}): ${err.message}`);
+      console.error('Refusing to write over a file that may hold your trust settings.');
+    } else {
+      console.error(`Could not lock ${prefsPath}.`);
+      console.error('Another mdr process is writing it. Try again in a moment.');
+    }
     process.exitCode = 1;
     return;
-  } catch {
-    /* file does not exist; safe to write */
   }
 
-  await writeFile(prefsPath, JSON.stringify({ trustedRoots: [] }, null, 2) + '\n', 'utf-8');
+  try {
+    // Checked under the lock, and only ENOENT counts as absent. A stat that
+    // bounces off a scanner cannot prove the file is missing, and guessing
+    // wrong here overwrites the trust settings this branch exists to protect.
+    try {
+      await retryTransient(() => stat(prefsPath));
+      console.error(`Refusing to overwrite existing ${prefsPath}.`);
+      console.error('Restricted mode would clobber your trust settings.');
+      console.error('Edit the file manually to set trustedRoots: [].');
+      process.exitCode = 1;
+      return;
+    } catch (err) {
+      if (err.code !== 'ENOENT') {
+        console.error(`Could not check ${prefsPath} (${err.code}).`);
+        console.error('Refusing to write over a file that may hold your trust settings.');
+        process.exitCode = 1;
+        return;
+      }
+    }
+
+    await atomicWriteFile(prefsPath, JSON.stringify({ trustedRoots: [] }, null, 2) + '\n');
+  } finally {
+    await release();
+  }
+
   console.log('Restricted mode enabled. Each folder will require explicit consent.');
   console.log(`Wrote ${prefsPath}`);
 }
@@ -482,16 +531,28 @@ async function installForClaudeDesktop() {
   const configPath = getClaudeDesktopConfigPath();
 
   let config = {};
+  let existing;
   try {
-    const existing = await readFile(configPath, 'utf8');
-    config = JSON.parse(existing);
+    existing = await retryTransient(() => readFile(configPath, 'utf8'));
   } catch (err) {
+    // Only a missing file may be treated as "start fresh". Every other read
+    // failure has to abort, because writing a fresh config over a file we
+    // could not read would delete every other MCP server in it.
     if (err.code !== 'ENOENT') {
+      throw new Error(
+        `Cannot read ${configPath} (${err.code}): ${err.message}\n` +
+          'Fix the permissions and retry; refusing to overwrite a config that may hold other MCP servers.',
+      );
+    }
+  }
+  if (existing !== undefined) {
+    try {
+      config = JSON.parse(existing);
+    } catch (err) {
       throw new Error(
         `Cannot parse ${configPath}: ${err.message}\nPlease fix the JSON syntax and retry.`,
       );
     }
-    // File missing — start fresh
   }
 
   if (typeof config !== 'object' || config === null) config = {};
@@ -516,7 +577,10 @@ async function installForClaudeDesktop() {
   config.mcpServers = mcpServers;
 
   await mkdir(dirname(configPath), { recursive: true });
-  await writeFile(configPath, JSON.stringify(config, null, 2) + '\n', 'utf8');
+  // Temp file + rename, never a bare write. This file is not ours: it holds
+  // every OTHER MCP server the user has configured, and a truncated write
+  // takes all of them down, not just md-redline's entry.
+  await atomicWriteFile(configPath, JSON.stringify(config, null, 2) + '\n');
   console.log(
     hadLegacyKey
       ? `[Claude Desktop] Renamed legacy mdr entry to md-redline in ${configPath}`
@@ -592,6 +656,13 @@ async function installMcpConfig(target) {
     } catch (err) {
       results.push({ name: 'Claude Code', ok: false, error: err instanceof Error ? err.message : 'unknown error' });
     }
+  }
+
+  // A thrown installer error was being captured here and never printed, so a
+  // failed install exited 1 with nothing on stderr to say why. installForClaudeCode
+  // reports its own failures and sets no `error`, so this never doubles up.
+  for (const result of results) {
+    if (!result.ok && result.error) console.error(`[${result.name}] ${result.error}`);
   }
 
   const anyChanged = results.some((r) => r.changed);
@@ -722,6 +793,16 @@ async function main() {
     // detached-teardown race — and honors MD_REDLINE_BROWSER like every other path.
     const target = process.argv[3];
     if (target) await openInBrowser(target);
+    return;
+  }
+
+  if (process.argv[2] === '__first-launch') {
+    // Internal, undocumented seam, same idea as __open above: print whether
+    // this invocation counts as a first launch and exit, without booting a
+    // server. The answer is otherwise only observable as one line of welcome
+    // text printed in the middle of a real startup, which a test cannot reach
+    // without spawning the whole app.
+    console.log(String(await isFirstLaunch()));
     return;
   }
 

--- a/bin/md-redline
+++ b/bin/md-redline
@@ -9,8 +9,9 @@ import process from 'process';
 import { fileURLToPath, pathToFileURL } from 'url';
 
 import { createRequire } from 'module';
-import { acquireFileLock } from './file-lock.js';
+import { acquireFileLock, LOCK_MAX_WAIT_MS, LockContentionError } from './file-lock.js';
 import { atomicWriteFile, retryTransient } from './fs-atomic.js';
+import { resolveHomeDir } from './home-dir.js';
 import { resolveApiPort } from './ports.js';
 
 import { checkServer, gracefulShutdown, killPort } from './server-control.js';
@@ -64,26 +65,36 @@ function printHelp() {
   console.log('Alias: md-redline');
 }
 
-async function isFirstLaunch() {
-  const prefsPath = join(homedir(), '.md-redline.json');
+/**
+ * What the server will do about trust on this launch, which is what decides
+ * whether to disclose it and in what words.
+ *
+ * 'seeded'     no trustedRoots on record, so the server seeds the home
+ *              directory. The genuine first launch, and the case a corrupt
+ *              file lands in too, since the server quarantines it and starts
+ *              fresh.
+ * 'unreadable' a prefs file exists and could not be read. The server ALSO
+ *              seeds home here (createApp's first-launch branch fires on
+ *              `trustedRoots === undefined`, and it applies in memory even
+ *              though it refuses to persist), so a user who ran `--restrict`
+ *              silently gets home trust back for this session. That has to be
+ *              said, and it is not a welcome.
+ * 'configured' trustedRoots is on record. Nothing to disclose.
+ */
+async function trustDisclosureState() {
+  const prefsPath = join(resolveHomeDir(), '.md-redline.json');
   let raw;
   try {
     raw = await retryTransient(() => readFile(prefsPath, 'utf8'));
   } catch (err) {
-    // ENOENT is the only error that means "first launch". Anything else is a
-    // prefs file that exists and could not be read (a scanner holding it, a
-    // permission problem), and greeting a returning user with the trust
-    // disclosure on every run is both wrong and alarming. Stay quiet.
-    return err.code === 'ENOENT';
+    return err.code === 'ENOENT' ? 'seeded' : 'unreadable';
   }
   try {
     const parsed = JSON.parse(raw);
-    // Garbage or a non-object: the server quarantines it on boot and starts
-    // fresh with default trust, so the disclosure is accurate.
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return true;
-    return parsed.trustedRoots === undefined;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return 'seeded';
+    return parsed.trustedRoots === undefined ? 'seeded' : 'configured';
   } catch {
-    return true;
+    return 'seeded';
   }
 }
 
@@ -106,7 +117,9 @@ async function resolveTarget(arg) {
     // Echo the resolved path too: `mdr ~/Desktop` on a OneDrive-redirected
     // Windows profile fails because C:\Users\<u>\Desktop does not exist,
     // which the raw argument alone cannot reveal.
-    throw new Error(target === arg ? `not found: ${arg}` : `not found: ${arg} (resolved to ${target})`);
+    throw new Error(
+      target === arg ? `not found: ${arg}` : `not found: ${arg} (resolved to ${target})`,
+    );
   }
 
   if (targetStat.isDirectory()) return { file: '', dir: target };
@@ -119,13 +132,14 @@ async function findServerPort() {
   try {
     const saved = (await readFile(PORT_FILE, 'utf8')).trim();
     const port = Number(saved);
-    if (port && await checkServer(port)) return port;
+    if (port && (await checkServer(port))) return port;
   } catch {}
 
   // Scan the port range as fallback, then the legacy pre-0.7 range
-  const bases = DEFAULT_SERVER_PORT === LEGACY_SERVER_PORT
-    ? [DEFAULT_SERVER_PORT]
-    : [DEFAULT_SERVER_PORT, LEGACY_SERVER_PORT];
+  const bases =
+    DEFAULT_SERVER_PORT === LEGACY_SERVER_PORT
+      ? [DEFAULT_SERVER_PORT]
+      : [DEFAULT_SERVER_PORT, LEGACY_SERVER_PORT];
   for (const base of bases) {
     for (let p = base; p < base + MAX_PORT_SCAN; p++) {
       if (await checkServer(p)) return p;
@@ -203,24 +217,28 @@ function spawnWindowsBrowser(command, url, { shellCommand = false } = {}) {
       [BROWSER_URL_VAR]: url,
     };
     const child = shellCommand
-      ? spawn(process.env.ComSpec ?? 'cmd.exe', [
-          '/d',
-          '/s',
-          '/c',
-          // Outer quote pair is required: with /s, cmd strips only the first and
-          // last quote of the /c string, leaving `"cmd" "url"` intact. Pair it
-          // with windowsVerbatimArguments so Node does not backslash-escape the
-          // inner quotes (\") — cmd reads those literally and the command name
-          // becomes unrecognized.
-          `""%${BROWSER_COMMAND_VAR}%" "%${BROWSER_URL_VAR}%""`,
-        ], {
-          cwd: APP_DIR,
-          detached: true,
-          stdio: 'ignore',
-          env,
-          windowsHide: true,
-          windowsVerbatimArguments: true,
-        })
+      ? spawn(
+          process.env.ComSpec ?? 'cmd.exe',
+          [
+            '/d',
+            '/s',
+            '/c',
+            // Outer quote pair is required: with /s, cmd strips only the first and
+            // last quote of the /c string, leaving `"cmd" "url"` intact. Pair it
+            // with windowsVerbatimArguments so Node does not backslash-escape the
+            // inner quotes (\") — cmd reads those literally and the command name
+            // becomes unrecognized.
+            `""%${BROWSER_COMMAND_VAR}%" "%${BROWSER_URL_VAR}%""`,
+          ],
+          {
+            cwd: APP_DIR,
+            detached: true,
+            stdio: 'ignore',
+            env,
+            windowsHide: true,
+            windowsVerbatimArguments: true,
+          },
+        )
       : spawn(command, [url], {
           cwd: APP_DIR,
           detached: true,
@@ -244,19 +262,18 @@ function openWithWindowsShell(url) {
     // The outer quote pair plus windowsVerbatimArguments keeps cmd's /s quote
     // stripping and Node's argv escaping from mangling `start "" "url"` (without
     // them Node emits \" and the browser receives a corrupted \"url\").
-    const child = spawn(process.env.ComSpec ?? 'cmd.exe', [
-      '/d',
-      '/s',
-      '/c',
-      `"start "" "%${BROWSER_URL_VAR}%""`,
-    ], {
-      cwd: APP_DIR,
-      detached: true,
-      stdio: 'ignore',
-      env: { ...process.env, [BROWSER_URL_VAR]: url },
-      windowsHide: true,
-      windowsVerbatimArguments: true,
-    });
+    const child = spawn(
+      process.env.ComSpec ?? 'cmd.exe',
+      ['/d', '/s', '/c', `"start "" "%${BROWSER_URL_VAR}%""`],
+      {
+        cwd: APP_DIR,
+        detached: true,
+        stdio: 'ignore',
+        env: { ...process.env, [BROWSER_URL_VAR]: url },
+        windowsHide: true,
+        windowsVerbatimArguments: true,
+      },
+    );
 
     child.once('error', rejectSpawn);
     child.once('spawn', () => {
@@ -283,13 +300,18 @@ async function stopServer(quiet = false) {
   }
 
   // Clean up port file
-  try { await unlink(PORT_FILE); } catch {}
+  try {
+    await unlink(PORT_FILE);
+  } catch {}
 
   if (!quiet) console.log('mdr stopped.');
 }
 
 async function enableRestrictedMode() {
-  const prefsPath = join(homedir(), '.md-redline.json');
+  // resolveHomeDir, not homedir(): with MD_REDLINE_HOME set, a bare homedir()
+  // writes and locks a file the server never reads, so this would report
+  // success while trust stayed exactly as it was.
+  const prefsPath = join(resolveHomeDir(), '.md-redline.json');
 
   // The server takes this same lock around its own read-modify-write of the
   // prefs file. Without it, `mdr --restrict` racing a booting server either
@@ -299,15 +321,21 @@ async function enableRestrictedMode() {
   try {
     release = await acquireFileLock(prefsPath);
   } catch (err) {
-    // A filesystem error carries an errno; running out of attempts does not.
-    // The two need different advice, and telling someone with an unwritable
-    // home directory to wait for another process is a dead end.
-    if (err.code) {
+    // Contention and a filesystem failure need different advice, and telling
+    // someone with an unwritable home directory to wait for another process is
+    // a dead end. Discriminating on `err.code` alone got this backwards: on
+    // Windows an EACCES on the lock file IS retried, so a permanent condition
+    // arrives here as an exhausted budget with no errno of its own.
+    if (err instanceof LockContentionError) {
+      console.error(`Could not lock ${prefsPath} after ${LOCK_MAX_WAIT_MS}ms.`);
+      if (err.cause?.code) {
+        console.error(`Last error: ${err.cause.code}. Check permissions on ${dirname(prefsPath)}.`);
+      } else {
+        console.error('Another mdr process is writing it. Try again in a moment.');
+      }
+    } else {
       console.error(`Could not lock ${prefsPath} (${err.code}): ${err.message}`);
       console.error('Refusing to write over a file that may hold your trust settings.');
-    } else {
-      console.error(`Could not lock ${prefsPath}.`);
-      console.error('Another mdr process is writing it. Try again in a moment.');
     }
     process.exitCode = 1;
     return;
@@ -333,7 +361,17 @@ async function enableRestrictedMode() {
       }
     }
 
-    await atomicWriteFile(prefsPath, JSON.stringify({ trustedRoots: [] }, null, 2) + '\n');
+    try {
+      await atomicWriteFile(prefsPath, JSON.stringify({ trustedRoots: [] }, null, 2) + '\n');
+    } catch (err) {
+      // Every other branch here exits 1 with an explanation. Letting this one
+      // escape to main() printed a raw stack instead, with nothing to say
+      // whether restricted mode had been applied.
+      console.error(`Could not write ${prefsPath} (${err.code ?? 'unknown'}): ${err.message}`);
+      console.error('Restricted mode was NOT enabled.');
+      process.exitCode = 1;
+      return;
+    }
   } finally {
     await release();
   }
@@ -397,9 +435,17 @@ async function ensureServerRunning() {
   // default trust behavior. The server itself will write the prefs file on
   // boot; we check BEFORE spawning so the message corresponds to the very
   // first invocation only.
-  if (await isFirstLaunch()) {
+  const disclosure = await trustDisclosureState();
+  if (disclosure === 'seeded') {
     console.log('Welcome to md-redline! Trusting your home directory by default.');
-    console.log('Run `mdr --restrict` to opt out. See https://github.com/dejuknow/md-redline#permissions for details.');
+    console.log(
+      'Run `mdr --restrict` to opt out. See https://github.com/dejuknow/md-redline#permissions for details.',
+    );
+  } else if (disclosure === 'unreadable') {
+    // Not a welcome. This user has run mdr before and may well have opted out
+    // of home trust, and the point is that their opt-out is not in effect.
+    console.log(`Could not read ${join(resolveHomeDir(), '.md-redline.json')}.`);
+    console.log('Trusting your home directory for this session until it can be read again.');
   }
 
   if (!existing) console.log('Starting mdr...');
@@ -514,10 +560,20 @@ async function openInBrowser(url) {
 function getClaudeDesktopConfigPath() {
   const isWin = process.platform === 'win32';
   if (isWin) {
-    return join(process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'), 'Claude', 'claude_desktop_config.json');
+    return join(
+      process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'),
+      'Claude',
+      'claude_desktop_config.json',
+    );
   }
   if (process.platform === 'darwin') {
-    return join(homedir(), 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+    return join(
+      homedir(),
+      'Library',
+      'Application Support',
+      'Claude',
+      'claude_desktop_config.json',
+    );
   }
   return join(homedir(), '.config', 'Claude', 'claude_desktop_config.json');
 }
@@ -556,9 +612,8 @@ async function installForClaudeDesktop() {
   }
 
   if (typeof config !== 'object' || config === null) config = {};
-  const mcpServers = config.mcpServers && typeof config.mcpServers === 'object'
-    ? config.mcpServers
-    : {};
+  const mcpServers =
+    config.mcpServers && typeof config.mcpServers === 'object' ? config.mcpServers : {};
 
   const hadLegacyKey = Boolean(mcpServers.mdr) && !mcpServers['md-redline'];
   if (hadLegacyKey) {
@@ -602,13 +657,17 @@ async function installForClaudeCode() {
     child.once('exit', (code) => resolve(code === 0));
   });
   if (!claudeCheck) {
-    console.log('[Claude Code] claude CLI not found on PATH — skipping. Install Claude Code or run `claude mcp add md-redline mdr mcp` manually.');
+    console.log(
+      '[Claude Code] claude CLI not found on PATH — skipping. Install Claude Code or run `claude mcp add md-redline mdr mcp` manually.',
+    );
     return { ok: false, changed: false };
   }
 
   // Check whether md-redline is already registered.
   const listOutput = await new Promise((resolve) => {
-    const child = spawn('claude', ['mcp', 'list', '--scope', 'user'], { stdio: ['ignore', 'pipe', 'ignore'] });
+    const child = spawn('claude', ['mcp', 'list', '--scope', 'user'], {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
     let out = '';
     child.stdout.on('data', (chunk) => {
       out += chunk.toString('utf8');
@@ -622,15 +681,24 @@ async function installForClaudeCode() {
   }
 
   const addResult = await new Promise((resolve) => {
-    const child = spawn('claude', ['mcp', 'add', '--scope', 'user', 'md-redline', '--', 'mdr', 'mcp'], {
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    const child = spawn(
+      'claude',
+      ['mcp', 'add', '--scope', 'user', 'md-redline', '--', 'mdr', 'mcp'],
+      {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
     let stderr = '';
     child.stderr.on('data', (chunk) => {
       stderr += chunk.toString('utf8');
     });
     child.once('error', (err) => resolve({ ok: false, error: err.message }));
-    child.once('exit', (code) => resolve({ ok: code === 0, error: code === 0 ? null : stderr.trim() || `exited with code ${code}` }));
+    child.once('exit', (code) =>
+      resolve({
+        ok: code === 0,
+        error: code === 0 ? null : stderr.trim() || `exited with code ${code}`,
+      }),
+    );
   });
 
   if (!addResult.ok) {
@@ -647,14 +715,22 @@ async function installMcpConfig(target) {
     try {
       results.push({ name: 'Claude Desktop', ...(await installForClaudeDesktop()) });
     } catch (err) {
-      results.push({ name: 'Claude Desktop', ok: false, error: err instanceof Error ? err.message : 'unknown error' });
+      results.push({
+        name: 'Claude Desktop',
+        ok: false,
+        error: err instanceof Error ? err.message : 'unknown error',
+      });
     }
   }
   if (target === 'claude-code' || target === 'all') {
     try {
       results.push({ name: 'Claude Code', ...(await installForClaudeCode()) });
     } catch (err) {
-      results.push({ name: 'Claude Code', ok: false, error: err instanceof Error ? err.message : 'unknown error' });
+      results.push({
+        name: 'Claude Code',
+        ok: false,
+        error: err instanceof Error ? err.message : 'unknown error',
+      });
     }
   }
 
@@ -699,7 +775,11 @@ async function runMcpStdio() {
     // entries that disappear between readdir and stat. The outer block lets
     // unexpected errors surface instead of being misclassified as staleness.
     const bundleStat = (() => {
-      try { return statSync(distMcp); } catch { return null; }
+      try {
+        return statSync(distMcp);
+      } catch {
+        return null;
+      }
     })();
     if (bundleStat) {
       // The MCP bundle pulls in `server/**`, modules from `src/lib/`
@@ -722,10 +802,18 @@ async function runMcpStdio() {
         const p = stack.pop();
         if (!p) continue;
         let entryStat;
-        try { entryStat = statSync(p); } catch { continue; }
+        try {
+          entryStat = statSync(p);
+        } catch {
+          continue;
+        }
         if (entryStat.isDirectory()) {
           let entries;
-          try { entries = readdirSync(p); } catch { continue; }
+          try {
+            entries = readdirSync(p);
+          } catch {
+            continue;
+          }
           for (const entry of entries) stack.push(join(p, entry));
         } else if (p.endsWith('.ts')) {
           // Skip test files — they don't contribute to the bundled output,
@@ -741,7 +829,7 @@ async function runMcpStdio() {
       if (stalePath) {
         throw new Error(
           `mdr mcp bundle is stale (${stalePath} is ${staleAgeSec}s newer than dist/mcp-stdio.js).\n` +
-          `Run \`npm run build\` (or \`npm run dev\` which rebuilds on save).`,
+            `Run \`npm run build\` (or \`npm run dev\` which rebuilds on save).`,
         );
       }
     }
@@ -797,12 +885,12 @@ async function main() {
   }
 
   if (process.argv[2] === '__first-launch') {
-    // Internal, undocumented seam, same idea as __open above: print whether
-    // this invocation counts as a first launch and exit, without booting a
-    // server. The answer is otherwise only observable as one line of welcome
-    // text printed in the middle of a real startup, which a test cannot reach
-    // without spawning the whole app.
-    console.log(String(await isFirstLaunch()));
+    // Internal, undocumented seam, same idea as __open above: print which
+    // trust disclosure this invocation would print and exit, without booting a
+    // server. The answer is otherwise only observable as a line or two of text
+    // in the middle of a real startup, which a test cannot reach without
+    // spawning the whole app.
+    console.log(await trustDisclosureState());
     return;
   }
 
@@ -865,7 +953,9 @@ async function main() {
               `Warning: server refused access to ${targetPath} (HTTP ${grantRes.status}); it may open as access denied.`,
             );
           }
-        } catch { /* server will enforce its own checks */ }
+        } catch {
+          /* server will enforce its own checks */
+        }
       }
     }
 

--- a/bin/md-redline
+++ b/bin/md-redline
@@ -71,8 +71,8 @@ async function isFirstLaunch() {
     raw = await retryTransient(() => readFile(prefsPath, 'utf8'));
   } catch (err) {
     // ENOENT is the only error that means "first launch". Anything else is a
-    // prefs file that exists and could not be read — a scanner holding it, a
-    // permission problem — and greeting a returning user with the trust
+    // prefs file that exists and could not be read (a scanner holding it, a
+    // permission problem), and greeting a returning user with the trust
     // disclosure on every run is both wrong and alarming. Stay quiet.
     return err.code === 'ENOENT';
   }

--- a/bin/prefs-cli.test.ts
+++ b/bin/prefs-cli.test.ts
@@ -30,17 +30,25 @@ interface CliResult {
   stderr: string;
 }
 
-function runCli(args: string[], home: string): Promise<CliResult> {
+function runCli(
+  args: string[],
+  home: string,
+  extraEnv: NodeJS.ProcessEnv = {},
+): Promise<CliResult> {
   return new Promise((resolvePromise, reject) => {
     const child = spawn(process.execPath, [BIN, ...args], {
       env: {
         ...process.env,
         HOME: home,
         USERPROFILE: home,
+        // Inherited from the developer's shell this would move the prefs file
+        // out of the scratch home for every test in the file.
+        MD_REDLINE_HOME: '',
         // getClaudeDesktopConfigPath reads APPDATA before falling back to the
         // home dir, so a real one on Windows would send the write outside the
         // scratch dir and into the developer's own Claude config.
         APPDATA: join(home, 'AppData', 'Roaming'),
+        ...extraEnv,
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -112,25 +120,54 @@ describe('mdr --restrict', () => {
     expect(readdirSync(home).filter((e) => e.endsWith('.lock') || e.endsWith('.tmp'))).toEqual([]);
   });
 
-  it.skipIf(!canDenyRead)(
-    'refuses rather than guessing when the prefs file cannot be stat-ed',
-    async () => {
-      // An unreadable home is the case that used to fall into the "safe to
-      // write" branch and clobber trust settings the CLI could not see.
-      const home = makeHome();
-      writeFileSync(join(home, PREFS), JSON.stringify({ trustedRoots: ['/vault'] }));
-      chmodSync(home, 0o000);
+  it.skipIf(!canDenyRead)('refuses when the home directory is unwritable', async () => {
+    // Named for what it actually reaches. An unreadable home fails at the
+    // LOCK, one syscall before the stat guard, so this does not cover that
+    // guard and must not claim to: the run below never executes the
+    // non-ENOENT stat branch at all.
+    const home = makeHome();
+    writeFileSync(join(home, PREFS), JSON.stringify({ trustedRoots: ['/vault'] }));
+    chmodSync(home, 0o000);
 
-      const result = await runCli(['--restrict'], home);
+    const result = await runCli(['--restrict'], home);
 
-      chmodSync(home, 0o700);
-      expect(result.code).toBe(1);
-      expect(result.stderr).toContain('Refusing to write over a file');
-      expect(JSON.parse(readFileSync(join(home, PREFS), 'utf8'))).toEqual({
-        trustedRoots: ['/vault'],
-      });
-    },
-  );
+    chmodSync(home, 0o700);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toMatch(/Could not lock/);
+    expect(JSON.parse(readFileSync(join(home, PREFS), 'utf8'))).toEqual({
+      trustedRoots: ['/vault'],
+    });
+  });
+
+  it('writes where the server reads, not where $HOME points', async () => {
+    // MD_REDLINE_HOME moves the prefs file for the server (resolveHomeDir).
+    // A CLI using bare homedir() locked and wrote a DIFFERENT file and still
+    // printed success, so the user believed trust was revoked when it was not,
+    // and the lock the two sides are supposed to share was taken on two paths.
+    const home = makeHome();
+    const prefsHome = makeHome();
+
+    const result = await runCli(['--restrict'], home, { MD_REDLINE_HOME: prefsHome });
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(readFileSync(join(prefsHome, PREFS), 'utf8'))).toEqual({ trustedRoots: [] });
+    expect(existsSync(join(home, PREFS))).toBe(false);
+  });
+
+  it('refuses against the file MD_REDLINE_HOME points at', async () => {
+    // The guard has to follow the file too, or --restrict silently clobbers
+    // trust settings whenever that variable is set.
+    const home = makeHome();
+    const prefsHome = makeHome();
+    const saved = JSON.stringify({ trustedRoots: ['/vault'] });
+    writeFileSync(join(prefsHome, PREFS), saved);
+
+    const result = await runCli(['--restrict'], home, { MD_REDLINE_HOME: prefsHome });
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Refusing to overwrite');
+    expect(readFileSync(join(prefsHome, PREFS), 'utf8')).toBe(saved);
+  });
 
   it('gives up instead of racing a lock another process is holding', async () => {
     const home = makeHome();
@@ -148,24 +185,27 @@ describe('mdr --restrict', () => {
 });
 
 describe('mdr __first-launch', () => {
-  it('is a first launch when no prefs file exists', async () => {
+  it('discloses the home-trust seed when no prefs file exists', async () => {
     const home = makeHome();
 
-    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('true');
+    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('seeded');
   });
 
-  it('is not a first launch once trustedRoots has been recorded', async () => {
+  it('stays quiet once trustedRoots has been recorded', async () => {
     const home = makeHome();
     writeFileSync(join(home, PREFS), JSON.stringify({ trustedRoots: ['/vault'] }));
 
-    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('false');
+    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('configured');
   });
 
   it.skipIf(!canDenyRead)(
-    'is not a first launch when the prefs file exists but cannot be read',
+    'still discloses when the prefs file exists but cannot be read',
     async () => {
-      // Returning true here greets a user who has run mdr for months with the
-      // trust disclosure, on every single launch.
+      // The server's first-launch branch fires on `trustedRoots === undefined`
+      // and an unreadable file looks exactly like that, so it seeds home trust
+      // in memory for the session. Staying silent here hides that from a user
+      // who may have run --restrict specifically to prevent it. Greeting them
+      // as a newcomer would be wrong too, hence a state of its own.
       const home = makeHome();
       writeFileSync(join(home, PREFS), JSON.stringify({ trustedRoots: ['/vault'] }));
       chmodSync(join(home, PREFS), 0o000);
@@ -173,17 +213,17 @@ describe('mdr __first-launch', () => {
       const result = await runCli(['__first-launch'], home);
 
       chmodSync(join(home, PREFS), 0o600);
-      expect(result.stdout.trim()).toBe('false');
+      expect(result.stdout.trim()).toBe('unreadable');
     },
   );
 
-  it('is a first launch when the prefs file is unparseable', async () => {
+  it('discloses when the prefs file is unparseable', async () => {
     // The server quarantines it on boot and starts fresh with default trust,
     // so the disclosure is accurate.
     const home = makeHome();
     writeFileSync(join(home, PREFS), '{ not json');
 
-    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('true');
+    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('seeded');
   });
 });
 

--- a/bin/prefs-cli.test.ts
+++ b/bin/prefs-cli.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn } from 'child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+
+// These cover the two files the CLI writes that something else also owns: the
+// user's `.md-redline.json`, which the server rewrites on every boot, and
+// Claude Desktop's MCP config, which holds every other MCP server the user has
+// configured. Both used to go out through a bare writeFile.
+//
+// Driven as a subprocess with HOME/USERPROFILE pointed at a scratch dir,
+// because os.homedir() is what picks the paths and there is no seam for it.
+
+const BIN = join(__dirname, 'md-redline');
+const PREFS = '.md-redline.json';
+
+interface CliResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[], home: string): Promise<CliResult> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [BIN, ...args], {
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        // getClaudeDesktopConfigPath reads APPDATA before falling back to the
+        // home dir, so a real one on Windows would send the write outside the
+        // scratch dir and into the developer's own Claude config.
+        APPDATA: join(home, 'AppData', 'Roaming'),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+    child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+    child.once('error', reject);
+    child.once('exit', (code) => resolvePromise({ code, stdout, stderr }));
+  });
+}
+
+/** Claude Desktop's config path for a given fake home, per platform. */
+function desktopConfigPath(home: string): string {
+  if (process.platform === 'win32') {
+    return join(home, 'AppData', 'Roaming', 'Claude', 'claude_desktop_config.json');
+  }
+  if (process.platform === 'darwin') {
+    return join(home, 'Library', 'Application Support', 'Claude', 'claude_desktop_config.json');
+  }
+  return join(home, '.config', 'Claude', 'claude_desktop_config.json');
+}
+
+// chmod only toggles a read-only bit on Windows, and root ignores the mode
+// bits entirely, so the deny-read cases cannot be staged in either. They guard
+// POSIX behavior; the Windows-specific write hazards are covered by the
+// fault-injection suites in server/.
+const canDenyRead = process.platform !== 'win32' && process.getuid?.() !== 0;
+
+const homes: string[] = [];
+
+function makeHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'md-redline-cli-home-'));
+  homes.push(home);
+  return home;
+}
+
+afterEach(() => {
+  for (const home of homes.splice(0)) {
+    // chmod back first, or a directory a test locked cannot be removed.
+    chmodSync(home, 0o700);
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+describe('mdr --restrict', () => {
+  it('writes the prefs file and leaves no temp or lock behind', async () => {
+    const home = makeHome();
+
+    const result = await runCli(['--restrict'], home);
+
+    expect(result.code).toBe(0);
+    expect(JSON.parse(readFileSync(join(home, PREFS), 'utf8'))).toEqual({ trustedRoots: [] });
+    // A leaked lock blocks every later write, from this process and the
+    // server both, until it ages out 30s later.
+    expect(readdirSync(home).filter((e) => e.endsWith('.lock') || e.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('refuses to overwrite an existing prefs file', async () => {
+    const home = makeHome();
+    const saved = JSON.stringify({ trustedRoots: ['/vault'], author: 'Dennis' });
+    writeFileSync(join(home, PREFS), saved);
+
+    const result = await runCli(['--restrict'], home);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Refusing to overwrite');
+    expect(readFileSync(join(home, PREFS), 'utf8')).toBe(saved);
+    expect(readdirSync(home).filter((e) => e.endsWith('.lock') || e.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it.skipIf(!canDenyRead)(
+    'refuses rather than guessing when the prefs file cannot be stat-ed',
+    async () => {
+      // An unreadable home is the case that used to fall into the "safe to
+      // write" branch and clobber trust settings the CLI could not see.
+      const home = makeHome();
+      writeFileSync(join(home, PREFS), JSON.stringify({ trustedRoots: ['/vault'] }));
+      chmodSync(home, 0o000);
+
+      const result = await runCli(['--restrict'], home);
+
+      chmodSync(home, 0o700);
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain('Refusing to write over a file');
+      expect(JSON.parse(readFileSync(join(home, PREFS), 'utf8'))).toEqual({
+        trustedRoots: ['/vault'],
+      });
+    },
+  );
+
+  it('gives up instead of racing a lock another process is holding', async () => {
+    const home = makeHome();
+    // A fresh lock file, as a mid-write server would leave: young enough that
+    // the stale-steal path does not fire.
+    writeFileSync(join(home, `${PREFS}.lock`), '99999');
+
+    const result = await runCli(['--restrict'], home);
+
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain('Another mdr process is writing it');
+    // The whole point: it did NOT write while another writer held the lock.
+    expect(existsSync(join(home, PREFS))).toBe(false);
+  }, 15_000);
+});
+
+describe('mdr __first-launch', () => {
+  it('is a first launch when no prefs file exists', async () => {
+    const home = makeHome();
+
+    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('true');
+  });
+
+  it('is not a first launch once trustedRoots has been recorded', async () => {
+    const home = makeHome();
+    writeFileSync(join(home, PREFS), JSON.stringify({ trustedRoots: ['/vault'] }));
+
+    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('false');
+  });
+
+  it.skipIf(!canDenyRead)(
+    'is not a first launch when the prefs file exists but cannot be read',
+    async () => {
+      // Returning true here greets a user who has run mdr for months with the
+      // trust disclosure, on every single launch.
+      const home = makeHome();
+      writeFileSync(join(home, PREFS), JSON.stringify({ trustedRoots: ['/vault'] }));
+      chmodSync(join(home, PREFS), 0o000);
+
+      const result = await runCli(['__first-launch'], home);
+
+      chmodSync(join(home, PREFS), 0o600);
+      expect(result.stdout.trim()).toBe('false');
+    },
+  );
+
+  it('is a first launch when the prefs file is unparseable', async () => {
+    // The server quarantines it on boot and starts fresh with default trust,
+    // so the disclosure is accurate.
+    const home = makeHome();
+    writeFileSync(join(home, PREFS), '{ not json');
+
+    expect((await runCli(['__first-launch'], home)).stdout.trim()).toBe('true');
+  });
+});
+
+describe('mdr mcp install --claude-desktop', () => {
+  it('keeps every other MCP server in the config', async () => {
+    const home = makeHome();
+    const configPath = desktopConfigPath(home);
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(
+      configPath,
+      JSON.stringify({ mcpServers: { filesystem: { command: 'npx', args: ['-y', 'fs'] } } }),
+    );
+
+    const result = await runCli(['mcp', 'install', '--claude-desktop'], home);
+
+    expect(result.code).toBe(0);
+    const written = JSON.parse(readFileSync(configPath, 'utf8'));
+    expect(written.mcpServers.filesystem).toEqual({ command: 'npx', args: ['-y', 'fs'] });
+    expect(written.mcpServers['md-redline']).toEqual({ command: 'mdr', args: ['mcp'] });
+    expect(readdirSync(dirname(configPath)).filter((e) => e.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it.skipIf(!canDenyRead)(
+    'aborts without writing when the existing config cannot be read',
+    async () => {
+      // Starting fresh over a config we could not read deletes every other MCP
+      // server the user has, which is the worst outcome available here.
+      const home = makeHome();
+      const configPath = desktopConfigPath(home);
+      mkdirSync(dirname(configPath), { recursive: true });
+      const saved = JSON.stringify({ mcpServers: { filesystem: { command: 'npx' } } });
+      writeFileSync(configPath, saved);
+      chmodSync(configPath, 0o000);
+
+      const result = await runCli(['mcp', 'install', '--claude-desktop'], home);
+
+      chmodSync(configPath, 0o600);
+      expect(result.code).not.toBe(0);
+      expect(result.stderr).toContain('Cannot read');
+      expect(readFileSync(configPath, 'utf8')).toBe(saved);
+    },
+  );
+});

--- a/bin/server-control.js
+++ b/bin/server-control.js
@@ -62,7 +62,7 @@ export async function checkServer(port, { fetchFn = fetch, timeoutMs = 1_000 } =
     // Validate this is actually mdr's /api/config — other dev servers
     // (e.g. Next.js) return 200 with their SPA shell for unknown paths,
     // which would otherwise fool the port scan and hijack the browser open.
-    const data = await response.json();
+    const data = /** @type {Record<string, unknown> | null} */ (await response.json());
     return !!data && typeof data === 'object' && typeof data.homeDir === 'string';
   } catch {
     return false;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -30,12 +30,27 @@ export default defineConfig([
       'server/**/*.ts',
       'eval/**/*.ts',
       'e2e/**/*.ts',
+      'bin/**/*.ts',
       'vite.config.ts',
       'playwright.config.ts',
     ],
     extends: [js.configs.recommended, tseslint.configs.recommended],
     languageOptions: {
       ecmaVersion: 2020,
+      globals: globals.node,
+    },
+  },
+  {
+    // bin/ is plain JS with no build step, and it holds the filesystem
+    // primitives the CLI and the server share. Without an entry here eslint
+    // matched none of it and exited 0 having checked nothing, which reads
+    // exactly like passing. Type errors are caught separately by
+    // tsconfig.bin.json (checkJs); this covers the lint rules.
+    files: ['bin/**/*.js'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 2023,
+      sourceType: 'module',
       globals: globals.node,
     },
   },

--- a/server/env.ts
+++ b/server/env.ts
@@ -1,5 +1,3 @@
-import { homedir } from 'os';
-
 /**
  * Server-side environment resolution. The port resolvers live in `bin/ports.js`,
  * which explains why they are plain JavaScript and why every reader has to share
@@ -9,27 +7,16 @@ import { homedir } from 'os';
 
 export { FALLBACK_PORT, resolveApiPort } from '../bin/ports.js';
 import { resolvePort } from '../bin/ports.js';
+/**
+ * Re-exported rather than defined here for the same reason as the ports: the
+ * CLI writes `.md-redline.json` too, and the two sides have to agree on which
+ * file that is. See `bin/home-dir.js`.
+ */
+export { resolveHomeDir } from '../bin/home-dir.js';
 
 export const FALLBACK_VITE_PORT = 5188;
 
 /** Port for the Vite dev client. No alias: this one only ever had the prefixed name. */
 export function resolveVitePort(env: NodeJS.ProcessEnv = process.env): number {
   return resolvePort(env, ['MD_REDLINE_VITE_PORT'], FALLBACK_VITE_PORT);
-}
-
-/**
- * Resolves the base directory for md-redline's preferences file.
- *
- * Blank counts as unset here too. A plain `?? homedir()` kept an empty string,
- * and an empty base directory is not an obvious failure: `.md-redline.json` then
- * resolves against the current working directory, so trusted roots and the
- * update-check cache get written wherever the user happened to launch from and
- * silently fail to persist across launches.
- *
- * Both `server/index.ts` and `server/update-check.ts` read this independently.
- * The update checker is constructed without a `homeDir` option, so its own read
- * is live in production rather than a test-only fallback.
- */
-export function resolveHomeDir(env: NodeJS.ProcessEnv = process.env): string {
-  return env.MD_REDLINE_HOME?.trim() || homedir();
 }

--- a/server/fs-retry.test.ts
+++ b/server/fs-retry.test.ts
@@ -305,19 +305,27 @@ describe('atomicWriteFile', () => {
     expect(await readFile(docPath, 'utf-8')).toBe('old\n');
   });
 
-  it('keeps the permissions the destination already had', async () => {
-    // A temp file is created at 0600-and-umask, so without carrying the mode
-    // over, the rename RELAXES anything the user or another tool tightened.
-    // Claude Desktop's MCP config is the file that makes this matter: it holds
-    // every other server's env block, and those carry API tokens.
-    await writeFile(docPath, 'old\n', { mode: 0o600 });
-    await chmod(docPath, 0o600);
+  // REAL_PLATFORM, not process.platform: the suite pins win32 in beforeAll, and
+  // this has to key off the machine actually running. Windows has no POSIX mode
+  // bits (chmod toggles a read-only flag and stat reports 0o666), so there is
+  // nothing to preserve and nothing to assert. inheritMode copies whatever the
+  // destination reports, which makes it a no-op there rather than a bug.
+  it.skipIf(REAL_PLATFORM === 'win32')(
+    'keeps the permissions the destination already had',
+    async () => {
+      // A temp file is created at 0600-and-umask, so without carrying the mode
+      // over, the rename RELAXES anything the user or another tool tightened.
+      // Claude Desktop's MCP config is the file that makes this matter: it
+      // holds every other server's env block, and those carry API tokens.
+      await writeFile(docPath, 'old\n', { mode: 0o600 });
+      await chmod(docPath, 0o600);
 
-    await atomicWriteFile(docPath, 'new\n');
+      await atomicWriteFile(docPath, 'new\n');
 
-    expect((await stat(docPath)).mode & 0o777).toBe(0o600);
-    expect(await readFile(docPath, 'utf-8')).toBe('new\n');
-  });
+      expect((await stat(docPath)).mode & 0o777).toBe(0o600);
+      expect(await readFile(docPath, 'utf-8')).toBe('new\n');
+    },
+  );
 
   it('does not retry a permanent rename failure', async () => {
     fault.rename.failuresLeft = 1;

--- a/server/fs-retry.test.ts
+++ b/server/fs-retry.test.ts
@@ -1,9 +1,10 @@
-import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, rm, writeFile, readFile, readdir } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
   atomicWriteFile,
+  FS_RETRY_BUDGET_MS,
   isTransientFsError,
   retryTransient,
   retryTransientSync,
@@ -22,7 +23,7 @@ const fault = vi.hoisted(() => ({
     /** Delete the temp file while reporting failure, as a sync client can. */
     stealTmp: false,
   },
-  open: { failuresLeft: 0, code: 'ENOSPC' },
+  open: { failuresLeft: 0, code: 'ENOSPC', attempts: 0 },
   // Faults the temp file's write/close, AFTER the temp file exists, which is
   // what makes the cleanup assertions non-vacuous.
   write: { failuresLeft: 0, code: 'ENOSPC' },
@@ -52,6 +53,7 @@ vi.mock('fs/promises', async (importOriginal) => {
       return actual.rename(from, to);
     },
     open: async (path: string, flags: string) => {
+      if (path.endsWith('.tmp')) fault.open.attempts += 1;
       if (fault.open.failuresLeft > 0 && path.endsWith('.tmp')) {
         fault.open.failuresLeft -= 1;
         throw faultError(fault.open.code, `open '${path}'`);
@@ -80,15 +82,26 @@ vi.mock('fs/promises', async (importOriginal) => {
   };
 });
 
+// Retrying the transient codes is Windows-only behavior, so the suite has to
+// say which platform it is exercising rather than inheriting the runner's.
+// Everything below runs as Windows except the POSIX describe at the end.
+const REAL_PLATFORM = process.platform;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
 let testDir: string;
 let docPath: string;
 
 beforeAll(async () => {
+  setPlatform('win32');
   testDir = await mkdtemp(join(tmpdir(), 'md-redline-fs-retry-'));
   docPath = join(testDir, 'doc.md');
 });
 
 afterAll(async () => {
+  setPlatform(REAL_PLATFORM);
   await rm(testDir, { recursive: true, force: true });
 });
 
@@ -100,7 +113,7 @@ beforeEach(async () => {
     commitAnyway: false,
     stealTmp: false,
   };
-  fault.open = { failuresLeft: 0, code: 'ENOSPC' };
+  fault.open = { failuresLeft: 0, code: 'ENOSPC', attempts: 0 };
   fault.write = { failuresLeft: 0, code: 'ENOSPC' };
   fault.close = { failuresLeft: 0, code: 'EIO' };
   for (const entry of await readdir(testDir).catch(() => [] as string[])) {
@@ -109,7 +122,7 @@ beforeEach(async () => {
 });
 
 describe('isTransientFsError', () => {
-  it.each(['EPERM', 'EACCES', 'EBUSY'])('treats %s as transient', (code) => {
+  it.each(['EPERM', 'EACCES', 'EBUSY'])('treats %s as transient on Windows', (code) => {
     expect(isTransientFsError(faultError(code, 'x'))).toBe(true);
   });
 
@@ -227,6 +240,27 @@ describe('atomicWriteFile', () => {
     expect((await readdir(testDir)).filter((e) => e.endsWith('.tmp'))).toEqual([]);
   });
 
+  it('writes through a bounced temp-file create', async () => {
+    // Windows AV hooks file creation as readily as the rename, so the very
+    // first syscall of a save is bounceable too.
+    await writeFile(docPath, 'old\n');
+    fault.open.failuresLeft = 3;
+    fault.open.code = 'EBUSY';
+
+    await atomicWriteFile(docPath, 'new\n');
+
+    expect(await readFile(docPath, 'utf-8')).toBe('new\n');
+    expect(fault.open.attempts).toBe(4);
+  });
+
+  it('does not retry a permanent temp-file create failure', async () => {
+    fault.open.failuresLeft = 1;
+    fault.open.code = 'ENOSPC';
+
+    await expect(atomicWriteFile(docPath, 'new\n')).rejects.toMatchObject({ code: 'ENOSPC' });
+    expect(fault.open.attempts).toBe(1);
+  });
+
   it('reports the write error, not the close error that follows it', async () => {
     // close surfaces deferred write errors, so it fires on the way out of a
     // failed write. Reporting its code instead would send a permanent ENOSPC
@@ -277,5 +311,53 @@ describe('atomicWriteFile', () => {
 
     await expect(atomicWriteFile(docPath, 'new\n')).rejects.toMatchObject({ code: 'EXDEV' });
     expect(fault.rename.attempts).toBe(1);
+  });
+});
+
+describe('off Windows', () => {
+  // EPERM/EACCES/EBUSY are permanent on POSIX (an unwritable directory, a
+  // sticky bit, a macOS uchg flag, a denied Files-and-Folders grant), so the
+  // budget would be spent waiting for something that cannot clear.
+  beforeEach(() => setPlatform('darwin'));
+  afterEach(() => setPlatform('win32'));
+
+  it.each(['EPERM', 'EACCES', 'EBUSY'])('treats %s as permanent', (code) => {
+    expect(isTransientFsError(faultError(code, 'x'))).toBe(false);
+  });
+
+  it('fails a bounced call on the first attempt instead of burning the budget', async () => {
+    let calls = 0;
+    const started = Date.now();
+    await expect(
+      retryTransient(async () => {
+        calls += 1;
+        throw faultError('EPERM', 'locked');
+      }),
+    ).rejects.toMatchObject({ code: 'EPERM' });
+
+    expect(calls).toBe(1);
+    // The point of the gate: no backoff is paid for a hopeless call.
+    expect(Date.now() - started).toBeLessThan(FS_RETRY_BUDGET_MS);
+  });
+
+  it('fails a bounced sync call on the first attempt', () => {
+    let calls = 0;
+    expect(() =>
+      retryTransientSync(() => {
+        calls += 1;
+        throw faultError('EBUSY', 'locked');
+      }),
+    ).toThrow(/EBUSY/);
+    expect(calls).toBe(1);
+  });
+
+  it('surfaces a bounced save immediately, with the destination intact', async () => {
+    await writeFile(docPath, 'old\n');
+    fault.rename.failuresLeft = 1;
+
+    await expect(atomicWriteFile(docPath, 'new\n')).rejects.toMatchObject({ code: 'EPERM' });
+    expect(fault.rename.attempts).toBe(1);
+    expect(await readFile(docPath, 'utf-8')).toBe('old\n');
+    expect((await readdir(testDir)).filter((e) => e.endsWith('.tmp'))).toEqual([]);
   });
 });

--- a/server/fs-retry.test.ts
+++ b/server/fs-retry.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, rm, writeFile, readFile, readdir } from 'fs/promises';
+import { chmod, mkdtemp, rm, stat, writeFile, readFile, readdir } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -305,6 +305,20 @@ describe('atomicWriteFile', () => {
     expect(await readFile(docPath, 'utf-8')).toBe('old\n');
   });
 
+  it('keeps the permissions the destination already had', async () => {
+    // A temp file is created at 0600-and-umask, so without carrying the mode
+    // over, the rename RELAXES anything the user or another tool tightened.
+    // Claude Desktop's MCP config is the file that makes this matter: it holds
+    // every other server's env block, and those carry API tokens.
+    await writeFile(docPath, 'old\n', { mode: 0o600 });
+    await chmod(docPath, 0o600);
+
+    await atomicWriteFile(docPath, 'new\n');
+
+    expect((await stat(docPath)).mode & 0o777).toBe(0o600);
+    expect(await readFile(docPath, 'utf-8')).toBe('new\n');
+  });
+
   it('does not retry a permanent rename failure', async () => {
     fault.rename.failuresLeft = 1;
     fault.rename.code = 'EXDEV';
@@ -315,14 +329,23 @@ describe('atomicWriteFile', () => {
 });
 
 describe('off Windows', () => {
-  // EPERM/EACCES/EBUSY are permanent on POSIX (an unwritable directory, a
-  // sticky bit, a macOS uchg flag, a denied Files-and-Folders grant), so the
-  // budget would be spent waiting for something that cannot clear.
+  // The gate is per-errno, not per-platform, and the split is the whole point:
+  // EPERM/EACCES on POSIX mean a permanent permission condition (an unwritable
+  // directory, a sticky bit, a macOS uchg flag, a denied Files-and-Folders
+  // grant) where the budget buys nothing, while EBUSY means contention on
+  // every platform and is what SMB, NFS and the FUSE/FileProvider mounts
+  // behind Dropbox, Google Drive and iCloud return while they hold a file.
   beforeEach(() => setPlatform('darwin'));
   afterEach(() => setPlatform('win32'));
 
-  it.each(['EPERM', 'EACCES', 'EBUSY'])('treats %s as permanent', (code) => {
+  it.each(['EPERM', 'EACCES'])('treats %s as permanent', (code) => {
     expect(isTransientFsError(faultError(code, 'x'))).toBe(false);
+  });
+
+  it('still treats EBUSY as contention, because on POSIX it is', () => {
+    // Gating this to win32 as well would strand every save onto a cloud-sync
+    // or network volume, which is where these documents actually live.
+    expect(isTransientFsError(faultError('EBUSY', 'x'))).toBe(true);
   });
 
   it('fails a bounced call on the first attempt instead of burning the budget', async () => {
@@ -345,10 +368,23 @@ describe('off Windows', () => {
     expect(() =>
       retryTransientSync(() => {
         calls += 1;
-        throw faultError('EBUSY', 'locked');
+        throw faultError('EACCES', 'denied');
       }),
-    ).toThrow(/EBUSY/);
+    ).toThrow(/EACCES/);
     expect(calls).toBe(1);
+  });
+
+  it('rides out a contended save on a network or cloud volume', async () => {
+    // The regression this guards: a blanket win32 gate made this save fail on
+    // the first bounce, losing a comment the user had just written.
+    await writeFile(docPath, 'old\n');
+    fault.rename.failuresLeft = 3;
+    fault.rename.code = 'EBUSY';
+
+    await atomicWriteFile(docPath, 'new\n');
+
+    expect(await readFile(docPath, 'utf-8')).toBe('new\n');
+    expect(fault.rename.attempts).toBe(4);
   });
 
   it('surfaces a bounced save immediately, with the destination intact', async () => {

--- a/server/fs-retry.ts
+++ b/server/fs-retry.ts
@@ -6,11 +6,36 @@ import { randomBytes } from 'crypto';
 // client like OneDrive or Dropbox. They clear on their own within a few
 // milliseconds. 5 attempts spread over 100ms of linear backoff (10+20+30+40)
 // cover the window without stalling a real failure.
-const FS_MAX_ATTEMPTS = 5;
-const FS_RETRY_BASE_MS = 10;
+export const FS_MAX_ATTEMPTS = 5;
+export const FS_RETRY_BASE_MS = 10;
+/**
+ * Wall-clock a hopeless call can spend inside retryTransient: the sum of the
+ * linear backoffs between attempts (10+20+30+40). Exported so callers that
+ * hand-roll their own contention loop can size themselves against it instead
+ * of drifting apart silently.
+ */
+export const FS_RETRY_BUDGET_MS =
+  ((FS_MAX_ATTEMPTS * (FS_MAX_ATTEMPTS - 1)) / 2) * FS_RETRY_BASE_MS;
 const TRANSIENT_FS_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
 
+/**
+ * Windows is the only platform where these codes mean "try again". POSIX
+ * reports the same three for conditions that are permanent by construction: an
+ * unwritable directory, a sticky bit, a macOS `uchg` flag, a denied
+ * Files-and-Folders grant. There, every attempt fails identically, so the loop
+ * buys nothing and costs the caller its full budget before surfacing the error
+ * the user actually needs to see. Reproduced on Darwin against a locked
+ * document, on the app's highest-frequency write path.
+ *
+ * Read per call rather than captured at module load, so the tests can exercise
+ * both sides on whichever platform they run.
+ */
+function platformRetriesTransientCodes(): boolean {
+  return process.platform === 'win32';
+}
+
 export function isTransientFsError(err: unknown): boolean {
+  if (!platformRetriesTransientCodes()) return false;
   const code = (err as NodeJS.ErrnoException).code;
   return !!code && TRANSIENT_FS_CODES.has(code);
 }
@@ -22,12 +47,7 @@ export function sleep(ms: number): Promise<void> {
 /**
  * Run a filesystem call, retrying the transient failures above. Every other
  * code (EXDEV, ENOSPC, ENOENT) is a real failure and rethrows on the first
- * attempt.
- *
- * POSIX reports the same codes for permanent conditions instead (an unwritable
- * directory, a sticky bit, a macOS immutable flag, a denied Files-and-Folders
- * grant), so the loop is not free there. FS_MAX_ATTEMPTS caps what a hopeless
- * call wastes at 100ms.
+ * attempt, as does everything off Windows — see isTransientFsError.
  */
 export async function retryTransient<T>(op: () => Promise<T>): Promise<T> {
   let lastErr: unknown;
@@ -71,14 +91,26 @@ export function retryTransientSync<T>(op: () => T): T {
  * stale or adversarial `.tmp` cannot block writes, and O_EXCL keeps it from
  * following a symlink.
  *
- * The rename is retried because it is the call Windows bounces most often: it
- * touches both the temp file and the destination, and the destination is the
- * file the user just had open. On any failure the temp file is removed rather
- * than left in the user's folder, where it would show up in Explorer and in
- * `git status`.
+ * Both the create and the rename are retried, because both are calls Windows
+ * bounces: the create because AV hooks file creation, the rename because it
+ * touches the destination the user just had open. On any failure the temp file
+ * is removed rather than left in the user's folder, where it would show up in
+ * Explorer and in `git status`.
  */
 async function writeTempFile(tmpPath: string, content: string): Promise<void> {
-  const fd = await open(tmpPath, 'wx');
+  // Creating the temp file is bounceable for the same reason the rename is:
+  // Windows AV and sync clients hook file creation, and this is the first
+  // syscall of every save. Only the open retries. The write and the close are
+  // not idempotent against a file that now exists, and re-running them would
+  // need the O_EXCL create dropped, which is what keeps a symlink planted at
+  // tmpPath from being followed.
+  //
+  // A create that bounces AFTER the file lands makes the next attempt fail
+  // EEXIST, which is permanent and ends the save. That is the intended
+  // outcome: the caller removes the orphan, the destination is untouched, and
+  // the user retries. Recovering the file instead would mean unlinking a path
+  // this process cannot prove it owns.
+  const fd = await retryTransient(() => open(tmpPath, 'wx'));
   let failure: unknown;
   try {
     await fd.writeFile(content, 'utf-8');

--- a/server/fs-retry.ts
+++ b/server/fs-retry.ts
@@ -1,163 +1,19 @@
-import { open, readFile, rename, unlink } from 'fs/promises';
-import { randomBytes } from 'crypto';
-
-// Windows bounces filesystem calls with these codes while another handle is
-// open on the path: a virus scanner mid-scan, the search indexer, a sync
-// client like OneDrive or Dropbox. They clear on their own within a few
-// milliseconds. 5 attempts spread over 100ms of linear backoff (10+20+30+40)
-// cover the window without stalling a real failure.
-export const FS_MAX_ATTEMPTS = 5;
-export const FS_RETRY_BASE_MS = 10;
 /**
- * Wall-clock a hopeless call can spend inside retryTransient: the sum of the
- * linear backoffs between attempts (10+20+30+40). Exported so callers that
- * hand-roll their own contention loop can size themselves against it instead
- * of drifting apart silently.
+ * Server-side view of the crash-safe write helpers. The implementation lives
+ * in `bin/fs-atomic.js` because the CLI is plain JS shipped as is and cannot
+ * import a `.ts` module, yet writes the same two files this server does: the
+ * user's `.md-redline.json` and, on `mdr mcp install`, a JSON config another
+ * process owns. One implementation, imported from both sides, is the only way
+ * those stay in step. `server/env.ts` has the same arrangement with
+ * `bin/ports.js`.
  */
-export const FS_RETRY_BUDGET_MS =
-  ((FS_MAX_ATTEMPTS * (FS_MAX_ATTEMPTS - 1)) / 2) * FS_RETRY_BASE_MS;
-const TRANSIENT_FS_CODES = new Set(['EPERM', 'EACCES', 'EBUSY']);
-
-/**
- * Windows is the only platform where these codes mean "try again". POSIX
- * reports the same three for conditions that are permanent by construction: an
- * unwritable directory, a sticky bit, a macOS `uchg` flag, a denied
- * Files-and-Folders grant. There, every attempt fails identically, so the loop
- * buys nothing and costs the caller its full budget before surfacing the error
- * the user actually needs to see. Reproduced on Darwin against a locked
- * document, on the app's highest-frequency write path.
- *
- * Read per call rather than captured at module load, so the tests can exercise
- * both sides on whichever platform they run.
- */
-function platformRetriesTransientCodes(): boolean {
-  return process.platform === 'win32';
-}
-
-export function isTransientFsError(err: unknown): boolean {
-  if (!platformRetriesTransientCodes()) return false;
-  const code = (err as NodeJS.ErrnoException).code;
-  return !!code && TRANSIENT_FS_CODES.has(code);
-}
-
-export function sleep(ms: number): Promise<void> {
-  return new Promise((res) => setTimeout(res, ms));
-}
-
-/**
- * Run a filesystem call, retrying the transient failures above. Every other
- * code (EXDEV, ENOSPC, ENOENT) is a real failure and rethrows on the first
- * attempt, as does everything off Windows — see isTransientFsError.
- */
-export async function retryTransient<T>(op: () => Promise<T>): Promise<T> {
-  let lastErr: unknown;
-  for (let attempt = 1; attempt <= FS_MAX_ATTEMPTS; attempt++) {
-    try {
-      return await op();
-    } catch (err) {
-      lastErr = err;
-      if (!isTransientFsError(err)) throw err;
-      if (attempt < FS_MAX_ATTEMPTS) await sleep(FS_RETRY_BASE_MS * attempt);
-    }
-  }
-  throw lastErr;
-}
-
-/**
- * Synchronous twin of retryTransient, for the startup path that reads
- * preferences before the event loop is doing anything else. Atomics.wait is
- * the only way to sleep without yielding; blocking for at most 100ms once at
- * boot beats losing the user's trusted roots to a scanner.
- */
-export function retryTransientSync<T>(op: () => T): T {
-  let lastErr: unknown;
-  for (let attempt = 1; attempt <= FS_MAX_ATTEMPTS; attempt++) {
-    try {
-      return op();
-    } catch (err) {
-      lastErr = err;
-      if (!isTransientFsError(err)) throw err;
-      if (attempt < FS_MAX_ATTEMPTS) {
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, FS_RETRY_BASE_MS * attempt);
-      }
-    }
-  }
-  throw lastErr;
-}
-
-/**
- * Write `content` to `path` via a temp file and a rename, so a crash mid-write
- * cannot leave a half-written file. The temp name carries a random suffix so a
- * stale or adversarial `.tmp` cannot block writes, and O_EXCL keeps it from
- * following a symlink.
- *
- * Both the create and the rename are retried, because both are calls Windows
- * bounces: the create because AV hooks file creation, the rename because it
- * touches the destination the user just had open. On any failure the temp file
- * is removed rather than left in the user's folder, where it would show up in
- * Explorer and in `git status`.
- */
-async function writeTempFile(tmpPath: string, content: string): Promise<void> {
-  // Creating the temp file is bounceable for the same reason the rename is:
-  // Windows AV and sync clients hook file creation, and this is the first
-  // syscall of every save. Only the open retries. The write and the close are
-  // not idempotent against a file that now exists, and re-running them would
-  // need the O_EXCL create dropped, which is what keeps a symlink planted at
-  // tmpPath from being followed.
-  //
-  // A create that bounces AFTER the file lands makes the next attempt fail
-  // EEXIST, which is permanent and ends the save. That is the intended
-  // outcome: the caller removes the orphan, the destination is untouched, and
-  // the user retries. Recovering the file instead would mean unlinking a path
-  // this process cannot prove it owns.
-  const fd = await retryTransient(() => open(tmpPath, 'wx'));
-  let failure: unknown;
-  try {
-    await fd.writeFile(content, 'utf-8');
-  } catch (err) {
-    failure = err;
-  } finally {
-    try {
-      await fd.close();
-    } catch (closeErr) {
-      // close surfaces deferred write errors, so a failure here means the temp
-      // file is not trustworthy either way. It must not REPLACE an earlier
-      // error though: the write's own code is what decides whether this is
-      // worth retrying, and a close error can carry a different one.
-      failure ??= closeErr;
-    }
-  }
-  if (failure) throw failure;
-}
-
-async function renameIntoPlace(tmpPath: string, path: string, content: string): Promise<void> {
-  let attempted = false;
-  await retryTransient(async () => {
-    const firstAttempt = !attempted;
-    attempted = true;
-    try {
-      await rename(tmpPath, path);
-    } catch (err) {
-      // rename is not idempotent, and retrying re-probes a temp file whose
-      // fate may have changed: an attempt that reported failure can still have
-      // moved the file, and a sync client can consume the temp file between
-      // attempts. Both leave a later attempt failing with ENOENT for a write
-      // that already landed. Confirm by content rather than reporting a save
-      // that succeeded as failed, and never on the first attempt, where ENOENT
-      // means the temp file genuinely never existed.
-      if (firstAttempt || (err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      if ((await readFile(path, 'utf-8').catch(() => null)) !== content) throw err;
-    }
-  });
-}
-
-export async function atomicWriteFile(path: string, content: string): Promise<void> {
-  const tmpPath = `${path}.${randomBytes(6).toString('hex')}.tmp`;
-  try {
-    await writeTempFile(tmpPath, content);
-    await renameIntoPlace(tmpPath, path, content);
-  } catch (err) {
-    await unlink(tmpPath).catch(() => {});
-    throw err;
-  }
-}
+export {
+  atomicWriteFile,
+  FS_MAX_ATTEMPTS,
+  FS_RETRY_BASE_MS,
+  FS_RETRY_BUDGET_MS,
+  isTransientFsError,
+  retryTransient,
+  retryTransientSync,
+  sleep,
+} from '../bin/fs-atomic.js';

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -50,12 +50,15 @@ vi.mock('fs', async (importOriginal) => {
 // save in progress, and armed per test, off by default: every other test in
 // this file runs against a clean filesystem.
 // `target` narrows the fault to saves landing on one file, which is what makes
-// a mid-batch failure (and the rollback of the files already written) stageable.
+// a mid-batch failure (and the rollback of the files already written)
+// stageable. null means every path, since '' would make endsWith('') true and
+// read as narrowing while narrowing nothing.
 const saveFault = vi.hoisted(() => ({
   failuresLeft: 0,
   code: 'EPERM',
   attempts: 0,
-  target: '',
+  /** @type {string | null} */
+  target: null as string | null,
 }));
 
 vi.mock('fs/promises', async (importOriginal) => {
@@ -64,7 +67,9 @@ vi.mock('fs/promises', async (importOriginal) => {
     ...actual,
     rename: async (from: string, to: string) => {
       if (!String(from).endsWith('.tmp')) return actual.rename(from, to);
-      if (!String(to).endsWith(saveFault.target)) return actual.rename(from, to);
+      if (saveFault.target !== null && !String(to).endsWith(saveFault.target)) {
+        return actual.rename(from, to);
+      }
       saveFault.attempts += 1;
       if (saveFault.failuresLeft > 0) {
         saveFault.failuresLeft -= 1;
@@ -4409,7 +4414,7 @@ describe('save path under filesystem faults', () => {
     saveFault.failuresLeft = 0;
     saveFault.code = 'EPERM';
     saveFault.attempts = 0;
-    saveFault.target = '';
+    saveFault.target = null;
     setPlatform(REAL_PLATFORM);
     await writeFile(faultFile, '# Original\n');
   });
@@ -4417,7 +4422,7 @@ describe('save path under filesystem faults', () => {
   afterEach(async () => {
     setPlatform(REAL_PLATFORM);
     saveFault.failuresLeft = 0;
-    saveFault.target = '';
+    saveFault.target = null;
     await rm(faultFile, { force: true });
   });
 
@@ -4462,6 +4467,10 @@ describe('save path under filesystem faults', () => {
     // Same hazard, one step earlier: the second request chains onto the first
     // while it is still in flight, so it takes the rejection directly rather
     // than finding the map already cleaned up.
+    // A code the retry never absorbs, so exactly one save fails on every
+    // platform. EPERM would be retried away on Windows, where this branch is
+    // aimed, and the test would pass there for the wrong reason.
+    saveFault.code = 'ENOSPC';
     saveFault.failuresLeft = 1;
     const [first, second] = await Promise.all([
       save(faultFile, '# First\n'),
@@ -4473,6 +4482,9 @@ describe('save path under filesystem faults', () => {
     // Before the fix both came back 500, the second without a write attempted.
     const statuses = [first.response.status, second.response.status].sort();
     expect(statuses).toEqual([200, 500]);
+    // Exactly one rename reached the fault, so the other save genuinely ran
+    // rather than being skipped by an inherited rejection.
+    expect(saveFault.attempts).toBe(2);
     expect(await readFile(faultFile, 'utf-8')).toBe(
       first.response.status === 200 ? '# First\n' : '# Second\n',
     );
@@ -4585,6 +4597,31 @@ describe('writePortFile', () => {
     expect((await readdir(dir)).filter((e) => e.endsWith('.tmp'))).toEqual([]);
 
     await rm(dir, { recursive: true, force: true });
+  });
+
+  it('clears a stale entry when it cannot write its own', async () => {
+    // The fallback only works if the file is GONE. The CLI reads it first and
+    // takes the port it names as soon as that port answers, so an entry left
+    // naming a still-live orphan server from an earlier launch sends the
+    // user's document to the orphan, which has its own trusted roots.
+    const dir = await mkdtemp(join(tmpdir(), 'md-redline-portfile-'));
+    const portFile = join(dir, 'md-redline.port');
+    await writeFile(portFile, '6373');
+    saveFault.target = 'md-redline.port';
+    saveFault.failuresLeft = Number.MAX_SAFE_INTEGER;
+    saveFault.code = 'ENOSPC';
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      expect(await writePortFile(portFile, 6374)).toBe(false);
+      await expect(readFile(portFile, 'utf8')).rejects.toThrow();
+    } finally {
+      logged.mockRestore();
+      saveFault.failuresLeft = 0;
+      saveFault.target = null;
+      saveFault.code = 'EPERM';
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 
   it('reports failure instead of throwing, so a boot is never lost to it', async () => {

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1,5 +1,15 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { mkdtemp, mkdir, readFile, realpath, rm, symlink, utimes, writeFile } from 'fs/promises';
+import {
+  mkdtemp,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  rm,
+  symlink,
+  utimes,
+  writeFile,
+} from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -8,6 +18,7 @@ import {
   isPathInsideRoot,
   normalizeHostname,
   removePortFileIfOwned,
+  writePortFile,
   type CreateAppOptions,
 } from './index';
 import { addReply, parseComments } from '../src/lib/comment-parser';
@@ -4335,5 +4346,49 @@ describe('removePortFileIfOwned', () => {
     expect(() =>
       removePortFileIfOwned(join(tmpdir(), 'md-redline-portfile-nonexistent'), 6373),
     ).not.toThrow();
+  });
+});
+
+describe('writePortFile', () => {
+  it('records the port in the form removePortFileIfOwned recognizes', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'md-redline-portfile-'));
+    const portFile = join(dir, 'md-redline.port');
+
+    expect(await writePortFile(portFile, 6373)).toBe(true);
+    expect(await readFile(portFile, 'utf8')).toBe('6373');
+    // The two halves have to agree on the format or a server never cleans up
+    // after itself.
+    removePortFileIfOwned(portFile, 6373);
+    await expect(readFile(portFile, 'utf8')).rejects.toThrow();
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('replaces a stale file left by an unclean exit', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'md-redline-portfile-'));
+    const portFile = join(dir, 'md-redline.port');
+    await writeFile(portFile, '6374');
+
+    expect(await writePortFile(portFile, 6373)).toBe(true);
+    expect(await readFile(portFile, 'utf8')).toBe('6373');
+    // No temp file may survive in tmpdir, where nothing ever cleans it up.
+    expect((await readdir(dir)).filter((e) => e.endsWith('.tmp'))).toEqual([]);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('reports failure instead of throwing, so a boot is never lost to it', async () => {
+    // The port file is a hint the CLI can do without: it falls back to
+    // scanning the port range. Rejecting here used to reach process.exit(1)
+    // and stop a server that was already listening.
+    const portFile = join(tmpdir(), 'md-redline-portfile-no-such-dir', 'md-redline.port');
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      expect(await writePortFile(portFile, 6373)).toBe(false);
+      expect(String(logged.mock.calls[0][0])).toContain('Could not record the port');
+    } finally {
+      logged.mockRestore();
+    }
   });
 });

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   mkdtemp,
   mkdir,
@@ -41,6 +41,38 @@ vi.mock('fs', async (importOriginal) => {
         throw err;
       }
       return actual.readFileSync(path, encoding);
+    },
+  };
+});
+
+// Fails the rename inside atomicWriteFile, which is how a save bounces off a
+// scanner on Windows. Scoped to the temp-file suffix so it only ever catches a
+// save in progress, and armed per test, off by default: every other test in
+// this file runs against a clean filesystem.
+// `target` narrows the fault to saves landing on one file, which is what makes
+// a mid-batch failure (and the rollback of the files already written) stageable.
+const saveFault = vi.hoisted(() => ({
+  failuresLeft: 0,
+  code: 'EPERM',
+  attempts: 0,
+  target: '',
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  return {
+    ...actual,
+    rename: async (from: string, to: string) => {
+      if (!String(from).endsWith('.tmp')) return actual.rename(from, to);
+      if (!String(to).endsWith(saveFault.target)) return actual.rename(from, to);
+      saveFault.attempts += 1;
+      if (saveFault.failuresLeft > 0) {
+        saveFault.failuresLeft -= 1;
+        const err: NodeJS.ErrnoException = new Error(`${saveFault.code}: simulated`);
+        err.code = saveFault.code;
+        throw err;
+      }
+      return actual.rename(from, to);
     },
   };
 });
@@ -4346,6 +4378,184 @@ describe('removePortFileIfOwned', () => {
     expect(() =>
       removePortFileIfOwned(join(tmpdir(), 'md-redline-portfile-nonexistent'), 6373),
     ).not.toThrow();
+  });
+});
+
+describe('save path under filesystem faults', () => {
+  // Every atomicWriteFile call site in this file is otherwise exercised only
+  // against a clean filesystem, so the retry's interaction with the writeLocks
+  // chain, the rollback and the expectedMtime check went untested. These arm
+  // the rename fault, which is how a save bounces off a scanner on Windows.
+  const REAL_PLATFORM = process.platform;
+  let faultFile: string;
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  }
+
+  function save(path: string, content: string, expectedMtime?: number) {
+    return requestJson(app, '/api/file', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path, content, ...(expectedMtime != null ? { expectedMtime } : {}) }),
+    });
+  }
+
+  beforeAll(async () => {
+    faultFile = join(docsDir, 'fault-injection.md');
+  });
+
+  beforeEach(async () => {
+    saveFault.failuresLeft = 0;
+    saveFault.code = 'EPERM';
+    saveFault.attempts = 0;
+    saveFault.target = '';
+    setPlatform(REAL_PLATFORM);
+    await writeFile(faultFile, '# Original\n');
+  });
+
+  afterEach(async () => {
+    setPlatform(REAL_PLATFORM);
+    saveFault.failuresLeft = 0;
+    saveFault.target = '';
+    await rm(faultFile, { force: true });
+  });
+
+  it('reports a failed save as a failure and leaves the file untouched', async () => {
+    // The one outcome that must never happen: 200 with the old bytes on disk,
+    // which tells the editor its content is safe when it is not.
+    saveFault.failuresLeft = Number.MAX_SAFE_INTEGER;
+
+    const { response } = await save(faultFile, '# Saved\n');
+
+    expect(response.status).toBe(500);
+    expect(await readFile(faultFile, 'utf-8')).toBe('# Original\n');
+    expect((await readdir(docsDir)).filter((e) => e.endsWith('.tmp'))).toEqual([]);
+  });
+
+  it('rides out a bounced save on Windows without the client seeing it', async () => {
+    setPlatform('win32');
+    saveFault.failuresLeft = 3;
+
+    const { response } = await save(faultFile, '# Saved\n');
+
+    expect(response.status).toBe(200);
+    expect(await readFile(faultFile, 'utf-8')).toBe('# Saved\n');
+    expect(saveFault.attempts).toBe(4);
+  });
+
+  it('does not wedge the writeLocks chain when a save fails', async () => {
+    // A failed write leaves a rejected promise in the per-path lock chain. If
+    // the next save inherits it, the file is locked out of saving for the rest
+    // of the session, which is worse than the failure that caused it.
+    saveFault.failuresLeft = Number.MAX_SAFE_INTEGER;
+    expect((await save(faultFile, '# Lost\n')).response.status).toBe(500);
+
+    saveFault.failuresLeft = 0;
+    const { response } = await save(faultFile, '# Recovered\n');
+
+    expect(response.status).toBe(200);
+    expect(await readFile(faultFile, 'utf-8')).toBe('# Recovered\n');
+  });
+
+  it('lets a queued save through when the one ahead of it fails', async () => {
+    // Same hazard, one step earlier: the second request chains onto the first
+    // while it is still in flight, so it takes the rejection directly rather
+    // than finding the map already cleaned up.
+    saveFault.failuresLeft = 1;
+    const [first, second] = await Promise.all([
+      save(faultFile, '# First\n'),
+      save(faultFile, '# Second\n'),
+    ]);
+
+    // Which of the two reaches the lock first is up to the event loop, so the
+    // invariant is what gets asserted: one save fails, the other still lands.
+    // Before the fix both came back 500, the second without a write attempted.
+    const statuses = [first.response.status, second.response.status].sort();
+    expect(statuses).toEqual([200, 500]);
+    expect(await readFile(faultFile, 'utf-8')).toBe(
+      first.response.status === 200 ? '# First\n' : '# Second\n',
+    );
+  });
+
+  it('keeps the conflict check ahead of the write when the write then fails', async () => {
+    // A stale expectedMtime must lose to the conflict branch, not to the write
+    // fault: a 500 here would send the editor into retry instead of showing
+    // the user the external edit it is about to destroy.
+    const first = await save(faultFile, '# Version 1\n');
+    expect(first.response.status).toBe(200);
+
+    await writeFile(faultFile, '# External edit\n', 'utf-8');
+    const future = new Date(Date.now() + 5000);
+    await utimes(faultFile, future, future);
+    saveFault.attempts = 0;
+    saveFault.failuresLeft = Number.MAX_SAFE_INTEGER;
+
+    const { response, body } = await save(faultFile, '# Version 2\n', first.body.mtime as number);
+
+    expect(response.status).toBe(409);
+    expect(body.code).toBe('CONFLICT');
+    expect(await readFile(faultFile, 'utf-8')).toBe('# External edit\n');
+    // The conflict short-circuits before the write, so the fault never fired.
+    expect(saveFault.attempts).toBe(0);
+  });
+
+  it('saves through a bounce when expectedMtime matches', async () => {
+    setPlatform('win32');
+    const first = await save(faultFile, '# Version 1\n');
+    saveFault.failuresLeft = 2;
+
+    const { response } = await save(faultFile, '# Version 2\n', first.body.mtime as number);
+
+    expect(response.status).toBe(200);
+    expect(await readFile(faultFile, 'utf-8')).toBe('# Version 2\n');
+  });
+
+  it('rolls the batch back when a later file in it cannot be written', async () => {
+    // The rollback exists for exactly this: a multi-file agent batch that
+    // fails partway leaves markers in the files it already wrote, and the
+    // agent is told the batch failed. Only a write fault reaches it, so it
+    // had never run.
+    const dir = await realpath(await mkdtemp(join(tmpdir(), 'mdr-rollback-')));
+    const first = join(dir, 'first.md');
+    const second = join(dir, 'second.md');
+    const secondOriginal = '# Second\n\nBravo anchor here.\n';
+    await writeFile(first, '# First\n\nAlpha anchor here.\n', 'utf8');
+    await writeFile(second, secondOriginal, 'utf8');
+
+    const { app: testApp } = await buildTestApp({ allowedRoots: [dir] });
+    const create = await testApp.request('/api/review-sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ filePaths: [first, second], origin: 'agent' }),
+    });
+    const { sessionId } = (await create.json()) as { sessionId: string };
+
+    saveFault.target = 'second.md';
+    saveFault.failuresLeft = Number.MAX_SAFE_INTEGER;
+
+    const res = await testApp.request(`/api/review-sessions/${sessionId}/agent-comments`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        questions: [
+          { filePath: first, anchor: 'Alpha anchor', text: 'a?' },
+          { filePath: second, anchor: 'Bravo anchor', text: 'b?' },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(500);
+    expect((await res.json()) as { error: string }).toMatchObject({
+      error: expect.stringContaining('rolled back'),
+    });
+    // The marker that DID land has to come back out, or the user is left
+    // answering half a question set the agent never received.
+    expect(await readFile(first, 'utf8')).not.toMatch(/agentInitiated/);
+    expect(await readFile(second, 'utf8')).toBe(secondOriginal);
+    expect((await readdir(dir)).filter((e) => e.endsWith('.tmp'))).toEqual([]);
+
+    await rm(dir, { recursive: true, force: true });
   });
 });
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -1536,6 +1536,34 @@ export function removePortFileIfOwned(portFile: string, port: number): void {
   }
 }
 
+/**
+ * Record the listening port for the CLI's fast-path lookup.
+ *
+ * Best effort by design. The file is a hint: when it is missing or stale the
+ * CLI scans the port range instead and finds the server anyway. It used to be
+ * written with an unretried O_EXCL open whose only error path was the boot
+ * handler's `process.exit(1)`, which turned one bounced syscall in
+ * `os.tmpdir()` — among the most heavily scanned directories on Windows — into
+ * a server that never starts, before the user reaches a document at all.
+ *
+ * atomicWriteFile brings the retry and keeps the symlink safety the O_EXCL was
+ * there for: the temp file is created with O_EXCL and the rename replaces
+ * whatever sits at the destination rather than writing through it.
+ */
+export async function writePortFile(portFile: string, port: number): Promise<boolean> {
+  try {
+    await atomicWriteFile(portFile, String(port));
+    return true;
+  } catch (err) {
+    console.error(
+      `Could not record the port at ${portFile}; ` +
+        'the CLI will fall back to scanning for this server:',
+      err,
+    );
+    return false;
+  }
+}
+
 function tryListen(appFetch: typeof app.fetch, port: number): Promise<number> {
   return new Promise((res, rej) => {
     const server = serve({ fetch: appFetch, port, hostname: '127.0.0.1' }, () => res(port));
@@ -1561,23 +1589,7 @@ async function findAvailablePort(appFetch: typeof app.fetch): Promise<number> {
 if (isMainModule) {
   findAvailablePort(app.fetch)
     .then(async (port) => {
-      // Write port file safely: use O_EXCL to prevent symlink clobber attacks.
-      // If the file already exists (previous unclean exit), unlink it first
-      // to avoid following a symlink that may have replaced the stale file.
-      try {
-        const fd = await open(PORT_FILE, 'wx');
-        await fd.writeFile(String(port));
-        await fd.close();
-      } catch (e) {
-        if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
-          unlinkSync(PORT_FILE);
-          const fd = await open(PORT_FILE, 'wx');
-          await fd.writeFile(String(port));
-          await fd.close();
-        } else {
-          throw e;
-        }
-      }
+      await writePortFile(PORT_FILE, port);
       if (updatesEnabled) void updateChecker.start();
       console.log(`md-redline server running on http://127.0.0.1:${port}`);
       const initialArg = process.argv[2] ? resolve(process.cwd(), process.argv[2]) : '';

--- a/server/index.ts
+++ b/server/index.ts
@@ -578,6 +578,13 @@ export function createAppFull(options: CreateAppOptions = {}) {
     const prevLock = writeLocks.get(resolved) ?? Promise.resolve();
     let result!: T;
     const currentWrite = prevLock
+      // Wait for the write ahead of us to SETTLE, not to succeed. Chaining
+      // with a bare .then() means a rejection ahead in the queue skips our
+      // callback entirely and surfaces as our failure: our own write is never
+      // attempted, and the caller is told its content did not land when
+      // nothing was ever tried. The failure belongs to the request that
+      // caused it, which is awaiting this same promise and reports it.
+      .catch(() => {})
       .then(async () => {
         result = await fn();
       })
@@ -820,6 +827,12 @@ export function createAppFull(options: CreateAppOptions = {}) {
       const prevLock = writeLocks.get(resolved) ?? Promise.resolve();
       let conflictResponse: Response | null = null;
       const currentWrite = prevLock
+        // Settle, don't succeed — see withFileLock. A save that queued behind
+        // a failing one used to inherit its rejection and answer 500 without
+        // ever attempting the write, and because each failure became the next
+        // request's prevLock, one bounced save could take the whole queue
+        // behind it down with it.
+        .catch(() => {})
         .then(async () => {
           // Conflict detection: if the client sent an expectedMtime, verify the
           // file hasn't been modified externally since the client last loaded it.

--- a/server/index.ts
+++ b/server/index.ts
@@ -827,7 +827,7 @@ export function createAppFull(options: CreateAppOptions = {}) {
       const prevLock = writeLocks.get(resolved) ?? Promise.resolve();
       let conflictResponse: Response | null = null;
       const currentWrite = prevLock
-        // Settle, don't succeed — see withFileLock. A save that queued behind
+        // Settle, don't succeed. See withFileLock. A save that queued behind
         // a failing one used to inherit its rejection and answer 500 without
         // ever attempting the write, and because each failure became the next
         // request's prevLock, one bounced save could take the whole queue
@@ -1556,8 +1556,8 @@ export function removePortFileIfOwned(portFile: string, port: number): void {
  * CLI scans the port range instead and finds the server anyway. It used to be
  * written with an unretried O_EXCL open whose only error path was the boot
  * handler's `process.exit(1)`, which turned one bounced syscall in
- * `os.tmpdir()` — among the most heavily scanned directories on Windows — into
- * a server that never starts, before the user reaches a document at all.
+ * `os.tmpdir()`, among the most heavily scanned directories on Windows, into a
+ * server that never starts, before the user reaches a document at all.
  *
  * atomicWriteFile brings the retry and keeps the symlink safety the O_EXCL was
  * there for: the temp file is created with O_EXCL and the rename replaces

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { bodyLimit } from 'hono/body-limit';
 import { serve } from '@hono/node-server';
-import { readFile, readdir, stat, realpath, open } from 'fs/promises';
+import { readFile, readdir, stat, realpath, open, unlink } from 'fs/promises';
 import { promises as fsPromises } from 'fs';
 import { watch, statSync, realpathSync, readFileSync, unlinkSync, type FSWatcher } from 'fs';
 import { join, extname, resolve, dirname } from 'path';
@@ -1568,6 +1568,14 @@ export async function writePortFile(portFile: string, port: number): Promise<boo
     await atomicWriteFile(portFile, String(port));
     return true;
   } catch (err) {
+    // Remove whatever is still there before falling back, because the fallback
+    // only works if the file is gone. The CLI reads this file FIRST and takes
+    // the port it names as soon as that port answers, scanning only when it
+    // does not. A stale entry naming a still-live orphan server from an
+    // earlier launch would therefore send the user's document to the orphan,
+    // which has its own trusted roots and its own watcher. The old boot path
+    // unlinked before rewriting and never left that window open.
+    await unlink(portFile).catch(() => {});
     console.error(
       `Could not record the port at ${portFile}; ` +
         'the CLI will fall back to scanning for this server:',

--- a/server/preferences.test.ts
+++ b/server/preferences.test.ts
@@ -476,7 +476,9 @@ describe('transient filesystem failures (Windows)', () => {
     try {
       await writePreferences(testDir, { author: 'Alice' });
       expect(logged).toHaveBeenCalledTimes(1);
-      expect(String(logged.mock.calls[0][0])).toContain('Could not release the preferences lock');
+      expect(String(logged.mock.calls[0][0])).toContain(
+        'Could not release the lock at ' + join(testDir, '.md-redline.json.lock'),
+      );
     } finally {
       logged.mockRestore();
       fault.unlink = { failuresLeft: 0, code: 'EBUSY' };

--- a/server/preferences.test.ts
+++ b/server/preferences.test.ts
@@ -107,11 +107,19 @@ async function expectRejectionCode(promise: Promise<unknown>, code: string): Pro
 
 let testDir: string;
 
+// The transient-code retries only run on Windows (see isTransientFsError), so
+// the fault-injection tests below have to declare that platform rather than
+// inheriting the runner's and passing or failing by accident. fs-retry.test.ts
+// owns the POSIX side.
+const REAL_PLATFORM = process.platform;
+
 beforeAll(async () => {
+  Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
   testDir = await mkdtemp(join(tmpdir(), 'md-redline-prefs-'));
 });
 
 afterAll(async () => {
+  Object.defineProperty(process, 'platform', { value: REAL_PLATFORM, configurable: true });
   await rm(testDir, { recursive: true });
 });
 

--- a/server/preferences.test.ts
+++ b/server/preferences.test.ts
@@ -8,6 +8,7 @@ import {
   readPreferencesResult,
   readPreferencesSync,
   readPreferencesSyncResult,
+  resetReadFailureReportingForTests,
   sanitizePreferencesPatch,
   writePreferences,
 } from './preferences';
@@ -124,6 +125,9 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
+  // Read failures are reported once per condition and the record outlives a
+  // single test, so a case asserting on that log has to start from a clean one.
+  resetReadFailureReportingForTests();
   fault.rename = { suffix: '.tmp', failuresLeft: 0, code: 'EPERM', attempts: 0 };
   fault.open = { suffix: '', failuresLeft: 0, code: 'EPERM' };
   fault.read = { failuresLeft: 0, code: 'EPERM', attempts: 0 };
@@ -614,6 +618,68 @@ describe('transient read failures', () => {
       expect(await readPreferences(testDir)).toEqual({});
       expect(logged).toHaveBeenCalledTimes(1);
       expect(String(logged.mock.calls[0][0])).toContain('Could not read preferences');
+    } finally {
+      logged.mockRestore();
+    }
+  });
+
+  it('reports a persistent read failure once, not once per request', async () => {
+    // GET /api/preferences reads the file per request and the client hydrates
+    // from several places on mount, so the same line was repeated several
+    // times per page load, indefinitely, burying the one that carried news.
+    await writeFile(join(testDir, '.md-redline.json'), JSON.stringify({ trustedRoots: [] }));
+    fault.read = { failuresLeft: Number.MAX_SAFE_INTEGER, code: 'EPERM', attempts: 0 };
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      await readPreferences(testDir);
+      await readPreferences(testDir);
+      readPreferencesSync(testDir);
+
+      expect(logged).toHaveBeenCalledTimes(1);
+    } finally {
+      logged.mockRestore();
+    }
+  });
+
+  it('reports again when the condition changes', async () => {
+    await writeFile(join(testDir, '.md-redline.json'), JSON.stringify({ trustedRoots: [] }));
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      fault.read = { failuresLeft: Number.MAX_SAFE_INTEGER, code: 'EPERM', attempts: 0 };
+      await readPreferences(testDir);
+      fault.read = { failuresLeft: Number.MAX_SAFE_INTEGER, code: 'EACCES', attempts: 0 };
+      await readPreferences(testDir);
+
+      expect(logged.mock.calls.map((call) => String(call[0]))).toEqual([
+        expect.stringContaining('(EPERM)'),
+        expect.stringContaining('(EACCES)'),
+      ]);
+    } finally {
+      logged.mockRestore();
+    }
+  });
+
+  it('says so when the file becomes readable again', async () => {
+    // Onset without recovery leaves the log claiming a problem that is over.
+    await writeFile(join(testDir, '.md-redline.json'), JSON.stringify({ author: 'Alice' }));
+    const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      fault.read = { failuresLeft: Number.MAX_SAFE_INTEGER, code: 'EPERM', attempts: 0 };
+      await readPreferences(testDir);
+      fault.read = { failuresLeft: 0, code: 'EPERM', attempts: 0 };
+      expect(await readPreferences(testDir)).toEqual({ author: 'Alice' });
+      // And the next failure is news again, not swallowed by the old record.
+      fault.read = { failuresLeft: Number.MAX_SAFE_INTEGER, code: 'EPERM', attempts: 0 };
+      await readPreferences(testDir);
+
+      expect(logged.mock.calls.map((call) => String(call[0]))).toEqual([
+        expect.stringContaining('Could not read preferences'),
+        expect.stringContaining('are readable again'),
+        expect.stringContaining('Could not read preferences'),
+      ]);
     } finally {
       logged.mockRestore();
     }

--- a/server/preferences.test.ts
+++ b/server/preferences.test.ts
@@ -437,13 +437,21 @@ describe('corrupted prefs quarantine', () => {
     const logs = captureErrors();
     try {
       await writePreferences(testDir, { author: 'Alice' });
+      // Corrupt it again so the SECOND write re-enters the quarantine path
+      // with the rename still failing. Without this the file is valid JSON by
+      // then and the second write never reaches the branch under test, so the
+      // case would pass whether or not a failed quarantine wedges anything.
+      await writeFile(join(testDir, '.md-redline.json'), '{ broken again');
       fault.rename.failuresLeft = Number.MAX_SAFE_INTEGER;
       await writePreferences(testDir, { theme: 'dark' });
     } finally {
       logs.restore();
     }
 
-    expect(await readPreferences(testDir)).toEqual({ author: 'Alice', theme: 'dark' });
+    // The second write started from a quarantine that failed, so it merges
+    // onto {} rather than onto the earlier author.
+    expect(await readPreferences(testDir)).toEqual({ theme: 'dark' });
+    expect(logs.messages.filter((m) => m.includes('could not be moved to'))).toHaveLength(2);
   });
 
   it('does not quarantine a healthy prefs file', async () => {

--- a/server/preferences.test.ts
+++ b/server/preferences.test.ts
@@ -319,6 +319,19 @@ describe('addTrustedRoot', () => {
 });
 
 describe('corrupted prefs quarantine', () => {
+  /**
+   * Quarantining always logs now, so tests that trigger it capture stderr.
+   * Messages are recorded as they arrive rather than read off `mock.calls`
+   * afterwards, because mockRestore() clears that history.
+   */
+  function captureErrors(): { messages: string[]; restore: () => void } {
+    const messages: string[] = [];
+    const spy = vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      messages.push(String(args[0]));
+    });
+    return { messages, restore: () => spy.mockRestore() };
+  }
+
   it('moves an unparseable prefs file aside instead of overwriting it', async () => {
     // Seed a corrupt file directly
     const prefsFile = join(testDir, '.md-redline.json');
@@ -326,7 +339,18 @@ describe('corrupted prefs quarantine', () => {
 
     // The next write must NOT silently obliterate the corrupt content. The
     // implementation moves the corrupt file to a `.corrupt-<ts>` sibling.
-    await writePreferences(testDir, { author: 'Recovered' });
+    const logs = captureErrors();
+    try {
+      await writePreferences(testDir, { author: 'Recovered' });
+    } finally {
+      logs.restore();
+    }
+
+    // Silence is what makes settings appear to vanish on their own: the log is
+    // how the user learns the copy exists and where it is.
+    const moved = logs.messages.find((m) => m.includes('Moved the file to'));
+    expect(moved).toContain('not valid JSON');
+    expect(moved).toContain('.md-redline.json.corrupt-');
 
     const entries = await readdir(testDir);
     const quarantined = entries.find(
@@ -347,7 +371,13 @@ describe('corrupted prefs quarantine', () => {
     const prefsFile = join(testDir, '.md-redline.json');
     await writeFile(prefsFile, '["not", "an", "object"]');
 
-    await writePreferences(testDir, { theme: 'dark' });
+    const logs = captureErrors();
+    try {
+      await writePreferences(testDir, { theme: 'dark' });
+    } finally {
+      logs.restore();
+    }
+    expect(logs.messages.some((m) => m.includes('not a JSON object'))).toBe(true);
 
     const entries = await readdir(testDir);
     expect(
@@ -356,6 +386,60 @@ describe('corrupted prefs quarantine', () => {
 
     const fresh = await readPreferences(testDir);
     expect(fresh).toEqual({ theme: 'dark' });
+  });
+
+  it('warns that the bytes are about to be lost when the move fails', async () => {
+    // The failure path is the one that matters: the write proceeds over the
+    // original either way, so this log is the user's only warning that their
+    // settings are being destroyed rather than set aside.
+    await writeFile(join(testDir, '.md-redline.json'), '{ this is not json');
+    // Scoped to the prefs path, so atomicWriteFile's own `.tmp` rename still
+    // works and the write below actually lands.
+    fault.rename = {
+      suffix: '.md-redline.json',
+      failuresLeft: Number.MAX_SAFE_INTEGER,
+      code: 'EPERM',
+      attempts: 0,
+    };
+
+    const logs = captureErrors();
+    try {
+      await expect(writePreferences(testDir, { author: 'Alice' })).resolves.toEqual({
+        author: 'Alice',
+      });
+    } finally {
+      logs.restore();
+    }
+
+    const warning = logs.messages.find((m) => m.includes('could not be moved to'));
+    expect(warning).toContain('cannot be recovered');
+    // Retried, not attempted once: a bounced rename on Windows is exactly the
+    // case where a second try saves the file.
+    expect(fault.rename.attempts).toBe(5);
+  });
+
+  it('keeps saving settings after a failed quarantine', async () => {
+    // Refusing to write would be the safer-looking choice and the wrong one:
+    // it would leave the app unable to persist a single setting until the
+    // user cleaned up by hand.
+    await writeFile(join(testDir, '.md-redline.json'), '{ this is not json');
+    fault.rename = {
+      suffix: '.md-redline.json',
+      failuresLeft: Number.MAX_SAFE_INTEGER,
+      code: 'EPERM',
+      attempts: 0,
+    };
+
+    const logs = captureErrors();
+    try {
+      await writePreferences(testDir, { author: 'Alice' });
+      fault.rename.failuresLeft = Number.MAX_SAFE_INTEGER;
+      await writePreferences(testDir, { theme: 'dark' });
+    } finally {
+      logs.restore();
+    }
+
+    expect(await readPreferences(testDir)).toEqual({ author: 'Alice', theme: 'dark' });
   });
 
   it('does not quarantine a healthy prefs file', async () => {

--- a/server/preferences.ts
+++ b/server/preferences.ts
@@ -216,6 +216,36 @@ export function readPreferencesSync(homeDir: string): Preferences {
 }
 
 /**
+ * Move a prefs file we cannot parse out of the way, so the write that follows
+ * does not land on top of it. These are the user's own settings, and after
+ * that write they are gone, so neither outcome may be silent: on success the
+ * log is how they find the copy, and on failure it is the only warning they
+ * will ever get that the bytes are about to be destroyed.
+ *
+ * The rename is retried, which off Windows is a single attempt anyway. What it
+ * must not do is throw: the caller cannot proceed with a file it cannot read,
+ * and refusing to write would leave the app unable to save a setting ever
+ * again until the user intervened by hand.
+ */
+async function quarantineCorruptPrefs(filePath: string, reason: string): Promise<void> {
+  const quarantinePath = corruptQuarantinePath(filePath);
+  try {
+    await retryTransient(() => rename(filePath, quarantinePath));
+    console.error(
+      `Preferences at ${filePath} were ${reason}. Moved the file to ` +
+        `${quarantinePath} and starting fresh.`,
+    );
+  } catch (err) {
+    console.error(
+      `Preferences at ${filePath} were ${reason} and could not be moved to ` +
+        `${quarantinePath}. The next write overwrites them and they cannot be ` +
+        'recovered afterwards:',
+      err,
+    );
+  }
+}
+
+/**
  * Read the prefs file and parse it. If the file exists but is unparseable,
  * MOVE it to a quarantine path before returning {}, so the next write does
  * not silently overwrite a file the user might want to recover. The
@@ -238,7 +268,7 @@ async function readAndQuarantineIfCorrupt(filePath: string): Promise<Preferences
     const parsed = JSON.parse(raw);
     if (!isPlainObject(parsed)) {
       // Structurally wrong (array / null / scalar). Quarantine and start fresh.
-      await rename(filePath, corruptQuarantinePath(filePath)).catch(() => {});
+      await quarantineCorruptPrefs(filePath, 'not a JSON object');
       return {};
     }
     // Strip unknown keys / wrong-typed fields before merging. The cast is
@@ -247,7 +277,7 @@ async function readAndQuarantineIfCorrupt(filePath: string): Promise<Preferences
     return sanitizePreferencesPatch(parsed) as Preferences;
   } catch {
     // Unparseable. Quarantine before the next write overwrites it.
-    await rename(filePath, corruptQuarantinePath(filePath)).catch(() => {});
+    await quarantineCorruptPrefs(filePath, 'not valid JSON');
     return {};
   }
 }

--- a/server/preferences.ts
+++ b/server/preferences.ts
@@ -1,14 +1,9 @@
-import { readFile, rename, open, stat, unlink } from 'fs/promises';
+import { readFile, rename } from 'fs/promises';
 import { readFileSync } from 'fs';
 import { randomBytes } from 'crypto';
 import { join } from 'path';
-import {
-  atomicWriteFile,
-  isTransientFsError,
-  retryTransient,
-  retryTransientSync,
-  sleep,
-} from './fs-retry';
+import { atomicWriteFile, retryTransient, retryTransientSync } from './fs-retry';
+import { acquireFileLock } from '../bin/file-lock.js';
 import {
   DOC_WIDTHS,
   PROSE_FONTS,
@@ -18,10 +13,6 @@ import {
 } from '../src/lib/settings';
 
 const PREFS_FILENAME = '.md-redline.json';
-const LOCK_SUFFIX = '.lock';
-const LOCK_STALE_MS = 30_000;
-const LOCK_MAX_ATTEMPTS = 60;
-const LOCK_RETRY_BASE_MS = 25;
 
 export interface RecentFile {
   path: string;
@@ -222,92 +213,6 @@ export async function readPreferences(homeDir: string): Promise<Preferences> {
 
 export function readPreferencesSync(homeDir: string): Preferences {
   return readPreferencesSyncResult(homeDir).prefs;
-}
-
-/**
- * Acquire a cross-process lock on the preferences file before performing a
- * read-modify-write. The in-process `writeLock` only serializes within a
- * single Node process; running two `mdr` instances against the same home
- * directory would otherwise race the read+write cycle and lose updates.
- *
- * Implementation: O_EXCL sentinel file. If the lock is older than
- * LOCK_STALE_MS we treat it as abandoned (the holder crashed) and steal it.
- */
-async function acquireFileLock(filePath: string): Promise<() => Promise<void>> {
-  const lockPath = `${filePath}${LOCK_SUFFIX}`;
-  for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
-    let fd;
-    try {
-      fd = await open(lockPath, 'wx');
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code !== 'EEXIST') {
-        // The lock file is created and removed on every write, which makes it
-        // the same scanner bait as the temp file. Back off on the transient
-        // codes instead of failing the whole write.
-        if (!isTransientFsError(err)) throw err;
-        await sleep(LOCK_RETRY_BASE_MS);
-        continue;
-      }
-      // Lock exists. If it's stale (holder crashed), steal it.
-      try {
-        const lockStat = await stat(lockPath);
-        if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
-          try {
-            await unlink(lockPath);
-          } catch {
-            /* someone else just released it */
-          }
-          continue;
-        }
-      } catch {
-        // Lock vanished between EEXIST and stat — retry immediately.
-        continue;
-      }
-      // Backoff with a small random jitter to avoid thundering herd.
-      await sleep(LOCK_RETRY_BASE_MS + Math.floor(Math.random() * LOCK_RETRY_BASE_MS));
-      continue;
-    }
-
-    // The lock file exists and is ours from here. Anything that fails before
-    // we return the release closure has to remove it, or the next attempt
-    // deadlocks against our own orphan: it is far too young for the
-    // stale-steal branch above, so the loop burns every remaining attempt and
-    // then blocks all writers until LOCK_STALE_MS elapses.
-    let writeErr: unknown;
-    try {
-      await fd.writeFile(`${process.pid}`);
-    } catch (err) {
-      writeErr = err;
-    }
-    // Close before unlinking: Windows refuses to remove a file that still has
-    // an open handle, which would defeat the cleanup below. The pid is only a
-    // debugging aid (staleness is decided by mtime), so a failed close on the
-    // success path is not worth failing the write over.
-    await fd.close().catch(() => {});
-    if (writeErr) {
-      await unlink(lockPath).catch(() => {});
-      if (!isTransientFsError(writeErr)) throw writeErr;
-      await sleep(LOCK_RETRY_BASE_MS);
-      continue;
-    }
-
-    return async () => {
-      try {
-        await retryTransient(() => unlink(lockPath));
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
-        // An orphaned lock blocks every writer, in this process and any other
-        // mdr instance, until it ages out. Never silent.
-        console.error(
-          `Could not release the preferences lock at ${lockPath}; writes are ` +
-            `blocked until it ages out after ${LOCK_STALE_MS}ms:`,
-          err,
-        );
-      }
-    };
-  }
-  throw new Error(`Could not acquire preferences lock at ${lockPath}`);
 }
 
 /**

--- a/server/preferences.ts
+++ b/server/preferences.ts
@@ -175,13 +175,33 @@ export interface PreferencesRead {
   unreadable: boolean;
 }
 
+/**
+ * Errno of the last reported read failure, per prefs path, or absent once a
+ * read succeeds again.
+ *
+ * GET /api/preferences reads the file on every request, and the client hydrates
+ * from several places on mount and polls every five minutes after that. A
+ * persistently unreadable file therefore repeated the same line several times
+ * per page load, forever, which buries the one occurrence that carried
+ * information. Reported once per distinct condition instead, and again when it
+ * changes or clears.
+ */
+const reportedReadFailures = new Map<string, string>();
+
 function emptyOnReadFailure(err: unknown, homeDir: string): PreferencesRead {
   const code = (err as NodeJS.ErrnoException).code;
   // ENOENT is the ordinary "no prefs yet" case; a SyntaxError has no code.
   const unreadable = !!code && code !== 'ENOENT';
-  if (unreadable) {
+  const path = prefsPath(homeDir);
+  if (!unreadable) {
+    // The file is gone, or it parsed badly having been read fine. Either way
+    // whatever was blocking reads no longer is, and a later recurrence is news
+    // again. Silent: neither case is worth a line of its own here.
+    reportedReadFailures.delete(path);
+  } else if (reportedReadFailures.get(path) !== code) {
+    reportedReadFailures.set(path, code as string);
     console.error(
-      `Could not read preferences at ${prefsPath(homeDir)} (${code}); ` +
+      `Could not read preferences at ${path} (${code}); ` +
         'continuing without saved settings for this session:',
       err,
     );
@@ -189,9 +209,23 @@ function emptyOnReadFailure(err: unknown, homeDir: string): PreferencesRead {
   return { prefs: {}, unreadable };
 }
 
+/** Close the loop on a reported failure, so recovery is as visible as onset. */
+function noteReadSucceeded(homeDir: string): void {
+  const path = prefsPath(homeDir);
+  if (reportedReadFailures.delete(path)) {
+    console.error(`Preferences at ${path} are readable again.`);
+  }
+}
+
+/** Only for tests, which share a module instance across cases. */
+export function resetReadFailureReportingForTests(): void {
+  reportedReadFailures.clear();
+}
+
 export async function readPreferencesResult(homeDir: string): Promise<PreferencesRead> {
   try {
     const raw = await retryTransient(() => readFile(prefsPath(homeDir), 'utf-8'));
+    noteReadSucceeded(homeDir);
     return { prefs: sanitizePreferencesPatch(JSON.parse(raw)) as Preferences, unreadable: false };
   } catch (err) {
     return emptyOnReadFailure(err, homeDir);
@@ -201,6 +235,7 @@ export async function readPreferencesResult(homeDir: string): Promise<Preference
 export function readPreferencesSyncResult(homeDir: string): PreferencesRead {
   try {
     const raw = retryTransientSync(() => readFileSync(prefsPath(homeDir), 'utf-8'));
+    noteReadSucceeded(homeDir);
     return { prefs: sanitizePreferencesPatch(JSON.parse(raw)) as Preferences, unreadable: false };
   } catch (err) {
     return emptyOnReadFailure(err, homeDir);

--- a/src/lib/preferences-client.test.ts
+++ b/src/lib/preferences-client.test.ts
@@ -3,6 +3,7 @@ import {
   fetchPreferences,
   savePreferencesToDisk,
   migrateLocalStorageToDisk,
+  resetPreferencesRequestForTests,
 } from './preferences-client';
 
 // Mock localStorage
@@ -32,6 +33,7 @@ beforeEach(() => {
   localStorageMock.clear();
   mockFetch.mockReset();
   vi.clearAllMocks();
+  resetPreferencesRequestForTests();
 });
 
 function jsonResponse(body: unknown, init?: ResponseInit) {
@@ -52,6 +54,47 @@ describe('fetchPreferences', () => {
     mockFetch.mockResolvedValue(jsonResponse({ error: 'boom' }, { status: 500 }));
     const result = await fetchPreferences();
     expect(result).toEqual({});
+  });
+
+  it('serves concurrent callers from one request', async () => {
+    // Settings, theme, author, recent files and the localStorage migration all
+    // hydrate on mount. Five requests per page load meant the server read and
+    // parsed the same file five times, each read carrying the full filesystem
+    // retry budget on Windows.
+    let release: (value: Response) => void = () => {};
+    mockFetch.mockReturnValue(
+      new Promise<Response>((res) => {
+        release = res;
+      }),
+    );
+
+    const all = Promise.all([fetchPreferences(), fetchPreferences(), fetchPreferences()]);
+    release(jsonResponse({ author: 'Alice' }));
+
+    expect(await all).toEqual([{ author: 'Alice' }, { author: 'Alice' }, { author: 'Alice' }]);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not serve a later caller a stale result', async () => {
+    // Sharing is scoped to a request in flight, not cached. The update
+    // notice polls this every five minutes and has to see saves made since.
+    mockFetch.mockResolvedValueOnce(jsonResponse({ author: 'Alice' }));
+    expect(await fetchPreferences()).toEqual({ author: 'Alice' });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ author: 'Bob' }));
+    expect(await fetchPreferences()).toEqual({ author: 'Bob' });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not wedge every later caller when a request fails', async () => {
+    // The shared promise has to be released on the failure path too, or one
+    // unreachable server leaves the app unable to read preferences until a
+    // reload.
+    mockFetch.mockRejectedValueOnce(new Error('offline'));
+    expect(await fetchPreferences()).toEqual({});
+
+    mockFetch.mockResolvedValueOnce(jsonResponse({ author: 'Alice' }));
+    expect(await fetchPreferences()).toEqual({ author: 'Alice' });
   });
 
   it('returns empty object on invalid JSON response', async () => {

--- a/src/lib/preferences-client.ts
+++ b/src/lib/preferences-client.ts
@@ -14,9 +14,20 @@ export interface DiskPreferences {
   updateDismissedVersion?: string;
 }
 
+/**
+ * Ceiling on a single preferences read. The server answers this from a local
+ * file in milliseconds, so anything near this is a request that will never
+ * come back: the dev server killed mid-request, the Vite proxy losing its
+ * backend, a suspended laptop dropping the socket without an RST. Without a
+ * bound, one of those would pin the shared promise below forever.
+ */
+const PREFERENCES_FETCH_TIMEOUT_MS = 10_000;
+
 async function requestPreferences(): Promise<DiskPreferences> {
   try {
-    const res = await fetch('/api/preferences');
+    const res = await fetch('/api/preferences', {
+      signal: AbortSignal.timeout(PREFERENCES_FETCH_TIMEOUT_MS),
+    });
     const data = await readJsonResponse<DiskPreferences>(res);
     if (!res.ok || !data) return {};
     return data;
@@ -45,9 +56,13 @@ let inFlight: Promise<DiskPreferences> | null = null;
  */
 export function fetchPreferences(): Promise<DiskPreferences> {
   if (!inFlight) {
-    inFlight = requestPreferences().finally(() => {
-      inFlight = null;
+    const pending: Promise<DiskPreferences> = requestPreferences().finally(() => {
+      // Identity-checked: a reset (or any future invalidation) can replace
+      // `inFlight` while this request is still open, and clearing
+      // unconditionally would null out the newer promise instead of its own.
+      if (inFlight === pending) inFlight = null;
     });
+    inFlight = pending;
   }
   return inFlight;
 }

--- a/src/lib/preferences-client.ts
+++ b/src/lib/preferences-client.ts
@@ -14,7 +14,7 @@ export interface DiskPreferences {
   updateDismissedVersion?: string;
 }
 
-export async function fetchPreferences(): Promise<DiskPreferences> {
+async function requestPreferences(): Promise<DiskPreferences> {
   try {
     const res = await fetch('/api/preferences');
     const data = await readJsonResponse<DiskPreferences>(res);
@@ -23,6 +23,38 @@ export async function fetchPreferences(): Promise<DiskPreferences> {
   } catch {
     return {};
   }
+}
+
+let inFlight: Promise<DiskPreferences> | null = null;
+
+/**
+ * Read the on-disk preferences, sharing a request already in flight.
+ *
+ * Five independent consumers hydrate from this on mount (settings, theme,
+ * author, recent files, the localStorage migration) and each one used to open
+ * its own request, so every page load asked the server to read and parse the
+ * same file five times over. The server reads it per request, and on Windows
+ * each read can spend the whole filesystem retry budget, so the cost of the
+ * duplicates is not just a few extra sockets.
+ *
+ * Only concurrent calls share. The result is not cached, so the update
+ * notice's five-minute poll still sees fresh data, and a read that starts
+ * after a save reflects it. The one stale window is a call that joins a
+ * request already open when a save lands, which is a single request wide and
+ * behind every caller here, all of which read once on mount.
+ */
+export function fetchPreferences(): Promise<DiskPreferences> {
+  if (!inFlight) {
+    inFlight = requestPreferences().finally(() => {
+      inFlight = null;
+    });
+  }
+  return inFlight;
+}
+
+/** Only for tests, which share a module instance across cases. */
+export function resetPreferencesRequestForTests(): void {
+  inFlight = null;
 }
 
 export async function savePreferencesToDisk(patch: Partial<DiskPreferences>): Promise<boolean> {

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.bin.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    /* Bundler mode, matching tsconfig.node.json */
+    "moduleResolution": "bundler",
+    "noEmit": true,
+
+    /* The point of this project: bin/ is plain JS with no build step, so
+       without checkJs it is invisible to every static gate the repo has. The
+       filesystem primitives the CLI and the server share live here, and they
+       used to be strict-mode TypeScript. */
+    "allowJs": true,
+    "checkJs": true,
+
+    /* Baseline rather than the full `strict` of tsconfig.node.json. The
+       pre-existing modules here (ports, server-control, spawn-command,
+       version-compare) were written as untyped JS and predate this project;
+       demanding annotations on them would mean rewriting code this change has
+       no business touching. What IS caught everywhere is the class that
+       matters most for a file with no build step: undefined identifiers,
+       misspelled properties on known types, wrong arity, bad imports.
+
+       fs-atomic.js and file-lock.js carry JSDoc types, so they are checked as
+       thoroughly here as they were as TypeScript. */
+    "strict": false,
+    "noImplicitAny": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["bin/**/*.js"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.app.json" },
-    { "path": "./tsconfig.node.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.bin.json" }
   ]
 }


### PR DESCRIPTION
Every write of a user-visible file now goes through a crash-safe path with a
retry sized to the failure it is actually recovering from, and the shared
primitives that do it are finally covered by the type checker and the linter.

## What was wrong

**Saves could fail one syscall earlier than the retry covered.** `atomicWriteFile`
retried the rename but not the `open(tmpPath,'wx')` before it. Windows AV hooks
file creation just as readily as the move.

**The CLI had none of this.** `bin/` is plain JS and could not import
`server/fs-retry.ts`, so `mdr --restrict` and `mdr mcp install` wrote with a
bare `writeFile` while the server wrote atomically under a lock. The Claude
Desktop config is the worst case: it holds every other MCP server the user has
configured, and an interrupted write took all of them down.

**A bounced write in `os.tmpdir()` could stop the server from starting.** The
port file is a hint the CLI can do without, but its only error path was
`process.exit(1)`.

**A save queued behind a failing one inherited the rejection.** Both `writeLocks`
chains sequenced with a bare `prevLock.then()`, so the second request answered
500 without ever attempting its write, and each failure became the next
request's `prevLock`.

**A failed prefs quarantine destroyed the file it protects, silently.** Success
was silent too, so settings appeared to vanish on their own.

**Preferences were read five times per page load** and an unreadable file logged
the same line for every one of them, forever.

## What changed

The primitives move down to `bin/fs-atomic.js`, `bin/file-lock.js` and
`bin/home-dir.js` with `.d.ts` siblings, and the server imports them, the same
arrangement `server/env.ts` already had with `bin/ports.js`. One implementation
matters most for the lock: two writers taking different locks are not
serialized at all, and under `MD_REDLINE_HOME` the two sides were computing
different paths.

The retry gate is per errno, not per platform. EBUSY is contention everywhere,
including the SMB, NFS and FUSE mounts behind Dropbox, Google Drive and iCloud,
which is where these documents live. EPERM and EACCES are retried only on
win32, because on POSIX they mean a permanent permission condition.

`atomicWriteFile` also carries the destination's mode across, so a save no
longer relaxes a 0600 config to 0644.

## The tooling gap

`bin/**` matched no eslint block and no tsconfig, so `eslint bin/` exited 0
having checked nothing and `tsc` never read the directory. A call to an
undefined function survived both gates. That was tolerable when `bin/` held
four small helpers and is not now that it holds these primitives.
`tsconfig.bin.json` turns on `checkJs` and joins the solution build, eslint gets
a `bin/` block, and the two moved modules carry JSDoc types so they are checked
as thoroughly as when they were TypeScript. The same probe now exits 2.

## Verification

- 1888 unit tests pass, including new fault-injection coverage at the save call
  sites: a failed save reports failure and leaves the file untouched, a bounced
  save is invisible to the client, a failure does not wedge later saves or the
  one queued behind it, a stale `expectedMtime` still loses to the conflict
  branch rather than to the write fault, and a multi-file agent batch that fails
  partway rolls the earlier file back.
- 348 Playwright tests pass, 0 flaky.
- `tsc -b`, `eslint` and `npm run build` clean, with `bin/` genuinely covered
  for the first time.
- The Windows-only paths are exercised by pinning `process.platform` rather than
  inheriting the runner's, so both sides of every gate run on every OS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmbAmt7STTWrkaHFRSzDpw