### PR TITLE
Write a background tab's backfill the way the active tab's is written

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -757,7 +757,13 @@ on `--theme-bg-inset`), never the crimson accent:
   (the case that matters most, since no toast fires there), and an explicit
   reload. None of them mark anything while a tab's first fetch is still in
   flight, since with no prior content to diff against the file's whole reply
-  history would look new. Activating a comment marks its replies read, in
+  history would look new. Stamping a reply changes the content, so both SSE
+  paths write it back through `scheduleBackfillWrite`, one debounce timer per
+  path. That write is not a save and must not behave like one: it waits 2s so an
+  agent can finish a batch, and it goes out as a direct fetch rather than
+  through the save queue, which reports a 409 as a failed save. Here a 409 is
+  the ordinary outcome, because the agent writes again in the meantime and the
+  next event re-triggers the backfill. Activating a comment marks its replies read, in
   either density. Only anchored density surfaces the unread state, because
   it is the only one that hides reply text; List density renders every reply
   in full but does not clear the marks by itself, so a reply read there stays

--- a/e2e/file-watcher.spec.ts
+++ b/e2e/file-watcher.spec.ts
@@ -8,6 +8,7 @@ import { resetTestAppState } from './helpers/test-state';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE = resolve(__dirname, 'fixtures/test-doc.md');
+const FIXTURE_2 = resolve(__dirname, 'fixtures/test-doc-2.md');
 const FIXTURE_ORIGINAL = TEST_DOC_BASELINE;
 
 test.beforeEach(async ({ page }) => {
@@ -418,5 +419,60 @@ test.describe('File watcher - external changes', () => {
         timeout: 5_000,
       })
       .toBe(true);
+  });
+
+  test('a background tab backfills on the same debounce as the active tab', async ({ page }) => {
+    // The two watchers shared the code that stamps arriving replies but not the
+    // write that persists it. The active tab waits 2s and writes with a direct
+    // fetch; the background tab went straight to the save queue, which reports
+    // a 409 as a failed save. A 409 is the expected outcome here, because the
+    // agent writes again between the event and the write, so the reader got
+    // "File was modified externally" on a tab they were not even looking at,
+    // for a write they never asked for.
+    await openFixture(page);
+    await page.waitForTimeout(1500);
+
+    // Open a second file, which pushes the fixture into a background tab.
+    await page.locator('button[title="Open file"]').click();
+    const input = page.getByPlaceholder('File path or name...');
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill(FIXTURE_2);
+    await input.press('Enter');
+    await expect(page.getByRole('heading', { name: 'Second Test Document' })).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.waitForTimeout(1500);
+
+    const stampedAt = () =>
+      readFileSync(FIXTURE, 'utf-8').match(/"id":"bg-r1"[^}]*"timestamp":"([^"]+)"/)?.[1] ?? null;
+
+    // An agent-style reply, with no timestamp of its own, into the file behind
+    // the background tab.
+    writeFileSync(
+      FIXTURE,
+      FIXTURE_ORIGINAL.replace(
+        'valid credentials',
+        `<!-- @comment${JSON.stringify({
+          id: 'bg-c1',
+          anchor: 'valid credentials',
+          text: 'How are creds validated?',
+          author: 'Dennis',
+          timestamp: '2025-01-01T00:00:00.000Z',
+          replies: [{ id: 'bg-r1', text: 'JWT bearer.', author: 'Agent CLI' }],
+        })} -->valid credentials`,
+      ),
+    );
+
+    // The server debounces its watch events by 150ms, so an undebounced write
+    // lands within about 400ms. Nothing may be on disk at this point: waiting
+    // is what keeps an agent's next edit from failing under it.
+    await page.waitForTimeout(900);
+    expect(stampedAt()).toBeNull();
+
+    // And it still lands, once the debounce elapses.
+    await expect.poll(stampedAt, { timeout: 10_000 }).not.toBeNull();
+
+    // Nothing about a backfill is the reader's business, on any tab.
+    await expect(page.getByText(/modified externally/i)).not.toBeVisible();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,16 @@ import { PAD_L, DOC_WIDTH_COLS } from './lib/page-geometry';
 /** Shared empty result for the "no replies arrived" case. */
 const NO_REPLY_IDS: ReadonlySet<string> = new Set<string>();
 
