### PR TITLE
Make the file lock know who holds it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,11 @@ An optional MCP stdio server lets AI agents request human review and wait for fe
   `.md-redline.json` takes around a read-modify-write. Shared so `mdr --restrict` and the server
   cannot interleave; its attempt budget derives from `FS_RETRY_BUDGET_MS`. Exhausting that budget
   throws `LockContentionError`; any other throw is a filesystem error with its errno intact, and
-  callers word their advice from that difference
+  callers word their advice from that difference. A lock older than `LOCK_STALE_MS` is stolen as
+  abandoned, so holding one is not the same as still holding it: each acquisition writes a
+  `pid uuid` token and release unlinks only a lock still carrying it. The module installs its own
+  SIGINT/SIGTERM/SIGHUP and `exit` handlers while any lock is held, removes them once the last one
+  is released, and re-raises the signal so the process still dies with the status it would have
 - `bin/home-dir.js`: `resolveHomeDir` (`MD_REDLINE_HOME` or the OS home), which decides where
   `.md-redline.json` lives. Shared because a CLI resolving it differently from the server locks
   and writes a file the server never reads

--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -9,7 +9,9 @@
  */
 
 import { open, readFile, stat, unlink } from 'fs/promises';
+import { readFileSync, unlinkSync } from 'fs';
 import { randomUUID } from 'crypto';
+import { constants as osConstants } from 'os';
 
 import { FS_RETRY_BUDGET_MS, isTransientFsError, retryTransient, sleep } from './fs-atomic.js';
 
