### PR TITLE
Hold bin/ to the same strict as the rest of the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,9 @@ An optional MCP stdio server lets AI agents request human review and wait for fe
   0644. The retry gate is per-errno, NOT per-platform: EBUSY is contention everywhere (SMB, NFS,
   and the FUSE/FileProvider mounts behind Dropbox, Google Drive and iCloud all return it), while
   EPERM/EACCES are retried only on `win32`, because on POSIX they mean a permanent permission
-  condition. `server/fs-retry.ts` re-exports it for server-side importers
+  condition. It also exports `errorCode`, the one place the unchecked cast from a caught
+  `unknown` to an errno-bearing error is written down, which is what every `catch` in `bin/`
+  reads a `.code` through. `server/fs-retry.ts` re-exports it for server-side importers
 - `bin/file-lock.js`: `acquireFileLock`, the O_EXCL cross-process lock every writer of
   `.md-redline.json` takes around a read-modify-write. Shared so `mdr --restrict` and the server
   cannot interleave; its attempt budget derives from `FS_RETRY_BUDGET_MS`. Exhausting that budget
@@ -310,14 +312,21 @@ deliberately, which is what keeps the window small.
 It has no build step, so before those existed eslint matched none of it and
 exited 0 having checked nothing, which reads exactly like passing, and `tsc`
 never saw it at all. A call to an undefined function survived both gates. The
-config is deliberately looser than `tsconfig.node.json` (no `strict`, no
-`noImplicitAny`) because the older modules here predate it and were written
-untyped; `fs-atomic.js` and `file-lock.js` carry JSDoc types so they are checked
-as thoroughly as they were when they were TypeScript. The CLI body is checked
-too, which is why it is `bin/cli.js` and not `bin/md-redline`: an extensionless
-file matches no glob `tsc` accepts, and that name is the published command and
-cannot change. What is left unchecked is the shim itself, which is why it does
-nothing but import.
+config now runs the same `strict` as `tsconfig.node.json`, so a JS file here is
+held to what a TS file is held to in `server/`; types are carried in JSDoc,
+since there is no build step to strip anything. The CLI body is checked too,
+which is why it is `bin/cli.js` and not `bin/md-redline`: an extensionless file
+matches no glob `tsc` accepts, and that name is the published command and cannot
+change. What is left unchecked is the shim itself, which is why it does nothing
+but import.
+
+The `include` list names `bin/**/*.js`, `bin/**/*.test.ts` and the browser stub
+one at a time, and must stay that way. A `.d.ts` caught by a wider glob SHADOWS
+its `.js`: TypeScript drops the implementation from the program and checks the
+declaration instead, which silently stops checking `fs-atomic.js` and
+`file-lock.js`. The declarations are there for the server, which imports these
+from a project without `allowJs`. After editing that list, confirm what is
+actually in the program with `tsc -p tsconfig.bin.json --listFiles`.
 
 `MD_REDLINE_REGISTRY_URL` and `MD_REDLINE_BASE_URL` keep a plain `??` by choice:
 both are development or background-only, and a blank value fails visibly at the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,7 +56,11 @@ An optional MCP stdio server lets AI agents request human review and wait for fe
   `.md-redline.json` takes around a read-modify-write. Shared so `mdr --restrict` and the server
   cannot interleave; its attempt budget derives from `FS_RETRY_BUDGET_MS`. Exhausting that budget
   throws `LockContentionError`; any other throw is a filesystem error with its errno intact, and
-  callers word their advice from that difference
+  callers word their advice from that difference. A lock older than `LOCK_STALE_MS` is stolen as
+  abandoned, so holding one is not the same as still holding it: each acquisition writes a
+  `pid uuid` token and release unlinks only a lock still carrying it. The module installs its own
+  SIGINT/SIGTERM/SIGHUP and `exit` handlers while any lock is held, removes them once the last one
+  is released, and re-raises the signal so the process still dies with the status it would have
 - `bin/home-dir.js`: `resolveHomeDir` (`MD_REDLINE_HOME` or the OS home), which decides where
   `.md-redline.json` lives. Shared because a CLI resolving it differently from the server locks
   and writes a file the server never reads

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -22,7 +22,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 import { createRequire } from 'module';
 import { acquireFileLock, LOCK_MAX_WAIT_MS, LockContentionError } from './file-lock.js';
-import { atomicWriteFile, retryTransient } from './fs-atomic.js';
+import { atomicWriteFile, errorCode, retryTransient } from './fs-atomic.js';
 import { resolveHomeDir } from './home-dir.js';
 import { resolveApiPort } from './ports.js';
 