+/**
+ * How long a timestamp backfill waits before writing.
+ *
+ * Long enough that an agent finishes a batch of edits first. Each write it
+ * makes arrives as an SSE event, and answering every one of them immediately
+ * changes the file under the agent's feet, which it reports as "Error editing
+ * file" on its next edit.
+ */
+const BACKFILL_WRITE_DELAY_MS = 2000;
+
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad|iPod/.test(navigator.userAgent);
 const modKey = isMac ? '\u2318' : 'Ctrl';
 const prevTabShortcut = isMac ? '\u2318\u21e7[' : 'Ctrl+Shift+[';
@@ -154,7 +164,6 @@ export default function App() {
     closeTabsToRight: closeTabsToRightDirect,
     switchTab,
     saveFile,
-    saveFileAt,
     getTabSnapshot,
     reloadFile,
     retryAllAccessDenied,
@@ -599,12 +608,66 @@ export default function App() {
   // it from either view.
   const [copyFeedback, setCopyFeedback] = useState(false);
   const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const backfillTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Keyed by path, not one timer for the whole app: two tabs can be backfilling
+  // at once, and a single timer meant whichever scheduled second cancelled the
+  // first, dropping its corrected timestamps until some later event happened to
+  // re-trigger it.
+  const backfillTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
   useEffect(
     () => () => {
       if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      for (const timer of backfillTimersRef.current.values()) clearTimeout(timer);
+      backfillTimersRef.current.clear();
     },
     [],
+  );
+
+  /**
+   * Write back content whose timestamps we corrected on the way in.
+   *
+   * Every watcher goes through here, foreground and background alike. This is
+   * NOT a user save and must not look like one: it is debounced so an agent can
+   * finish a batch first, and it writes with a direct fetch rather than through
+   * the save queue, because the queue reports a 409 as a failed save. A 409 is
+   * the ordinary outcome here, not a failure. The agent edits the file between
+   * the event that triggered this and the write itself, and the next event
+   * re-triggers the backfill anyway.
+   *
+   * A background tab used to take the queue instead, so the same expected 409
+   * surfaced on the tab as "File was modified externally. Reload to see
+   * changes." for a write the reader never asked for.
+   */
+  const scheduleBackfillWrite = useCallback(
+    (path: string, content: string, expectedMtime: number | undefined) => {
+      const pending = backfillTimersRef.current.get(path);
+      if (pending) clearTimeout(pending);
+      backfillTimersRef.current.set(
+        path,
+        setTimeout(async () => {
+          backfillTimersRef.current.delete(path);
+          try {
+            const res = await fetch('/api/file', {
+              method: 'PUT',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ path, content, expectedMtime }),
+            });
+            // On success, sync the tab's mtime to the post-backfill value so
+            // the next user-initiated save doesn't 409 against the stale
+            // pre-backfill mtime. The backfill's own write is suppressed by
+            // the server's lastWrittenContent cache, so no SSE event will
+            // deliver this mtime — we have to read it from the response.
+            if (res.ok) {
+              const data = await readJsonResponse<{ mtime?: number }>(res);
+              if (data?.mtime != null) updateTab(path, { mtime: data.mtime });
+            }
+            // 409s are expected and benign here (see above) — ignore.
+          } catch {
+            // Network errors: the next SSE event will re-trigger the backfill.
+          }
+        }, BACKFILL_WRITE_DELAY_MS),
+      );
+    },
+    [updateTab],
   );
   const handleCopyDocument = useCallback(() => {
     const clean = rawMarkdownRef.current.replace(createCommentMarkerRegex(), '');
@@ -1582,49 +1645,9 @@ export default function App() {
       });
 
       // Persist the corrected timestamps back to disk so reloads see the right
-      // values. Debounced to avoid a write-watch-write bounce when an agent
-      // makes rapid edits: each agent write triggers an SSE event → backfill →
-      // save → SSE event, which changes the file under the agent's feet and
-      // causes "Error editing file" on its next edit. A 2s debounce lets the
-      // agent finish its batch of edits before we write the timestamps.
-      //
-      // Uses a direct fetch instead of saveFile() because the save queue shows
-      // a "Save failed" toast on 409 CONFLICT. Since the agent modifies the
-      // file between the SSE event and the debounced save, 409s are expected
-      // and benign — the next SSE event will re-trigger the backfill.
+      // values.
       if (nextContent !== content) {
-        if (backfillTimerRef.current) clearTimeout(backfillTimerRef.current);
-        const pathToSave = path;
-        const contentToSave = nextContent;
-        const mtimeToSave = mtime;
-        backfillTimerRef.current = setTimeout(async () => {
-          backfillTimerRef.current = null;
-          try {
-            const res = await fetch('/api/file', {
-              method: 'PUT',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                path: pathToSave,
-                content: contentToSave,
-                expectedMtime: mtimeToSave,
-              }),
-            });
-            // On success, sync the tab's mtime to the post-backfill value so
-            // the next user-initiated save doesn't 409 against the stale
-            // pre-backfill mtime. The backfill's own write is suppressed by
-            // the server's lastWrittenContent cache, so no SSE event will
-            // deliver this mtime — we have to read it from the response.
-            if (res.ok) {
-              const data = await readJsonResponse<{ mtime?: number }>(res);
-              if (data?.mtime != null) {
-                updateTab(pathToSave, { mtime: data.mtime });
-              }
-            }
-            // 409s are expected and benign here (see comment above) — ignore.
-          } catch {
-            // Network errors: the next SSE event will re-trigger the backfill.
-          }
-        }, 2000);
+        scheduleBackfillWrite(path, nextContent, mtime);
       }
 
       // Flag the diff button when content changed and a snapshot exists