@@ -46,6 +48,117 @@ const LOCK_MAX_ATTEMPTS = Math.ceil(LOCK_MAX_WAIT_MS / LOCK_RETRY_BASE_MS);
  */
 function mintHolderToken() {
   return `${process.pid} ${randomUUID()}`;
+}
+
+/**
+ * Locks this process holds right now, keyed by lock path, valued by the token
+ * that proves each one is ours. An interrupt between acquiring and the caller's
+ * `finally` leaves the file behind otherwise, and an orphan wedges every writer
+ * of that path (this process, another mdr, the server) until it ages out
+ * LOCK_STALE_MS later. `mdr --restrict` is the shortest way to see it: one
+ * Ctrl-C inside a window the user has no way to know they are in.
+ *
+ * @type {Map<string, string>}
+ */
+const heldLocks = new Map();
+
+/**
+ * Signals that terminate the process by default, so a caller's `finally` never
+ * runs. `exit` is separately necessary: it does NOT fire on a default signal
+ * death, and the signal handlers below do not fire when something else's
+ * handler calls process.exit first, which is exactly what the server does.
+ */
+const CLEANUP_SIGNALS = /** @type {const} */ (['SIGINT', 'SIGTERM', 'SIGHUP']);
+
+/** @type {Map<string, () => void>} */
+const installedSignalHandlers = new Map();
+let exitHandlerInstalled = false;
+
+/**
+ * Remove every lock still held, synchronously, because this is all that a
+ * signal handler or an `exit` listener can do. Ownership is re-checked the same
+ * way release does it: a lock stolen while we stalled belongs to someone else
+ * now, and taking it with us on the way out is the failure this module works
+ * hardest to prevent.
+ *
+ * Best effort by construction. Nothing is retried and no error is reported: the
+ * process is on its way out, there is no one left to tell, and a lock left
+ * behind here is the exact 30-second orphan that this path exists to make rare
+ * rather than certain.
+ */
+function releaseHeldLocksSync() {
+  for (const [lockPath, token] of heldLocks) {
+    try {
+      if (readFileSync(lockPath, 'utf-8') === token) unlinkSync(lockPath);
+    } catch {
+      /* already gone, or unreadable; either way there is nothing safe to do */
+    }
+  }
+  // Cleared whether or not each unlink worked, so a re-raised signal cannot
+  // walk this list a second time.
+  heldLocks.clear();
+}
+
+/**
+ * @param {(typeof CLEANUP_SIGNALS)[number]} signal
+ * @returns {void}
+ */
+function handleTerminatingSignal(signal) {
+  releaseHeldLocksSync();
+
+  // Another listener owns the exit decision (the server shuts down and exits
+  // from its own SIGINT handler). Taking it away from them here would cut that
+  // shutdown short. The trade this accepts is the mirror of the one above: a
+  // handler that keeps running after releasing our lock is left unserialized
+  // for the rest of its shutdown, which is bounded and quiet, where the orphan
+  // it replaces blocks unrelated processes for a fixed 30 seconds.
+  if (process.listenerCount(signal) > 1) return;
+
+  // Nothing else is listening, and merely having a listener has already
+  // replaced Node's default disposition: without the re-raise, Ctrl-C would
+  // leave the process running. Remove ourselves first so the second delivery
+  // reaches that default, and the process dies with the same 128+n status a
+  // caller would have seen if this module had never installed anything.
+  uninstallCleanupHandlers();
+  process.kill(process.pid, signal);
+  // Unreachable on POSIX, where the re-raise terminates before returning.
+  // Windows has no signal to re-raise, so anything that gets here still has to
+  // stop rather than linger with the lock already gone.
+  process.exit(128 + (osConstants.signals[signal] ?? 15));
+}
+
+function installCleanupHandlers() {
+  if (exitHandlerInstalled) return;
+  exitHandlerInstalled = true;
+  process.on('exit', releaseHeldLocksSync);
+  for (const signal of CLEANUP_SIGNALS) {
+    const handler = () => handleTerminatingSignal(signal);
+    installedSignalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+}
+
+/**
+ * Uninstalled as soon as the last lock is released, not left for the life of
+ * the process. The server takes this lock on every preferences write, so
+ * handlers that accumulated would both leak listeners and keep changing how the
+ * process responds to a signal long after the reason for it was gone.
+ */
+function uninstallCleanupHandlers() {
+  if (!exitHandlerInstalled) return;
+  exitHandlerInstalled = false;
+  process.off('exit', releaseHeldLocksSync);
+  for (const [signal, handler] of installedSignalHandlers) process.off(signal, handler);
+  installedSignalHandlers.clear();
+}
+
+/**
+ * @param {string} lockPath
+ * @returns {void}
+ */
+function forgetHeldLock(lockPath) {
+  heldLocks.delete(lockPath);
+  if (heldLocks.size === 0) uninstallCleanupHandlers();
 }
 
 /**
@@ -178,7 +291,14 @@ export async function acquireFileLock(filePath) {
       continue;
     }
 
+    heldLocks.set(lockPath, token);
+    installCleanupHandlers();
+
     return async () => {
+      // Before the unlink, not after: whichever of the two paths gets there
+      // first, the other must not try the same removal again.
+      forgetHeldLock(lockPath);
+
       let holder;
       try {
         holder = await retryTransient(() => readFile(lockPath, 'utf-8'));

--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -8,7 +8,8 @@
  * Types live in `file-lock.d.ts`.
  */
 
-import { open, stat, unlink } from 'fs/promises';
+import { open, readFile, stat, unlink } from 'fs/promises';
+import { randomUUID } from 'crypto';
 
 import { FS_RETRY_BUDGET_MS, isTransientFsError, retryTransient, sleep } from './fs-atomic.js';
 
@@ -29,6 +30,23 @@ const LOCK_RETRY_BASE_MS = 25;
 export const LOCK_MAX_WAIT_MS = 15 * FS_RETRY_BUDGET_MS;
 
 const LOCK_MAX_ATTEMPTS = Math.ceil(LOCK_MAX_WAIT_MS / LOCK_RETRY_BASE_MS);
+
+/**
+ * What a holder writes into its lock file, and the only evidence that the lock
+ * on disk is still the one it took.
+ *
+ * The pid alone cannot do this job. It is not unique over time (pids are
+ * reused), it is not unique across machines (the prefs file lives on synced and
+ * network mounts), and a process that takes the lock twice in sequence writes
+ * the same bytes both times. A uuid alongside it makes every acquisition
+ * distinguishable from every other, and keeping the pid first leaves the file
+ * as readable to someone debugging an abandoned lock as it was before.
+ *
+ * @returns {string}
+ */
+function mintHolderToken() {
+  return `${process.pid} ${randomUUID()}`;
+}
 
 /**
  * Thrown when the attempt budget runs out, as opposed to a filesystem error,
@@ -61,6 +79,12 @@ export class LockContentionError extends Error {
  * Implementation: O_EXCL sentinel file. If the lock is older than
  * LOCK_STALE_MS we treat it as abandoned (the holder crashed) and steal it.
  *
+ * Because a lock CAN be stolen, holding one is not the same as still holding
+ * it: a holder that stalls past LOCK_STALE_MS (the machine suspends, a cloud
+ * mount hydrates the file) comes back to a lock path that now belongs to
+ * someone else. Every acquisition therefore writes a token that identifies it,
+ * and release unlinks only a lock still carrying that token.
+ *
  * @param {string} filePath
  * @returns {Promise<() => Promise<void>>} release closure
  * @throws {LockContentionError} when the attempt budget runs out. Any other
@@ -68,6 +92,7 @@ export class LockContentionError extends Error {
  */
 export async function acquireFileLock(filePath) {
   const lockPath = `${filePath}${LOCK_SUFFIX}`;
+  const token = mintHolderToken();
   let lastErr;
   for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
     let fd;
@@ -104,6 +129,13 @@ export async function acquireFileLock(filePath) {
       }
       if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
         try {
+          // Removing a lock this process does not hold, on the evidence of a
+          // stat taken a moment ago. If the abandoned holder released and a
+          // third writer acquired in the gap between that stat and this call,
+          // this unlinks the new holder's lock instead. No syscall compares and
+          // removes in one step, so the window cannot be closed here, only kept
+          // to the microseconds between two adjacent calls; the release path is
+          // where it was measured in the whole duration of a held lock.
           await unlink(lockPath);
         } catch (unlinkErr) {
           // ENOENT is the benign race: someone else released it first.
@@ -129,14 +161,15 @@ export async function acquireFileLock(filePath) {
     // then blocks all writers until LOCK_STALE_MS elapses.
     let writeErr;
     try {
-      await fd.writeFile(`${process.pid}`);
+      await fd.writeFile(token);
     } catch (err) {
       writeErr = err;
     }
     // Close before unlinking: Windows refuses to remove a file that still has
-    // an open handle, which would defeat the cleanup below. The pid is only a
-    // debugging aid (staleness is decided by mtime), so a failed close on the
-    // success path is not worth failing the write over.
+    // an open handle, which would defeat the cleanup below. A close that fails
+    // AFTER the token landed is not worth failing the write over; one that
+    // failed to flush it leaves a lock this holder can no longer prove is its
+    // own, and release treats that the same way it treats a stolen one.
     await fd.close().catch(() => {});
     if (writeErr) {
       await unlink(lockPath).catch(() => {});
@@ -146,6 +179,40 @@ export async function acquireFileLock(filePath) {
     }
 
     return async () => {
+      let holder;
+      try {
+        holder = await retryTransient(() => readFile(lockPath, 'utf-8'));
+      } catch (err) {
+        // Already gone: released twice, or stolen and released by whoever took
+        // it. Either way there is nothing here to remove.
+        if (err?.code === 'ENOENT') return;
+        // A read that will not succeed proves nothing about who holds the lock,
+        // and unlinking on that evidence is exactly the failure this check
+        // exists to prevent. Leaving it costs one stale window and then clears
+        // on its own; guessing wrong costs mutual exclusion.
+        console.error(
+          `Could not read the lock at ${lockPath} to confirm it is still ` +
+            `ours, so it was left in place; writes are blocked until it ages ` +
+            `out after ${LOCK_STALE_MS}ms:`,
+          err,
+        );
+        return;
+      }
+
+      if (holder !== token) {
+        // Our lock aged past LOCK_STALE_MS while we held it and another writer
+        // took it as abandoned. The write we just finished was NOT serialized
+        // against theirs, and unlinking this would hand a third writer the same
+        // window. Say so: a file that comes back different needs an explanation
+        // somewhere, and this is the only place that has one.
+        console.error(
+          `The lock at ${lockPath} was taken over by another writer while we ` +
+            `held it (ours was idle past ${LOCK_STALE_MS}ms), so this write ` +
+            `was not serialized against theirs. Leaving their lock in place.`,
+        );
+        return;
+      }
+
       try {
         await retryTransient(() => unlink(lockPath));
       } catch (err) {

--- a/bin/file-lock.test.ts
+++ b/bin/file-lock.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
+import { spawn } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 
 import {
   acquireFileLock,
@@ -219,4 +221,142 @@ describe('a lock stolen out from under its holder', () => {
     },
     5_000 + LOCK_MAX_WAIT_MS,
   );
+});
+
+// An interrupt between acquiring and the caller's `finally` used to leave the
+// lock on disk, which wedges every writer of that file (this process, another
+// mdr, the server) until it ages out 30 seconds later. `mdr --restrict` is the
+// shortest path to it: one Ctrl-C in a window the user cannot see.
+//
+// Driven as real child processes because there is no in-process seam for a
+// signal: the handler under test is the one Node installs on the process, and
+// the exit status it produces is half of what the fix has to preserve.
+describe('an interrupt while the lock is held', () => {
+  const lockModule = pathToFileURL(join(__dirname, 'file-lock.js')).href;
+
+  interface Child {
+    kill: (signal: NodeJS.Signals) => void;
+    exited: Promise<{ code: number | null; signal: NodeJS.Signals | null; stderr: string }>;
+  }
+
+  /** Start a child that acquires the lock, prints `ready`, and waits. */
+  async function holdLockInChild(body = ''): Promise<Child> {
+    const source = `
+      import { acquireFileLock } from ${JSON.stringify(lockModule)};
+      ${body}
+      const release = await acquireFileLock(${JSON.stringify(target)});
+      globalThis.__release = release;
+      console.log('ready');
+      setInterval(() => {}, 1000);
+    `;
+    const child = spawn(process.execPath, ['--input-type=module', '-e', source], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+
+    await new Promise<void>((resolve, reject) => {
+      child.stdout.on('data', (chunk) => {
+        if (String(chunk).includes('ready')) resolve();
+      });
+      child.once('error', reject);
+      child.once('exit', () => reject(new Error(`child exited early: ${stderr}`)));
+    });
+
+    return {
+      kill: (signal) => child.kill(signal),
+      exited: new Promise((resolve) => {
+        child.once('exit', (code, signal) => resolve({ code, signal, stderr }));
+      }),
+    };
+  }
+
+  // On Windows there is no signal to deliver: child.kill() there is a
+  // TerminateProcess, which no handler can intercept. A real Ctrl-C in a
+  // console still reaches Node as a SIGINT event and still runs the cleanup
+  // below; it is only this way of provoking it that cannot exist.
+  const itPosix = it.skipIf(process.platform === 'win32');
+
+  itPosix('removes the lock instead of leaving it to age out', async () => {
+    const child = await holdLockInChild();
+    expect(existsSync(lockPath)).toBe(true);
+
+    child.kill('SIGINT');
+    await child.exited;
+
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  itPosix('still dies the way an uninterrupted Ctrl-C does', async () => {
+    // Handling a signal replaces Node's default disposition, so a cleanup
+    // handler that forgets to re-raise turns Ctrl-C into a hang or into the
+    // wrong exit status for every script that checks it.
+    const child = await holdLockInChild();
+    child.kill('SIGINT');
+
+    expect((await child.exited).signal).toBe('SIGINT');
+  });
+
+  itPosix('cleans up on SIGTERM too', async () => {
+    const child = await holdLockInChild();
+    child.kill('SIGTERM');
+    const { signal } = await child.exited;
+
+    expect(signal).toBe('SIGTERM');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  itPosix("defers to the process's own handler rather than exiting under it", async () => {
+    // The server's shape: it already handles SIGINT and exits itself. Our
+    // cleanup has to run without taking that decision away from it, which is
+    // also the only path where process.exit runs instead of a signal death.
+    const child = await holdLockInChild(`
+      process.on('SIGINT', () => { console.error('server handler ran'); process.exit(3); });
+    `);
+    child.kill('SIGINT');
+    const { code, signal, stderr } = await child.exited;
+
+    expect(stderr).toContain('server handler ran');
+    expect(code).toBe(3);
+    expect(signal).toBe(null);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  itPosix('leaves a lock that was stolen while the process stalled', async () => {
+    const child = await holdLockInChild();
+    await makeStale(lockPath);
+    const stealer = await acquireFileLock(target);
+    const stolenToken = await readFile(lockPath, 'utf-8');
+
+    child.kill('SIGINT');
+    await child.exited;
+
+    expect(await readFile(lockPath, 'utf-8')).toBe(stolenToken);
+    await stealer();
+  });
+
+  itPosix('stops handling signals once the lock is released', async () => {
+    // Cleanup that outlives the lock changes how the process dies for reasons
+    // unrelated to the lock, and a listener nothing removes is a leak in a
+    // server that writes preferences on every boot and every settings change.
+    const source = `
+      import { acquireFileLock } from ${JSON.stringify(lockModule)};
+      const release = await acquireFileLock(${JSON.stringify(target)});
+      await release();
+      console.log(JSON.stringify({
+        sigint: process.listenerCount('SIGINT'),
+        sigterm: process.listenerCount('SIGTERM'),
+        exit: process.listenerCount('exit'),
+      }));
+    `;
+    const child = spawn(process.execPath, ['--input-type=module', '-e', source], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+    const code = await new Promise<number | null>((resolve) => child.once('exit', resolve));
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({ sigint: 0, sigterm: 0, exit: 0 });
+  });
 });

--- a/bin/file-lock.test.ts
+++ b/bin/file-lock.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  acquireFileLock,
+  LOCK_MAX_WAIT_MS,
+  LOCK_STALE_MS,
+  LOCK_SUFFIX,
+  LockContentionError,
+} from './file-lock.js';
+
+// The lock had no direct test: every assertion on it ran through
+// server/preferences.test.ts, so its invariants held only where preferences
+// happened to reach them. The one below about a stolen lock did not.
+
+// Fails a syscall the way an unwritable or unreadable lock path does. Hoisted
+// because vi.mock factories run before the module body, and scoped to `.lock`
+// so arming one never catches the test's own bookkeeping on another path.
+// vi.spyOn cannot do this job: an ESM namespace object is not configurable.
+const fault = vi.hoisted(() => ({
+  unlink: { failuresLeft: 0, code: 'EPERM' },
+  readFile: { failuresLeft: 0, code: 'EIO' },
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  const faulted = (code: string, call: string): NodeJS.ErrnoException =>
+    Object.assign(new Error(`${code}: simulated failure, ${call}`), { code });
+  return {
+    ...actual,
+    unlink: async (path: string) => {
+      if (fault.unlink.failuresLeft > 0 && String(path).endsWith(LOCK_SUFFIX)) {
+        fault.unlink.failuresLeft -= 1;
+        throw faulted(fault.unlink.code, `unlink '${path}'`);
+      }
+      return actual.unlink(path);
+    },
+    readFile: async (path: string, encoding: BufferEncoding) => {
+      if (fault.readFile.failuresLeft > 0 && String(path).endsWith(LOCK_SUFFIX)) {
+        fault.readFile.failuresLeft -= 1;
+        throw faulted(fault.readFile.code, `read '${path}'`);
+      }
+      return actual.readFile(path, encoding);
+    },
+  };
+});
+
+let dir: string;
+let target: string;
+let lockPath: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'mdr-lock-'));
+  target = join(dir, '.md-redline.json');
+  lockPath = `${target}${LOCK_SUFFIX}`;
+});
+
+afterEach(async () => {
+  fault.unlink.failuresLeft = 0;
+  fault.readFile.failuresLeft = 0;
+  vi.restoreAllMocks();
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Backdate the lock so the staleness branch treats its holder as crashed. */
+async function makeStale(path: string): Promise<void> {
+  const past = new Date(Date.now() - LOCK_STALE_MS * 2);
+  await utimes(path, past, past);
+}
+
+describe('acquireFileLock', () => {
+  it('creates the lock beside the file and removes it on release', async () => {
+    const release = await acquireFileLock(target);
+    expect(existsSync(lockPath)).toBe(true);
+
+    await release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('writes the holding pid, which is what makes an abandoned lock diagnosable', async () => {
+    const release = await acquireFileLock(target);
+    const contents = await readFile(lockPath, 'utf-8');
+    expect(contents.split(/\s/)[0]).toBe(String(process.pid));
+    await release();
+  });
+
+  it('serializes two holders: the second waits for the first to release', async () => {
+    const order: string[] = [];
+    const first = await acquireFileLock(target);
+
+    const second = acquireFileLock(target).then((release) => {
+      order.push('second-acquired');
+      return release;
+    });
+
+    // Long enough that the waiter has run several attempts and is still blocked.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(order).toEqual([]);
+
+    order.push('first-released');
+    await first();
+    await (
+      await second
+    )();
+
+    expect(order).toEqual(['first-released', 'second-acquired']);
+  });
+
+  it('steals a lock left behind by a crashed holder', async () => {
+    await writeFile(lockPath, '999999');
+    await makeStale(lockPath);
+
+    const release = await acquireFileLock(target);
+    expect(await readFile(lockPath, 'utf-8')).toContain(String(process.pid));
+    await release();
+  });
+
+  it(
+    'gives up with LockContentionError while a fresh lock stays put',
+    async () => {
+      await writeFile(lockPath, '999999');
+
+      await expect(acquireFileLock(target)).rejects.toThrow(LockContentionError);
+      // The lock it could not take is still the other holder's, untouched.
+      expect(await readFile(lockPath, 'utf-8')).toBe('999999');
+    },
+    5_000 + LOCK_MAX_WAIT_MS,
+  );
+
+  it('release is quiet when the lock is already gone', async () => {
+    const release = await acquireFileLock(target);
+    await rm(lockPath);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(release()).resolves.toBeUndefined();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('reports a release it could not perform, because an orphan blocks every writer', async () => {
+    const release = await acquireFileLock(target);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Every attempt inside retryTransient, so the release exhausts its budget.
+    fault.unlink.failuresLeft = Number.MAX_SAFE_INTEGER;
+
+    await release();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(lockPath),
+      expect.objectContaining({ code: 'EPERM' }),
+    );
+  });
+});
+
+describe('a lock stolen out from under its holder', () => {
+  // The scenario: a holder stalls past LOCK_STALE_MS (the machine suspends, a
+  // cloud mount hydrates the file), a second writer reads the stale mtime and
+  // steals the lock, and then the first one finishes and releases. Releasing by
+  // path alone unlinked the SECOND holder's lock, and from there nothing in the
+  // system held mutual exclusion while a writer believed it did.
+  it('is not deleted by the original holder on release', async () => {
+    const stalled = await acquireFileLock(target);
+    await makeStale(lockPath);
+
+    const stealer = await acquireFileLock(target);
+    const stolenToken = await readFile(lockPath, 'utf-8');
+
+    await stalled();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(await readFile(lockPath, 'utf-8')).toBe(stolenToken);
+
+    // And the real holder can still release its own.
+    await stealer();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('cannot be released by a holder whose own lock was replaced', async () => {
+    const stalled = await acquireFileLock(target);
+    await makeStale(lockPath);
+    const stealer = await acquireFileLock(target);
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await stalled();
+
+    // Never silent: a writer that has lost mutual exclusion has to be able to
+    // find out why the file it wrote came back different.
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(lockPath));
+    await stealer();
+  });
+
+  it('leaves the lock alone when ownership cannot be established', async () => {
+    const release = await acquireFileLock(target);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // A read that fails permanently proves nothing about who holds the lock.
+    // Unlinking on that evidence is the very defect above; orphaning ours costs
+    // one stale window and clears on its own.
+    fault.readFile.failuresLeft = Number.MAX_SAFE_INTEGER;
+
+    await release();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it(
+    'does not steal a lock that is merely old but still being held',
+    async () => {
+      // Staleness is decided on mtime, so a holder that refreshes nothing looks
+      // dead the moment it crosses the threshold. What must NOT happen is a steal
+      // of a lock that is inside the window.
+      const release = await acquireFileLock(target);
+      const before = await stat(lockPath);
+      await expect(acquireFileLock(target)).rejects.toThrow(LockContentionError);
+      const after = await stat(lockPath);
+      expect(after.mtimeMs).toBe(before.mtimeMs);
+      await release();
+    },
+    5_000 + LOCK_MAX_WAIT_MS,
+  );
+});

--- a/bin/fs-atomic.js
+++ b/bin/fs-atomic.js
@@ -8,7 +8,11 @@
  * two that drift: the CLI writes the user's prefs file and Claude Desktop's
  * MCP config, both of which the server or another tool may also be writing.
  *
- * Types live in `fs-atomic.d.ts`.
+ * Types live in `fs-atomic.d.ts`. The tests live in `server/fs-retry.test.ts`,
+ * not beside this file: `server/fs-retry.ts` is a re-export with no logic of
+ * its own, so those cover this module directly, and a second suite here would
+ * be duplicate surface rather than new coverage. `file-lock.js` is the opposite
+ * case and has its own.
  */
 
 import { chmod, open, readFile, rename, stat, unlink } from 'fs/promises';

--- a/server/fs-retry.test.ts
+++ b/server/fs-retry.test.ts
@@ -1,5 +1,15 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { chmod, mkdtemp, rm, stat, writeFile, readFile, readdir } from 'fs/promises';
+import {
+  chmod,
+  lstat,
+  mkdtemp,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+  readFile,
+  readdir,
+} from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -334,6 +344,32 @@ describe('atomicWriteFile', () => {
     await expect(atomicWriteFile(docPath, 'new\n')).rejects.toMatchObject({ code: 'EXDEV' });
     expect(fault.rename.attempts).toBe(1);
   });
+
+  // Creating a symlink on Windows needs Developer Mode or an elevated process,
+  // so the platform that cannot run this is also the one where the attack it
+  // describes does not arrive by this route.
+  it.skipIf(REAL_PLATFORM === 'win32')(
+    'replaces a symlink at the destination instead of writing through it',
+    async () => {
+      // The security half of the O_EXCL rename dance: a symlink planted at the
+      // path we are about to save is replaced by a regular file, and whatever
+      // it pointed at is untouched. Following it would let anything that can
+      // create a file in the directory redirect a save to a path of its
+      // choosing. The cost, recorded as a deliberate trade, is that a dotfiles
+      // symlink for a config file becomes a regular file until the next
+      // `chezmoi apply`.
+      const outside = join(testDir, 'outside.json');
+      await writeFile(outside, 'must not change\n');
+      const linkPath = join(testDir, 'linked.json');
+      await symlink(outside, linkPath);
+
+      await atomicWriteFile(linkPath, 'new\n');
+
+      expect(await readFile(outside, 'utf-8')).toBe('must not change\n');
+      expect(await readFile(linkPath, 'utf-8')).toBe('new\n');
+      expect((await lstat(linkPath)).isSymbolicLink()).toBe(false);
+    },
+  );
 });
 
 describe('off Windows', () => {


### PR DESCRIPTION
Three commits on one theme: the cross-process lock in `bin/file-lock.js` had no notion of *which* holder created the file on disk, and nothing imported it to prove otherwise.

### A stolen lock was deleted by its original holder

The lock recorded the holder's pid but never read it back, and staleness was decided on mtime alone. A holder that stalled past the 30s window (a suspended machine, a cloud mount hydrating the file) had its lock stolen as abandoned, finished its write, and then unlinked the path, removing the **new** holder's lock. From there nobody held mutual exclusion while a writer believed it did.

Each acquisition now writes a `pid uuid` token: the pid so an abandoned lock stays diagnosable, the uuid because a pid is unique neither over time nor across the synced and network mounts this file lives on. Release reads the lock back and unlinks only when the token still matches. A mismatch is reported rather than acted on, and a read that cannot be completed leaves the lock alone, because an orphan clears itself after the stale window and a wrong unlink does not.

The steal path still unlinks on the evidence of a stat taken a moment earlier, which is now documented where it happens. No syscall compares and removes in one step, so that window is the gap between two adjacent calls rather than the whole duration of a held lock.

### An interrupt while holding the lock left it behind

Between acquiring and the caller's `finally`, a Ctrl-C left the file on disk and wedged every writer of that path until it aged out. `mdr --restrict` is the shortest way in.

The handlers live in the lock module rather than at the call site, because every holder has the same window, and the ownership token above is what makes a synchronous cleanup safe. They are installed while a lock is held and removed when the last one is released, so the server does not accumulate listeners across preferences writes. Two behaviors this depends on, both verified rather than assumed:

- `process.on('exit')` does **not** run on a default signal death, so an `exit` hook alone is not enough.
- Signal listeners do **not** keep the event loop alive, so installing them cannot strand a process.

Handling a signal replaces Node's default disposition, so the handler re-raises after cleaning up and the process still dies with the status a caller would have seen. When something else is already listening, the server being the case that matters, it cleans up and leaves the exit decision alone.

### Tests

`bin/file-lock.test.ts` is the first thing to import the lock directly: 17 cases covering acquisition, contention, staleness, the stolen-lock invariants above, and the signal paths, the last driven as real child processes since the handler under test is the one Node installs on the process. The signal cases skip on Windows, where `child.kill()` is a `TerminateProcess` no handler can intercept; a real console Ctrl-C still reaches Node there and still runs the cleanup.

`fs-atomic.js` did not get a parallel suite. `server/fs-retry.ts` is a re-export with no logic of its own, so the existing tests already drive it directly and a second suite would be duplicate surface. It gained the one documented behavior that was asserted nowhere: a symlink at the destination is replaced by a regular file and whatever it pointed at is untouched, which is what keeps anything able to create a file in the directory from redirecting a save.

### Verification

`npm run build`, 1909 unit tests, `tsc -b`, `eslint .` and `format:check` all clean on macOS. The cross-OS matrix is what this PR is waiting on.