@@ -99,7 +99,7 @@ async function trustDisclosureState() {
   try {
     raw = await retryTransient(() => readFile(prefsPath, 'utf8'));
   } catch (err) {
-    return err.code === 'ENOENT' ? 'seeded' : 'unreadable';
+    return errorCode(err) === 'ENOENT' ? 'seeded' : 'unreadable';
   }
   try {
     const parsed = JSON.parse(raw);
@@ -110,6 +110,24 @@ async function trustDisclosureState() {
   }
 }
 
+/**
+ * A caught value's message, for error text the CLI is about to print.
+ *
+ * `catch` binds `unknown` and these strings go straight to the user, so a
+ * throw that is not an Error has to degrade to something readable instead of
+ * failing inside the handler that was reporting the first failure.
+ *
+ * @param {unknown} err
+ * @returns {string}
+ */
+function errorMessage(err) {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * @param {string} inputPath
+ * @returns {string}
+ */
 function expandHomePath(inputPath) {
   if (inputPath === '~') return homedir();
   if (inputPath.startsWith('~/') || inputPath.startsWith('~\\')) {
@@ -118,6 +136,10 @@ function expandHomePath(inputPath) {
   return inputPath;
 }
 
+/**
+ * @param {string} arg
+ * @returns {Promise<{ file: string; dir: string }>}
+ */
 async function resolveTarget(arg) {
   if (!arg) return { file: '', dir: '' };
 
@@ -178,10 +200,20 @@ async function findClientPort() {
   return null;
 }
 
+/**
+ * @param {number} ms
+ * @returns {Promise<void>}
+ */
 function delay(ms) {
   return new Promise((resolveDelay) => setTimeout(resolveDelay, ms));
 }
 
+/**
+ * @param {string} command
+ * @param {string[]} args
+ * @param {{ cwd?: string; detached?: boolean }} [options]
+ * @returns {Promise<import('child_process').ChildProcess>}
+ */
 function spawnDetached(command, args, options = {}) {
   return new Promise((resolveSpawn, rejectSpawn) => {
     const isWin = process.platform === 'win32';
@@ -227,6 +259,12 @@ function spawnDetached(command, args, options = {}) {
 const BROWSER_COMMAND_VAR = 'MD_REDLINE_INTERNAL_BROWSER_COMMAND';
 const BROWSER_URL_VAR = 'MD_REDLINE_INTERNAL_BROWSER_URL';
 
+/**
+ * @param {string} command
+ * @param {string} url
+ * @param {{ shellCommand?: boolean }} [options]
+ * @returns {Promise<import('child_process').ChildProcess>}
+ */
 function spawnWindowsBrowser(command, url, { shellCommand = false } = {}) {
   return new Promise((resolveSpawn, rejectSpawn) => {
     const env = {
@@ -272,6 +310,10 @@ function spawnWindowsBrowser(command, url, { shellCommand = false } = {}) {
   });
 }
 
+/**
+ * @param {string} url
+ * @returns {Promise<import('child_process').ChildProcess>}
+ */
 function openWithWindowsShell(url) {
   return new Promise((resolveSpawn, rejectSpawn) => {
     // Keep the encoded URL out of cmd.exe's command string. cmd expands the
@@ -358,7 +400,7 @@ async function enableRestrictedMode() {
         console.error('Another mdr process is writing it. Try again in a moment.');
       }
     } else {
-      console.error(`Could not lock ${prefsPath} (${err.code}): ${err.message}`);
+      console.error(`Could not lock ${prefsPath} (${errorCode(err)}): ${errorMessage(err)}`);
       console.error('Refusing to write over a file that may hold your trust settings.');
     }
     process.exitCode = 1;
@@ -377,8 +419,8 @@ async function enableRestrictedMode() {
       process.exitCode = 1;
       return;
     } catch (err) {
-      if (err.code !== 'ENOENT') {
-        console.error(`Could not check ${prefsPath} (${err.code}).`);
+      if (errorCode(err) !== 'ENOENT') {
+        console.error(`Could not check ${prefsPath} (${errorCode(err)}).`);
         console.error('Refusing to write over a file that may hold your trust settings.');
         process.exitCode = 1;
         return;
@@ -391,7 +433,9 @@ async function enableRestrictedMode() {
       // Every other branch here exits 1 with an explanation. Letting this one
       // escape to main() printed a raw stack instead, with nothing to say
       // whether restricted mode had been applied.
-      console.error(`Could not write ${prefsPath} (${err.code ?? 'unknown'}): ${err.message}`);
+      console.error(
+        `Could not write ${prefsPath} (${errorCode(err) ?? 'unknown'}): ${errorMessage(err)}`,
+      );
       console.error('Restricted mode was NOT enabled.');
       process.exitCode = 1;
       return;
@@ -404,6 +448,16 @@ async function enableRestrictedMode() {
   console.log(`Wrote ${prefsPath}`);
 }
 
+/**
+ * What the running server reports about itself, once it has been checked.
+ * @typedef {{ version: string; latest: string | null; updateCheckPending: boolean }} ServerVersionInfo
+ */
+
+/**
+ * @param {number} port
+ * @returns {Promise<ServerVersionInfo | null>} null when the server cannot be
+ *   asked, or answers with something that is not a version
+ */
 async function getServerVersionInfo(port) {
   try {
     const response = await fetch(`http://127.0.0.1:${port}/api/version`, {
@@ -430,6 +484,11 @@ async function getServerVersionInfo(port) {
   return null;
 }
 
+/**
+ * @param {number} port
+ * @param {ServerVersionInfo | null} initialInfo
+ * @returns {Promise<ServerVersionInfo | null>}
+ */
 async function waitForUpdateCheck(port, initialInfo) {
   let info = initialInfo;
   const deadline = Date.now() + UPDATE_CHECK_WAIT_MS;
@@ -536,6 +595,11 @@ async function ensureServerRunning() {
   return null;
 }
 
+/**
+ * @param {string} file
+ * @param {string} dir
+ * @returns {Promise<string>}
+ */
 async function buildUrl(file, dir) {
   const clientPort = await findClientPort();
   const serverPort = await findServerPort();
@@ -548,6 +612,10 @@ async function buildUrl(file, dir) {
   return baseUrl;
 }
 
+/**
+ * @param {string} url
+ * @returns {Promise<void>}
+ */
 async function openInBrowser(url) {
   // MD_REDLINE_BROWSER overrides the launcher with an explicit command that
   // receives the URL as its argument (e.g. a specific browser binary). Spawned
@@ -631,9 +699,9 @@ async function installForClaudeDesktop() {
     // Only a missing file may be treated as "start fresh". Every other read
     // failure has to abort, because writing a fresh config over a file we
     // could not read would delete every other MCP server in it.
-    if (err.code !== 'ENOENT') {
+    if (errorCode(err) !== 'ENOENT') {
       throw new Error(
-        `Cannot read ${configPath} (${err.code}): ${err.message}\n` +
+        `Cannot read ${configPath} (${errorCode(err)}): ${errorMessage(err)}\n` +
           'Fix the permissions and retry; refusing to overwrite a config that may hold other MCP servers.',
       );
     }
@@ -643,7 +711,7 @@ async function installForClaudeDesktop() {
       config = JSON.parse(existing);
     } catch (err) {
       throw new Error(
-        `Cannot parse ${configPath}: ${err.message}\nPlease fix the JSON syntax and retry.`,
+        `Cannot parse ${configPath}: ${errorMessage(err)}\nPlease fix the JSON syntax and retry.`,
       );
     }
   }
@@ -749,6 +817,12 @@ async function installForClaudeCode() {
   return { ok: true, changed: true };
 }
 
+/**
+ * @param {string} target one of 'all', 'claude-code', 'claude-desktop'. Typed
+ *   as a plain string because the caller derives it from argv and has already
+ *   rejected anything else.
+ * @returns {Promise<void>}
+ */
 async function installMcpConfig(target) {
   // `changed` and `error` are each set by only one of the two shapes pushed
   // here, and the reporting below reads both across every result.

--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -9,7 +9,9 @@
  */
 
 import { open, readFile, stat, unlink } from 'fs/promises';
+import { readFileSync, unlinkSync } from 'fs';
 import { randomUUID } from 'crypto';
+import { constants as osConstants } from 'os';
 
 import { FS_RETRY_BUDGET_MS, isTransientFsError, retryTransient, sleep } from './fs-atomic.js';
 
@@ -46,6 +48,117 @@ const LOCK_MAX_ATTEMPTS = Math.ceil(LOCK_MAX_WAIT_MS / LOCK_RETRY_BASE_MS);
  */
 function mintHolderToken() {
   return `${process.pid} ${randomUUID()}`;
+}
+
+/**
+ * Locks this process holds right now, keyed by lock path, valued by the token
+ * that proves each one is ours. An interrupt between acquiring and the caller's
+ * `finally` leaves the file behind otherwise, and an orphan wedges every writer
+ * of that path (this process, another mdr, the server) until it ages out
+ * LOCK_STALE_MS later. `mdr --restrict` is the shortest way to see it: one
+ * Ctrl-C inside a window the user has no way to know they are in.
+ *
+ * @type {Map<string, string>}
+ */
+const heldLocks = new Map();
+
+/**
+ * Signals that terminate the process by default, so a caller's `finally` never
+ * runs. `exit` is separately necessary: it does NOT fire on a default signal
+ * death, and the signal handlers below do not fire when something else's
+ * handler calls process.exit first, which is exactly what the server does.
+ */
+const CLEANUP_SIGNALS = /** @type {const} */ (['SIGINT', 'SIGTERM', 'SIGHUP']);
+
+/** @type {Map<string, () => void>} */
+const installedSignalHandlers = new Map();
+let exitHandlerInstalled = false;
+
+/**
+ * Remove every lock still held, synchronously, because this is all that a
+ * signal handler or an `exit` listener can do. Ownership is re-checked the same
+ * way release does it: a lock stolen while we stalled belongs to someone else
+ * now, and taking it with us on the way out is the failure this module works
+ * hardest to prevent.
+ *
+ * Best effort by construction. Nothing is retried and no error is reported: the
+ * process is on its way out, there is no one left to tell, and a lock left
+ * behind here is the exact 30-second orphan that this path exists to make rare
+ * rather than certain.
+ */
+function releaseHeldLocksSync() {
+  for (const [lockPath, token] of heldLocks) {
+    try {
+      if (readFileSync(lockPath, 'utf-8') === token) unlinkSync(lockPath);
+    } catch {
+      /* already gone, or unreadable; either way there is nothing safe to do */
+    }
+  }
+  // Cleared whether or not each unlink worked, so a re-raised signal cannot
+  // walk this list a second time.
+  heldLocks.clear();
+}
+
+/**
+ * @param {(typeof CLEANUP_SIGNALS)[number]} signal
+ * @returns {void}
+ */
+function handleTerminatingSignal(signal) {
+  releaseHeldLocksSync();
+
+  // Another listener owns the exit decision (the server shuts down and exits
+  // from its own SIGINT handler). Taking it away from them here would cut that
+  // shutdown short. The trade this accepts is the mirror of the one above: a
+  // handler that keeps running after releasing our lock is left unserialized
+  // for the rest of its shutdown, which is bounded and quiet, where the orphan
+  // it replaces blocks unrelated processes for a fixed 30 seconds.
+  if (process.listenerCount(signal) > 1) return;
+
+  // Nothing else is listening, and merely having a listener has already
+  // replaced Node's default disposition: without the re-raise, Ctrl-C would
+  // leave the process running. Remove ourselves first so the second delivery
+  // reaches that default, and the process dies with the same 128+n status a
+  // caller would have seen if this module had never installed anything.
+  uninstallCleanupHandlers();
+  process.kill(process.pid, signal);
+  // Unreachable on POSIX, where the re-raise terminates before returning.
+  // Windows has no signal to re-raise, so anything that gets here still has to
+  // stop rather than linger with the lock already gone.
+  process.exit(128 + (osConstants.signals[signal] ?? 15));
+}
+
+function installCleanupHandlers() {
+  if (exitHandlerInstalled) return;
+  exitHandlerInstalled = true;
+  process.on('exit', releaseHeldLocksSync);
+  for (const signal of CLEANUP_SIGNALS) {
+    const handler = () => handleTerminatingSignal(signal);
+    installedSignalHandlers.set(signal, handler);
+    process.on(signal, handler);
+  }
+}
+
+/**
+ * Uninstalled as soon as the last lock is released, not left for the life of
+ * the process. The server takes this lock on every preferences write, so
+ * handlers that accumulated would both leak listeners and keep changing how the
+ * process responds to a signal long after the reason for it was gone.
+ */
+function uninstallCleanupHandlers() {
+  if (!exitHandlerInstalled) return;
+  exitHandlerInstalled = false;
+  process.off('exit', releaseHeldLocksSync);
+  for (const [signal, handler] of installedSignalHandlers) process.off(signal, handler);
+  installedSignalHandlers.clear();
+}
+
+/**
+ * @param {string} lockPath
+ * @returns {void}
+ */
+function forgetHeldLock(lockPath) {
+  heldLocks.delete(lockPath);
+  if (heldLocks.size === 0) uninstallCleanupHandlers();
 }
 
 /**
@@ -178,7 +291,14 @@ export async function acquireFileLock(filePath) {
       continue;
     }
 
+    heldLocks.set(lockPath, token);
+    installCleanupHandlers();
+
     return async () => {
+      // Before the unlink, not after: whichever of the two paths gets there
+      // first, the other must not try the same removal again.
+      forgetHeldLock(lockPath);
+
       let holder;
       try {
         holder = await retryTransient(() => readFile(lockPath, 'utf-8'));

--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -13,7 +13,13 @@ import { readFileSync, unlinkSync } from 'fs';
 import { randomUUID } from 'crypto';
 import { constants as osConstants } from 'os';
 
-import { FS_RETRY_BUDGET_MS, isTransientFsError, retryTransient, sleep } from './fs-atomic.js';
+import {
+  errorCode,
+  FS_RETRY_BUDGET_MS,
+  isTransientFsError,
+  retryTransient,
+  sleep,
+} from './fs-atomic.js';
 
 export const LOCK_SUFFIX = '.lock';
 
@@ -212,7 +218,7 @@ export async function acquireFileLock(filePath) {
     try {
       fd = await open(lockPath, 'wx');
     } catch (err) {
-      const code = err?.code;
+      const code = errorCode(err);
       if (code !== 'EEXIST') {
         lastErr = err;
         // The lock file is created and removed on every write, which makes it
@@ -229,7 +235,7 @@ export async function acquireFileLock(filePath) {
       } catch (statErr) {
         // ENOENT means the lock vanished between the EEXIST and the stat, so
         // the path is free right now and there is nothing to wait for.
-        if (statErr?.code === 'ENOENT') continue;
+        if (errorCode(statErr) === 'ENOENT') continue;
         // Anything else is a condition that does NOT clear on its own at this
         // speed: a dangling symlink at the lock path (open reports EEXIST
         // while stat follows the link and fails), an unreadable directory, or
@@ -252,7 +258,7 @@ export async function acquireFileLock(filePath) {
           await unlink(lockPath);
         } catch (unlinkErr) {
           // ENOENT is the benign race: someone else released it first.
-          if (unlinkErr?.code !== 'ENOENT') {
+          if (errorCode(unlinkErr) !== 'ENOENT') {
             // We cannot remove an abandoned lock, so the recovery path this
             // branch exists for will not fire. Back off rather than spinning,
             // and keep the errno so the caller can say what is actually wrong.
@@ -305,7 +311,7 @@ export async function acquireFileLock(filePath) {
       } catch (err) {
         // Already gone: released twice, or stolen and released by whoever took
         // it. Either way there is nothing here to remove.
-        if (err?.code === 'ENOENT') return;
+        if (errorCode(err) === 'ENOENT') return;
         // A read that will not succeed proves nothing about who holds the lock,
         // and unlinking on that evidence is exactly the failure this check
         // exists to prevent. Leaving it costs one stale window and then clears
@@ -336,7 +342,7 @@ export async function acquireFileLock(filePath) {
       try {
         await retryTransient(() => unlink(lockPath));
       } catch (err) {
-        if (err?.code === 'ENOENT') return;
+        if (errorCode(err) === 'ENOENT') return;
         // An orphaned lock blocks every writer, in this process and any other
         // mdr instance, until it ages out. Never silent.
         console.error(

--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -8,7 +8,8 @@
  * Types live in `file-lock.d.ts`.
  */
 
-import { open, stat, unlink } from 'fs/promises';
+import { open, readFile, stat, unlink } from 'fs/promises';
+import { randomUUID } from 'crypto';
 
 import { FS_RETRY_BUDGET_MS, isTransientFsError, retryTransient, sleep } from './fs-atomic.js';
 
@@ -29,6 +30,23 @@ const LOCK_RETRY_BASE_MS = 25;
 export const LOCK_MAX_WAIT_MS = 15 * FS_RETRY_BUDGET_MS;
 
 const LOCK_MAX_ATTEMPTS = Math.ceil(LOCK_MAX_WAIT_MS / LOCK_RETRY_BASE_MS);
+
+/**
+ * What a holder writes into its lock file, and the only evidence that the lock
+ * on disk is still the one it took.
+ *
+ * The pid alone cannot do this job. It is not unique over time (pids are
+ * reused), it is not unique across machines (the prefs file lives on synced and
+ * network mounts), and a process that takes the lock twice in sequence writes
+ * the same bytes both times. A uuid alongside it makes every acquisition
+ * distinguishable from every other, and keeping the pid first leaves the file
+ * as readable to someone debugging an abandoned lock as it was before.
+ *
+ * @returns {string}
+ */
+function mintHolderToken() {
+  return `${process.pid} ${randomUUID()}`;
+}
 
 /**
  * Thrown when the attempt budget runs out, as opposed to a filesystem error,
@@ -61,6 +79,12 @@ export class LockContentionError extends Error {
  * Implementation: O_EXCL sentinel file. If the lock is older than
  * LOCK_STALE_MS we treat it as abandoned (the holder crashed) and steal it.
  *
+ * Because a lock CAN be stolen, holding one is not the same as still holding
+ * it: a holder that stalls past LOCK_STALE_MS (the machine suspends, a cloud
+ * mount hydrates the file) comes back to a lock path that now belongs to
+ * someone else. Every acquisition therefore writes a token that identifies it,
+ * and release unlinks only a lock still carrying that token.
+ *
  * @param {string} filePath
  * @returns {Promise<() => Promise<void>>} release closure
  * @throws {LockContentionError} when the attempt budget runs out. Any other
@@ -68,6 +92,7 @@ export class LockContentionError extends Error {
  */
 export async function acquireFileLock(filePath) {
   const lockPath = `${filePath}${LOCK_SUFFIX}`;
+  const token = mintHolderToken();
   let lastErr;
   for (let attempt = 0; attempt < LOCK_MAX_ATTEMPTS; attempt++) {
     let fd;
@@ -104,6 +129,13 @@ export async function acquireFileLock(filePath) {
       }
       if (Date.now() - lockStat.mtimeMs > LOCK_STALE_MS) {
         try {
+          // Removing a lock this process does not hold, on the evidence of a
+          // stat taken a moment ago. If the abandoned holder released and a
+          // third writer acquired in the gap between that stat and this call,
+          // this unlinks the new holder's lock instead. No syscall compares and
+          // removes in one step, so the window cannot be closed here, only kept
+          // to the microseconds between two adjacent calls; the release path is
+          // where it was measured in the whole duration of a held lock.
           await unlink(lockPath);
         } catch (unlinkErr) {
           // ENOENT is the benign race: someone else released it first.
@@ -129,14 +161,15 @@ export async function acquireFileLock(filePath) {
     // then blocks all writers until LOCK_STALE_MS elapses.
     let writeErr;
     try {
-      await fd.writeFile(`${process.pid}`);
+      await fd.writeFile(token);
     } catch (err) {
       writeErr = err;
     }
     // Close before unlinking: Windows refuses to remove a file that still has
-    // an open handle, which would defeat the cleanup below. The pid is only a
-    // debugging aid (staleness is decided by mtime), so a failed close on the
-    // success path is not worth failing the write over.
+    // an open handle, which would defeat the cleanup below. A close that fails
+    // AFTER the token landed is not worth failing the write over; one that
+    // failed to flush it leaves a lock this holder can no longer prove is its
+    // own, and release treats that the same way it treats a stolen one.
     await fd.close().catch(() => {});
     if (writeErr) {
       await unlink(lockPath).catch(() => {});
@@ -146,6 +179,40 @@ export async function acquireFileLock(filePath) {
     }
 
     return async () => {
+      let holder;
+      try {
+        holder = await retryTransient(() => readFile(lockPath, 'utf-8'));
+      } catch (err) {
+        // Already gone: released twice, or stolen and released by whoever took
+        // it. Either way there is nothing here to remove.
+        if (err?.code === 'ENOENT') return;
+        // A read that will not succeed proves nothing about who holds the lock,
+        // and unlinking on that evidence is exactly the failure this check
+        // exists to prevent. Leaving it costs one stale window and then clears
+        // on its own; guessing wrong costs mutual exclusion.
+        console.error(
+          `Could not read the lock at ${lockPath} to confirm it is still ` +
+            `ours, so it was left in place; writes are blocked until it ages ` +
+            `out after ${LOCK_STALE_MS}ms:`,
+          err,
+        );
+        return;
+      }
+
+      if (holder !== token) {
+        // Our lock aged past LOCK_STALE_MS while we held it and another writer
+        // took it as abandoned. The write we just finished was NOT serialized
+        // against theirs, and unlinking this would hand a third writer the same
+        // window. Say so: a file that comes back different needs an explanation
+        // somewhere, and this is the only place that has one.
+        console.error(
+          `The lock at ${lockPath} was taken over by another writer while we ` +
+            `held it (ours was idle past ${LOCK_STALE_MS}ms), so this write ` +
+            `was not serialized against theirs. Leaving their lock in place.`,
+        );
+        return;
+      }
+
       try {
         await retryTransient(() => unlink(lockPath));
       } catch (err) {

--- a/bin/file-lock.test.ts
+++ b/bin/file-lock.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
+import { spawn } from 'child_process';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { pathToFileURL } from 'url';
 
 import {
   acquireFileLock,
@@ -219,4 +221,142 @@ describe('a lock stolen out from under its holder', () => {
     },
     5_000 + LOCK_MAX_WAIT_MS,
   );
+});
+
+// An interrupt between acquiring and the caller's `finally` used to leave the
+// lock on disk, which wedges every writer of that file (this process, another
+// mdr, the server) until it ages out 30 seconds later. `mdr --restrict` is the
+// shortest path to it: one Ctrl-C in a window the user cannot see.
+//
+// Driven as real child processes because there is no in-process seam for a
+// signal: the handler under test is the one Node installs on the process, and
+// the exit status it produces is half of what the fix has to preserve.
+describe('an interrupt while the lock is held', () => {
+  const lockModule = pathToFileURL(join(__dirname, 'file-lock.js')).href;
+
+  interface Child {
+    kill: (signal: NodeJS.Signals) => void;
+    exited: Promise<{ code: number | null; signal: NodeJS.Signals | null; stderr: string }>;
+  }
+
+  /** Start a child that acquires the lock, prints `ready`, and waits. */
+  async function holdLockInChild(body = ''): Promise<Child> {
+    const source = `
+      import { acquireFileLock } from ${JSON.stringify(lockModule)};
+      ${body}
+      const release = await acquireFileLock(${JSON.stringify(target)});
+      globalThis.__release = release;
+      console.log('ready');
+      setInterval(() => {}, 1000);
+    `;
+    const child = spawn(process.execPath, ['--input-type=module', '-e', source], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.on('data', (chunk) => (stderr += String(chunk)));
+
+    await new Promise<void>((resolve, reject) => {
+      child.stdout.on('data', (chunk) => {
+        if (String(chunk).includes('ready')) resolve();
+      });
+      child.once('error', reject);
+      child.once('exit', () => reject(new Error(`child exited early: ${stderr}`)));
+    });
+
+    return {
+      kill: (signal) => child.kill(signal),
+      exited: new Promise((resolve) => {
+        child.once('exit', (code, signal) => resolve({ code, signal, stderr }));
+      }),
+    };
+  }
+
+  // On Windows there is no signal to deliver: child.kill() there is a
+  // TerminateProcess, which no handler can intercept. A real Ctrl-C in a
+  // console still reaches Node as a SIGINT event and still runs the cleanup
+  // below; it is only this way of provoking it that cannot exist.
+  const itPosix = it.skipIf(process.platform === 'win32');
+
+  itPosix('removes the lock instead of leaving it to age out', async () => {
+    const child = await holdLockInChild();
+    expect(existsSync(lockPath)).toBe(true);
+
+    child.kill('SIGINT');
+    await child.exited;
+
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  itPosix('still dies the way an uninterrupted Ctrl-C does', async () => {
+    // Handling a signal replaces Node's default disposition, so a cleanup
+    // handler that forgets to re-raise turns Ctrl-C into a hang or into the
+    // wrong exit status for every script that checks it.
+    const child = await holdLockInChild();
+    child.kill('SIGINT');
+
+    expect((await child.exited).signal).toBe('SIGINT');
+  });
+
+  itPosix('cleans up on SIGTERM too', async () => {
+    const child = await holdLockInChild();
+    child.kill('SIGTERM');
+    const { signal } = await child.exited;
+
+    expect(signal).toBe('SIGTERM');
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  itPosix("defers to the process's own handler rather than exiting under it", async () => {
+    // The server's shape: it already handles SIGINT and exits itself. Our
+    // cleanup has to run without taking that decision away from it, which is
+    // also the only path where process.exit runs instead of a signal death.
+    const child = await holdLockInChild(`
+      process.on('SIGINT', () => { console.error('server handler ran'); process.exit(3); });
+    `);
+    child.kill('SIGINT');
+    const { code, signal, stderr } = await child.exited;
+
+    expect(stderr).toContain('server handler ran');
+    expect(code).toBe(3);
+    expect(signal).toBe(null);
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  itPosix('leaves a lock that was stolen while the process stalled', async () => {
+    const child = await holdLockInChild();
+    await makeStale(lockPath);
+    const stealer = await acquireFileLock(target);
+    const stolenToken = await readFile(lockPath, 'utf-8');
+
+    child.kill('SIGINT');
+    await child.exited;
+
+    expect(await readFile(lockPath, 'utf-8')).toBe(stolenToken);
+    await stealer();
+  });
+
+  itPosix('stops handling signals once the lock is released', async () => {
+    // Cleanup that outlives the lock changes how the process dies for reasons
+    // unrelated to the lock, and a listener nothing removes is a leak in a
+    // server that writes preferences on every boot and every settings change.
+    const source = `
+      import { acquireFileLock } from ${JSON.stringify(lockModule)};
+      const release = await acquireFileLock(${JSON.stringify(target)});
+      await release();
+      console.log(JSON.stringify({
+        sigint: process.listenerCount('SIGINT'),
+        sigterm: process.listenerCount('SIGTERM'),
+        exit: process.listenerCount('exit'),
+      }));
+    `;
+    const child = spawn(process.execPath, ['--input-type=module', '-e', source], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+    const code = await new Promise<number | null>((resolve) => child.once('exit', resolve));
+
+    expect(code).toBe(0);
+    expect(JSON.parse(stdout)).toEqual({ sigint: 0, sigterm: 0, exit: 0 });
+  });
 });

--- a/bin/file-lock.test.ts
+++ b/bin/file-lock.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtemp, readFile, rm, stat, utimes, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+  acquireFileLock,
+  LOCK_MAX_WAIT_MS,
+  LOCK_STALE_MS,
+  LOCK_SUFFIX,
+  LockContentionError,
+} from './file-lock.js';
+
+// The lock had no direct test: every assertion on it ran through
+// server/preferences.test.ts, so its invariants held only where preferences
+// happened to reach them. The one below about a stolen lock did not.
+
+// Fails a syscall the way an unwritable or unreadable lock path does. Hoisted
+// because vi.mock factories run before the module body, and scoped to `.lock`
+// so arming one never catches the test's own bookkeeping on another path.
+// vi.spyOn cannot do this job: an ESM namespace object is not configurable.
+const fault = vi.hoisted(() => ({
+  unlink: { failuresLeft: 0, code: 'EPERM' },
+  readFile: { failuresLeft: 0, code: 'EIO' },
+}));
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs/promises')>();
+  const faulted = (code: string, call: string): NodeJS.ErrnoException =>
+    Object.assign(new Error(`${code}: simulated failure, ${call}`), { code });
+  return {
+    ...actual,
+    unlink: async (path: string) => {
+      if (fault.unlink.failuresLeft > 0 && String(path).endsWith(LOCK_SUFFIX)) {
+        fault.unlink.failuresLeft -= 1;
+        throw faulted(fault.unlink.code, `unlink '${path}'`);
+      }
+      return actual.unlink(path);
+    },
+    readFile: async (path: string, encoding: BufferEncoding) => {
+      if (fault.readFile.failuresLeft > 0 && String(path).endsWith(LOCK_SUFFIX)) {
+        fault.readFile.failuresLeft -= 1;
+        throw faulted(fault.readFile.code, `read '${path}'`);
+      }
+      return actual.readFile(path, encoding);
+    },
+  };
+});
+
+let dir: string;
+let target: string;
+let lockPath: string;
+
+beforeEach(async () => {
+  dir = await mkdtemp(join(tmpdir(), 'mdr-lock-'));
+  target = join(dir, '.md-redline.json');
+  lockPath = `${target}${LOCK_SUFFIX}`;
+});
+
+afterEach(async () => {
+  fault.unlink.failuresLeft = 0;
+  fault.readFile.failuresLeft = 0;
+  vi.restoreAllMocks();
+  await rm(dir, { recursive: true, force: true });
+});
+
+/** Backdate the lock so the staleness branch treats its holder as crashed. */
+async function makeStale(path: string): Promise<void> {
+  const past = new Date(Date.now() - LOCK_STALE_MS * 2);
+  await utimes(path, past, past);
+}
+
+describe('acquireFileLock', () => {
+  it('creates the lock beside the file and removes it on release', async () => {
+    const release = await acquireFileLock(target);
+    expect(existsSync(lockPath)).toBe(true);
+
+    await release();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('writes the holding pid, which is what makes an abandoned lock diagnosable', async () => {
+    const release = await acquireFileLock(target);
+    const contents = await readFile(lockPath, 'utf-8');
+    expect(contents.split(/\s/)[0]).toBe(String(process.pid));
+    await release();
+  });
+
+  it('serializes two holders: the second waits for the first to release', async () => {
+    const order: string[] = [];
+    const first = await acquireFileLock(target);
+
+    const second = acquireFileLock(target).then((release) => {
+      order.push('second-acquired');
+      return release;
+    });
+
+    // Long enough that the waiter has run several attempts and is still blocked.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(order).toEqual([]);
+
+    order.push('first-released');
+    await first();
+    await (
+      await second
+    )();
+
+    expect(order).toEqual(['first-released', 'second-acquired']);
+  });
+
+  it('steals a lock left behind by a crashed holder', async () => {
+    await writeFile(lockPath, '999999');
+    await makeStale(lockPath);
+
+    const release = await acquireFileLock(target);
+    expect(await readFile(lockPath, 'utf-8')).toContain(String(process.pid));
+    await release();
+  });
+
+  it(
+    'gives up with LockContentionError while a fresh lock stays put',
+    async () => {
+      await writeFile(lockPath, '999999');
+
+      await expect(acquireFileLock(target)).rejects.toThrow(LockContentionError);
+      // The lock it could not take is still the other holder's, untouched.
+      expect(await readFile(lockPath, 'utf-8')).toBe('999999');
+    },
+    5_000 + LOCK_MAX_WAIT_MS,
+  );
+
+  it('release is quiet when the lock is already gone', async () => {
+    const release = await acquireFileLock(target);
+    await rm(lockPath);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(release()).resolves.toBeUndefined();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('reports a release it could not perform, because an orphan blocks every writer', async () => {
+    const release = await acquireFileLock(target);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // Every attempt inside retryTransient, so the release exhausts its budget.
+    fault.unlink.failuresLeft = Number.MAX_SAFE_INTEGER;
+
+    await release();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining(lockPath),
+      expect.objectContaining({ code: 'EPERM' }),
+    );
+  });
+});
+
+describe('a lock stolen out from under its holder', () => {
+  // The scenario: a holder stalls past LOCK_STALE_MS (the machine suspends, a
+  // cloud mount hydrates the file), a second writer reads the stale mtime and
+  // steals the lock, and then the first one finishes and releases. Releasing by
+  // path alone unlinked the SECOND holder's lock, and from there nothing in the
+  // system held mutual exclusion while a writer believed it did.
+  it('is not deleted by the original holder on release', async () => {
+    const stalled = await acquireFileLock(target);
+    await makeStale(lockPath);
+
+    const stealer = await acquireFileLock(target);
+    const stolenToken = await readFile(lockPath, 'utf-8');
+
+    await stalled();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(await readFile(lockPath, 'utf-8')).toBe(stolenToken);
+
+    // And the real holder can still release its own.
+    await stealer();
+    expect(existsSync(lockPath)).toBe(false);
+  });
+
+  it('cannot be released by a holder whose own lock was replaced', async () => {
+    const stalled = await acquireFileLock(target);
+    await makeStale(lockPath);
+    const stealer = await acquireFileLock(target);
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    await stalled();
+
+    // Never silent: a writer that has lost mutual exclusion has to be able to
+    // find out why the file it wrote came back different.
+    expect(consoleError).toHaveBeenCalledWith(expect.stringContaining(lockPath));
+    await stealer();
+  });
+
+  it('leaves the lock alone when ownership cannot be established', async () => {
+    const release = await acquireFileLock(target);
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // A read that fails permanently proves nothing about who holds the lock.
+    // Unlinking on that evidence is the very defect above; orphaning ours costs
+    // one stale window and clears on its own.
+    fault.readFile.failuresLeft = Number.MAX_SAFE_INTEGER;
+
+    await release();
+
+    expect(existsSync(lockPath)).toBe(true);
+    expect(consoleError).toHaveBeenCalled();
+  });
+
+  it(
+    'does not steal a lock that is merely old but still being held',
+    async () => {
+      // Staleness is decided on mtime, so a holder that refreshes nothing looks
+      // dead the moment it crosses the threshold. What must NOT happen is a steal
+      // of a lock that is inside the window.
+      const release = await acquireFileLock(target);
+      const before = await stat(lockPath);
+      await expect(acquireFileLock(target)).rejects.toThrow(LockContentionError);
+      const after = await stat(lockPath);
+      expect(after.mtimeMs).toBe(before.mtimeMs);
+      await release();
+    },
+    5_000 + LOCK_MAX_WAIT_MS,
+  );
+});

--- a/bin/fs-atomic.d.ts
+++ b/bin/fs-atomic.d.ts
@@ -1,6 +1,7 @@
 export const FS_MAX_ATTEMPTS: number;
 export const FS_RETRY_BASE_MS: number;
 export const FS_RETRY_BUDGET_MS: number;
+export function errorCode(err: unknown): string | undefined;
 export function isTransientFsError(err: unknown): boolean;
 export function sleep(ms: number): Promise<void>;
 export function retryTransient<T>(op: () => Promise<T>): Promise<T>;

--- a/bin/fs-atomic.js
+++ b/bin/fs-atomic.js
@@ -8,7 +8,11 @@
  * two that drift: the CLI writes the user's prefs file and Claude Desktop's
  * MCP config, both of which the server or another tool may also be writing.
  *
- * Types live in `fs-atomic.d.ts`.
+ * Types live in `fs-atomic.d.ts`. The tests live in `server/fs-retry.test.ts`,
+ * not beside this file: `server/fs-retry.ts` is a re-export with no logic of
+ * its own, so those cover this module directly, and a second suite here would
+ * be duplicate surface rather than new coverage. `file-lock.js` is the opposite
+ * case and has its own.
  */
 
 import { chmod, open, readFile, rename, stat, unlink } from 'fs/promises';

--- a/bin/fs-atomic.js
+++ b/bin/fs-atomic.js
@@ -58,11 +58,26 @@ const CONTENTION_FS_CODES = new Set(['EBUSY']);
 const WINDOWS_ONLY_TRANSIENT_FS_CODES = new Set(['EPERM', 'EACCES']);
 
 /**
+ * The errno carried by a caught value, or undefined when it has none.
+ *
+ * `catch` binds `unknown`, and almost every handler across `bin/` wants the
+ * same one thing out of it. Written inline that is the same unchecked cast
+ * repeated a dozen times over; the cast is the part worth having in exactly one
+ * place, where it can say what it is assuming.
+ *
+ * @param {unknown} err
+ * @returns {string | undefined}
+ */
+export function errorCode(err) {
+  return /** @type {NodeJS.ErrnoException | null | undefined} */ (err)?.code;
+}
+
+/**
  * @param {unknown} err
  * @returns {boolean}
  */
 export function isTransientFsError(err) {
-  const code = /** @type {NodeJS.ErrnoException} */ (err)?.code;
+  const code = errorCode(err);
   if (!code) return false;
   if (CONTENTION_FS_CODES.has(code)) return true;
   // Read per call rather than captured at module load, so the tests can
@@ -203,7 +218,7 @@ async function renameIntoPlace(tmpPath, path, content) {
       // that already landed. Confirm by content rather than reporting a save
       // that succeeded as failed, and never on the first attempt, where ENOENT
       // means the temp file genuinely never existed.
-      if (firstAttempt || err?.code !== 'ENOENT') throw err;
+      if (firstAttempt || errorCode(err) !== 'ENOENT') throw err;
       if ((await readFile(path, 'utf-8').catch(() => null)) !== content) throw err;
     }
   });

--- a/bin/server-control.js
+++ b/bin/server-control.js
@@ -1,5 +1,10 @@
 import { execSync } from 'child_process';
 
+/**
+ * @param {number} port
+ * @param {NodeJS.Platform} [platform]
+ * @returns {string | null} null when the port is not a usable port number
+ */
 export function buildKillCommand(port, platform = process.platform) {
   if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
   if (platform === 'win32') {
@@ -15,9 +20,20 @@ export function buildKillCommand(port, platform = process.platform) {
   return `lsof -iTCP@127.0.0.1:${port} -sTCP:LISTEN -t | xargs kill 2>/dev/null`;
 }
 
+/**
+ * @param {number} port
+ * @param {object} [options]
+ * @param {NodeJS.Platform} [options.platform]
+ * @param {(cmd: string, opts: object) => unknown} [options.exec] seam for the
+ *   tests, which must never actually kill anything
+ * @returns {boolean}
+ */
 export function killPort(
   port,
-  { platform = process.platform, exec = (cmd, opts) => execSync(cmd, opts) } = {},
+  {
+    platform = process.platform,
+    exec = (/** @type {string} */ cmd, /** @type {object} */ opts) => execSync(cmd, opts),
+  } = {},
 ) {
   const command = buildKillCommand(port, platform);
   if (!command) return false;
@@ -49,6 +65,13 @@ export function killPort(
   }
 }
 
+/**
+ * @param {number} port
+ * @param {object} [options]
+ * @param {typeof fetch} [options.fetchFn]
+ * @param {number} [options.timeoutMs]
+ * @returns {Promise<boolean>} true only when the port answers as mdr itself
+ */
 export async function checkServer(port, { fetchFn = fetch, timeoutMs = 1_000 } = {}) {
   try {
     // 127.0.0.1, never `localhost`: the server binds IPv4 loopback only,
@@ -69,16 +92,31 @@ export async function checkServer(port, { fetchFn = fetch, timeoutMs = 1_000 } =
   }
 }
 
+/**
+ * Ask the server to exit, then wait for it to stop answering.
+ *
+ * @param {number} port
+ * @param {object} [options] every collaborator is injectable because the tests
+ *   drive this against a fake clock and a fake server
+ * @param {typeof fetch} [options.fetchFn]
+ * @param {(port: number) => Promise<boolean>} [options.checkServerFn]
+ * @param {number} [options.requestTimeoutMs]
+ * @param {number} [options.deadlineMs]
+ * @param {number} [options.pollMs]
+ * @param {() => number} [options.now]
+ * @param {(ms: number) => Promise<unknown>} [options.delay]
+ * @returns {Promise<boolean>} true when the server stopped answering in time
+ */
 export async function gracefulShutdown(
   port,
   {
     fetchFn = fetch,
-    checkServerFn = (p) => checkServer(p, { fetchFn }),
+    checkServerFn = (/** @type {number} */ p) => checkServer(p, { fetchFn }),
     requestTimeoutMs = 2_000,
     deadlineMs = 3_000,
     pollMs = 250,
     now = () => Date.now(),
-    delay = (ms) => new Promise((r) => setTimeout(r, ms)),
+    delay = (/** @type {number} */ ms) => new Promise((r) => setTimeout(r, ms)),
   } = {},
 ) {
   // The server handler returns JSON then calls `setImmediate(process.exit)`,

--- a/bin/spawn-command.js
+++ b/bin/spawn-command.js
@@ -18,6 +18,11 @@
 // token delimiters for cmd builtins like `start`.
 const NEEDS_QUOTING = /[\s&|<>^(),;=]/;
 
+/**
+ * @param {string} command
+ * @param {string[]} [args]
+ * @returns {string}
+ */
 export function buildWindowsCommand(command, args = []) {
   return [command, ...args]
     .map((part) => (part === '' || NEEDS_QUOTING.test(part) ? `"${part}"` : part))

--- a/server/fs-retry.test.ts
+++ b/server/fs-retry.test.ts
@@ -1,5 +1,15 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { chmod, mkdtemp, rm, stat, writeFile, readFile, readdir } from 'fs/promises';
+import {
+  chmod,
+  lstat,
+  mkdtemp,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+  readFile,
+  readdir,
+} from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -334,6 +344,32 @@ describe('atomicWriteFile', () => {
     await expect(atomicWriteFile(docPath, 'new\n')).rejects.toMatchObject({ code: 'EXDEV' });
     expect(fault.rename.attempts).toBe(1);
   });
+
+  // Creating a symlink on Windows needs Developer Mode or an elevated process,
+  // so the platform that cannot run this is also the one where the attack it
+  // describes does not arrive by this route.
+  it.skipIf(REAL_PLATFORM === 'win32')(
+    'replaces a symlink at the destination instead of writing through it',
+    async () => {
+      // The security half of the O_EXCL rename dance: a symlink planted at the
+      // path we are about to save is replaced by a regular file, and whatever
+      // it pointed at is untouched. Following it would let anything that can
+      // create a file in the directory redirect a save to a path of its
+      // choosing. The cost, recorded as a deliberate trade, is that a dotfiles
+      // symlink for a config file becomes a regular file until the next
+      // `chezmoi apply`.
+      const outside = join(testDir, 'outside.json');
+      await writeFile(outside, 'must not change\n');
+      const linkPath = join(testDir, 'linked.json');
+      await symlink(outside, linkPath);
+
+      await atomicWriteFile(linkPath, 'new\n');
+
+      expect(await readFile(outside, 'utf-8')).toBe('must not change\n');
+      expect(await readFile(linkPath, 'utf-8')).toBe('new\n');
+      expect((await lstat(linkPath)).isSymbolicLink()).toBe(false);
+    },
+  );
 });
 
 describe('off Windows', () => {

--- a/server/fs-retry.ts
+++ b/server/fs-retry.ts
@@ -9,6 +9,7 @@
  */
 export {
   atomicWriteFile,
+  errorCode,
   FS_MAX_ATTEMPTS,
   FS_RETRY_BASE_MS,
   FS_RETRY_BUDGET_MS,

--- a/tsconfig.bin.json
+++ b/tsconfig.bin.json
@@ -24,20 +24,24 @@
     "allowJs": true,
     "checkJs": true,
 
-    /* Baseline rather than the full `strict` of tsconfig.node.json. The
-       pre-existing modules here (ports, server-control, spawn-command,
-       version-compare) were written as untyped JS and predate this project;
-       demanding annotations on them would mean rewriting code this change has
-       no business touching. What IS caught everywhere is the class that
-       matters most for a file with no build step: undefined identifiers,
-       misspelled properties on known types, wrong arity, bad imports.
-
-       fs-atomic.js and file-lock.js carry JSDoc types, so they are checked as
-       thoroughly here as they were as TypeScript. */
-    "strict": false,
-    "noImplicitAny": false,
+    /* The same `strict` as tsconfig.node.json, so a JS file here is held to
+       what a TS file is held to in server/. This started looser because the
+       older modules predated the project and were written untyped, which meant
+       the directory that holds the CLI and every filesystem primitive it
+       shares with the server was the one place a caught error could be read
+       for a property it might not have. Annotating them was a day's work; the
+       gap it left was permanent. */
+    "strict": true,
+    "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["bin/**/*.js"]
+  /* Spelled out rather than a `bin/**` sweep, because a `.d.ts` in the include
+     list SHADOWS its `.js`: TypeScript drops the implementation from the
+     program and checks the declaration instead, silently un-checking
+     fs-atomic.js and file-lock.js, the two files here that most need it. The
+     hand-written declarations exist for the server, which imports these from a
+     project without allowJs, and they belong in that program rather than this
+     one. Verify with `tsc -p tsconfig.bin.json --listFiles` after editing. */
+  "include": ["bin/**/*.js", "bin/**/*.test.ts", "bin/cli-browser-stub.ts"]
 }


### PR DESCRIPTION
**Stacked.** Sits on #50 (the CLI body only exists as a checkable file there) and merges #49 (`file-lock.js` needs strict fixes on lines that PR rewrites). The base retargets to `main` when #50 merges, and #49's commits drop out of this diff once #49 merges. Review the last commit; the rest belongs to the two below it.

---

`tsconfig.bin.json` turned off `strict` and `noImplicitAny` because the older modules here were written untyped and predate the project that started checking them at all. The result was that the directory holding the CLI and every filesystem primitive it shares with the server was the one place in the repo where a caught error could be read for a property it might not have, and a parameter could be anything at all. Annotating them was an afternoon. The gap had no end date.

### 43 errors, two kinds

Parameters with no annotation, and `catch` bindings used as though they were errnos.

The second is now a single exported helper, `errorCode`, so the unchecked cast from `unknown` to an error with a `.code` is written down once, where it can state what it assumes, rather than a dozen times inline where it cannot. `server/fs-retry.ts` re-exports it, since the server catches the same things. The CLI keeps a local twin for the message half, which degrades a non-Error throw to something printable instead of failing inside the handler that was already reporting a failure.

Error text is unchanged, including the `(undefined)` that a code-less failure renders. That was deliberate: several of these strings are asserted in the CLI subprocess tests, and this change has no business editing what the user sees.

### The test files join the project

`bin/*.test.ts` belonged to no tsconfig project and so were checked by nothing. They join this one, which already has `allowJs` and can therefore resolve the JS modules they import without a declaration file for each.

### One trap, worth knowing about

The obvious include for that is `["bin/**/*.js", "bin/**/*.ts"]`. It works, and it silently stops checking `fs-atomic.js` and `file-lock.js`: the glob picks up their `.d.ts`, and a declaration in the program **shadows** its implementation, so tsc drops the `.js` and checks the declaration instead. Nothing fails; the files just stop being checked.

The include now names three globs one at a time, with the reason recorded in the config and in AGENTS.md, along with the only way to see it: `tsc -p tsconfig.bin.json --listFiles`.

### Verification

`npm run build`, 1909 unit tests, `tsc -b`, `eslint .`, `format:check`. `--listFiles` confirms all 21 files in `bin/` are in the program, tests included, where before neither the tests nor the CLI were.