@@ -1636,6 +1659,7 @@ export default function App() {
       activeFilePath,
       applyExternalContent,
       getTabSnapshot,
+      scheduleBackfillWrite,
       setDiffEnabled,
       settings.enableResolve,
       showToast,
@@ -1675,7 +1699,7 @@ export default function App() {
         const snapshot = getTabSnapshot(path);
         // Skip dirty background tabs entirely. The user has unsaved local
         // edits we'd otherwise overwrite (in memory AND on disk via the
-        // saveFileAt below). They should resolve the conflict by switching
+        // backfill write below). They should resolve the conflict by switching
         // to the tab and reloading explicitly.
         if (snapshot?.dirty === true) return;
         if (!snapshot) return;
@@ -1696,7 +1720,7 @@ export default function App() {
           ...(mtime != null ? { mtime } : {}),
         });
         if (nextContent !== content) {
-          saveFileAt(path, nextContent);
+          scheduleBackfillWrite(path, nextContent, mtime);
         }
       } catch {
         // ignore malformed events
@@ -1709,7 +1733,7 @@ export default function App() {
     backgroundPathsKey,
     getTabSnapshot,
     pageVisible,
-    saveFileAt,
+    scheduleBackfillWrite,
     updateTab,
   ]);
 


### PR DESCRIPTION
Both file watchers stamp arriving replies through the same helper, `applyExternalContent`, and then diverged on the write that persists the result.

The active tab waits 2s and writes with a direct fetch, for two reasons it documents inline:

- the delay lets an agent finish a batch of edits, because answering every one of its writes changes the file under it, which it reports as `Error editing file` on its next edit;
- the direct fetch keeps the expected 409 quiet, because the agent writes again between the event and the write.

The background tab called `saveFileAt` at once and got neither. That queue reports a 409 as a failed save, so the reader got `File was modified externally. Reload to see changes.` on a tab they were not looking at, for a write they never asked for.

### One function, one timer per path

Both paths now call `scheduleBackfillWrite`. It keeps a timer per path rather than the single timer the active path had: two tabs can be backfilling at once, and whichever scheduled second cancelled the first, dropping its corrected timestamps until some later event happened to re-trigger it. The timers are cleared on unmount now; the old one never was.

`saveFileAt` is no longer used in `App.tsx` and its binding is gone. It remains on the hook for the save path proper.

### Pinning the behavior from outside

The regression test asserts on the file rather than on anything internal. The server debounces its watch events by 150ms, so an undebounced write is on disk within about 400ms. The test requires nothing to be there at 900ms, and the corrected timestamp to arrive after that.

That assertion is what fails on the old code, which is the point of writing it this way:

```
Error: expect(received).toBeNull()
Received: "2026-08-11T18:30:09.830Z"
  > 470 |     expect(stampedAt()).toBeNull();
```

Verified in both directions: passing on this branch, failing with `src/App.tsx` reverted to main's version, on that line and no other.

### Verification

`npm run build`, 1891 unit tests, `tsc -b`, `eslint .`, `format:check`, and all 11 tests in `e2e/file-watcher.spec.ts`, which includes the existing active-tab backfill regression that now runs through the shared function.