### PR TITLE
Act on the server the user named, not the one that started last

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,8 +293,10 @@ implementations. A wrong argument to any of them is a build error again, which
 is what the declarations were for, except that nothing had ever checked THEM
 against the code they described.
 
-**Which running server a command acts on is `serverProbeOrder`, and the order is
-a correctness property.** A port the user NAMED (`MD_REDLINE_PORT`, or the
+**Which running server a command acts on is `serverProbeOrder`** (in
+`bin/server-control.js`, with the rest of finding and acting on a running
+server, rather than in `ports.js`, which resolves what port to bind)**, and the
+order is a correctness property.** A port the user NAMED (`MD_REDLINE_PORT`, or the
 `PORT` alias) is probed before the one in the port file, then the scan ranges,
 deduped. The port file records whichever server started last, so consulting it
 first meant a command aimed at one instance acted on another and said it
@@ -392,6 +394,7 @@ The undocumented `mdr __port` prints the API port the CLI resolved and exits, wh
 is the only way to observe it: that value only seeds the fallback scan inside
 `findServerPort`, and `--stop` would kill whatever it found. The same test file uses
 it to prove the CLI agrees with the server and `vite.config.ts`.
+
 The undocumented `mdr __find-server` prints which running server this invocation
 would act on (or `none`) and touches nothing, which is the only way to observe
 that choice: every other command that makes it then either kills the server or

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -293,6 +293,17 @@ implementations. A wrong argument to any of them is a build error again, which
 is what the declarations were for, except that nothing had ever checked THEM
 against the code they described.
 
+**Which running server a command acts on is `serverProbeOrder`, and the order is
+a correctness property.** A port the user NAMED (`MD_REDLINE_PORT`, or the
+`PORT` alias) is probed before the one in the port file, then the scan ranges,
+deduped. The port file records whichever server started last, so consulting it
+first meant a command aimed at one instance acted on another and said it
+succeeded: `--stop` killed the wrong server, and a plain `mdr` attached to it.
+Deciding this needs `resolveNamedApiPort`, not `resolveApiPort`, because that
+one answers 6373 both to an explicit `MD_REDLINE_PORT=6373` and to nothing set
+at all. With nothing named the port file still comes first, and has to: it is
+how a server that scanned upward past a busy default is found.
+
 `bin/fs-atomic.js`, `bin/file-lock.js` and `bin/home-dir.js` live there for the
 same reason, and it matters more for them: the CLI writes `.md-redline.json`
 (`mdr --restrict`, and the trust disclosure reads it) while the server rewrites
@@ -381,6 +392,13 @@ The undocumented `mdr __port` prints the API port the CLI resolved and exits, wh
 is the only way to observe it: that value only seeds the fallback scan inside
 `findServerPort`, and `--stop` would kill whatever it found. The same test file uses
 it to prove the CLI agrees with the server and `vite.config.ts`.
+The undocumented `mdr __find-server` prints which running server this invocation
+would act on (or `none`) and touches nothing, which is the only way to observe
+that choice: every other command that makes it then either kills the server or
+opens a browser at it, and neither is something a test can do to a developer's
+machine. `bin/find-server-cli.test.ts` drives it against fake servers with the
+port file redirected via `TMPDIR`.
+
 The undocumented `mdr __first-launch` prints which trust disclosure this
 invocation would print (`seeded`, `unreadable` or `configured`) and exits, for
 the same reason: the answer is otherwise a line or two of text in the middle of

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,9 +24,9 @@ import { createRequire } from 'module';
 import { acquireFileLock, LOCK_MAX_WAIT_MS, LockContentionError } from './file-lock.js';
 import { atomicWriteFile, errorCode, retryTransient } from './fs-atomic.js';
 import { resolveHomeDir } from './home-dir.js';
-import { FALLBACK_PORT, resolveNamedApiPort, serverProbeOrder } from './ports.js';
+import { FALLBACK_PORT, isValidPort, resolveNamedApiPort } from './ports.js';
 
-import { checkServer, gracefulShutdown, killPort } from './server-control.js';
+import { checkServer, gracefulShutdown, killPort, serverProbeOrder } from './server-control.js';
 import { buildWindowsCommand } from './spawn-command.js';
 import { isNewerVersion } from './version-compare.js';
 
@@ -172,7 +172,7 @@ async function resolveTarget(arg) {
 async function readPortFile() {
   try {
     const port = Number((await readFile(PORT_FILE, 'utf8')).trim());
-    return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
+    return isValidPort(port) ? port : null;
   } catch {
     // No port file or an unreadable one. Both mean nothing is recorded.
     return null;
@@ -183,14 +183,12 @@ async function readPortFile() {
  * @returns {Promise<number | null>} The first port answering as mdr, or null.
  */
 async function findServerPort() {
-  const bases =
-    DEFAULT_SERVER_PORT === LEGACY_SERVER_PORT
-      ? [DEFAULT_SERVER_PORT]
-      : [DEFAULT_SERVER_PORT, LEGACY_SERVER_PORT];
+  // No guard against the two being equal: serverProbeOrder dedupes, so a
+  // repeated base contributes nothing and shifts nothing.
   const order = serverProbeOrder({
     namedPort: NAMED_SERVER_PORT,
     portFilePort: await readPortFile(),
-    scanBases: bases,
+    scanBases: [DEFAULT_SERVER_PORT, LEGACY_SERVER_PORT],
     scanCount: MAX_PORT_SCAN,
   });
   for (const port of order) {
@@ -373,11 +371,18 @@ async function stopServer(quiet = false) {
     killPort(clientPort);
   }
 
-  // Clean up port file
-  try {
-    await unlink(PORT_FILE);
-  } catch {
-    // Already gone is the ordinary case: the server removes it on the way out.
+  // Only when it records the server we just killed. Now that a named port can
+  // win over the recorded one, the two are no longer the same server, and
+  // deleting the record of one that is still running costs the next `mdr` its
+  // fast-path lookup: if that server sits outside the scan windows, the CLI
+  // starts a second one and orphans it. `removePortFileIfOwned` in
+  // server/index.ts is the same guard, for the same reason, on the way out.
+  if ((await readPortFile()) === serverPort) {
+    try {
+      await unlink(PORT_FILE);
+    } catch {
+      // Already gone is the ordinary case: the server removes it on the way out.
+    }
   }
 
   if (!quiet) console.log('mdr stopped.');

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -24,7 +24,7 @@ import { createRequire } from 'module';
 import { acquireFileLock, LOCK_MAX_WAIT_MS, LockContentionError } from './file-lock.js';
 import { atomicWriteFile, errorCode, retryTransient } from './fs-atomic.js';
 import { resolveHomeDir } from './home-dir.js';
-import { resolveApiPort } from './ports.js';
+import { FALLBACK_PORT, resolveNamedApiPort, serverProbeOrder } from './ports.js';
 
 import { checkServer, gracefulShutdown, killPort } from './server-control.js';
 import { buildWindowsCommand } from './spawn-command.js';
@@ -37,7 +37,10 @@ const APP_DIR = resolve(__dirname, '..');
 const require = createRequire(import.meta.url);
 const { version: CLI_VERSION } = require(join(APP_DIR, 'package.json'));
 const DIST_SERVER = join(APP_DIR, 'dist', 'server.js');
-const DEFAULT_SERVER_PORT = resolveApiPort();
+// Asked for once, not once per reader: `resolvePort` warns on a value it cannot
+// use, and calling it twice would say so twice for a single typo.
+const NAMED_SERVER_PORT = resolveNamedApiPort();
+const DEFAULT_SERVER_PORT = NAMED_SERVER_PORT ?? FALLBACK_PORT;
 // Pre-0.7 servers bound 3001+. 0.7.0 (2026-07-18) moved the default to 6373, and
 // 0.6.0 shipped four days before it, so a machine that has not rebooted since can
 // still have one running. Scanning the old range lets the stale-server upgrade path
@@ -161,26 +164,37 @@ async function resolveTarget(arg) {
   throw new Error(`not a file or directory: ${arg}`);
 }
 
-async function findServerPort() {
-  // Try the port file first (fast path)
+/**
+ * Port recorded by the server that started most recently, or null.
+ *
+ * @returns {Promise<number | null>}
+ */
+async function readPortFile() {
   try {
-    const saved = (await readFile(PORT_FILE, 'utf8')).trim();
-    const port = Number(saved);
-    if (port && (await checkServer(port))) return port;
+    const port = Number((await readFile(PORT_FILE, 'utf8')).trim());
+    return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
   } catch {
-    // No port file, an unreadable one, or a port nothing answers on. All three
-    // mean the same thing here: nothing recorded, so scan for it.
+    // No port file or an unreadable one. Both mean nothing is recorded.
+    return null;
   }
+}
 
-  // Scan the port range as fallback, then the legacy pre-0.7 range
+/**
+ * @returns {Promise<number | null>} The first port answering as mdr, or null.
+ */
+async function findServerPort() {
   const bases =
     DEFAULT_SERVER_PORT === LEGACY_SERVER_PORT
       ? [DEFAULT_SERVER_PORT]
       : [DEFAULT_SERVER_PORT, LEGACY_SERVER_PORT];
-  for (const base of bases) {
-    for (let p = base; p < base + MAX_PORT_SCAN; p++) {
-      if (await checkServer(p)) return p;
-    }
+  const order = serverProbeOrder({
+    namedPort: NAMED_SERVER_PORT,
+    portFilePort: await readPortFile(),
+    scanBases: bases,
+    scanCount: MAX_PORT_SCAN,
+  });
+  for (const port of order) {
+    if (await checkServer(port)) return port;
   }
   return null;
 }
@@ -1019,6 +1033,17 @@ async function main() {
     // (--stop) kills whatever it finds. Lets a test prove the CLI, the server and
     // vite.config all answer with the same port for the same environment.
     console.log(DEFAULT_SERVER_PORT);
+    return;
+  }
+
+  if (process.argv[2] === '__find-server') {
+    // Internal, undocumented seam, same idea as __open above: print which
+    // running server this invocation would act on, and touch nothing. Every
+    // command that picks a server picks it here, and the choice is otherwise
+    // observable only through what the command then does to it: --stop kills
+    // it, and everything else opens a browser at it. Neither is something a
+    // test can do to a developer's machine.
+    console.log((await findServerPort()) ?? 'none');
     return;
   }
 

--- a/bin/find-server-cli.test.ts
+++ b/bin/find-server-cli.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { spawn } from 'child_process';
+import { spawn, type ChildProcess } from 'child_process';
 import { createServer, type Server } from 'http';
 import { mkdtempSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
@@ -17,6 +17,7 @@ import { join } from 'path';
 const BIN = join(__dirname, 'md-redline');
 
 const servers: Server[] = [];
+const children: ChildProcess[] = [];
 let scratch: string | null = null;
 
 /**
@@ -73,10 +74,14 @@ function findServer(env: NodeJS.ProcessEnv = {}): Promise<string> {
       },
       stdio: ['ignore', 'pipe', 'pipe'],
     });
+    children.push(child);
     let stdout = '';
     child.stdout.on('data', (chunk) => (stdout += String(chunk)));
     child.once('error', reject);
-    child.once('exit', () => resolvePromise(stdout.trim()));
+    // 'close', not 'exit': exit can fire before stdio has drained, and the
+    // port this reads IS the assertion. Every other subprocess test in bin/
+    // uses 'exit', but none of them races the child's last write.
+    child.once('close', () => resolvePromise(stdout.trim()));
   });
 }
 
@@ -85,6 +90,10 @@ function writePortFile(port: number): void {
 }
 
 afterEach(async () => {
+  // A child that never exits would otherwise outlive the test that spawned it:
+  // vitest abandons the awaiting promise on timeout, but nothing reaps the
+  // process. The servers get the same treatment, which they already had.
+  for (const child of children.splice(0)) child.kill();
   await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
   if (scratch) rmSync(scratch, { recursive: true, force: true });
   scratch = null;
@@ -136,10 +145,27 @@ describe('choosing which running server to act on', () => {
   });
 });
 
-/** A port nothing is listening on: bound, read back, released. */
+/**
+ * A port nothing is listening on: bound, read back, released.
+ *
+ * Deliberately not startFakeServer plus a pop() off the shared array. That
+ * borrowed both its request handling, which is irrelevant here, and an
+ * assumption that every caller awaits sequentially, which would silently close
+ * somebody else's server the first time two of these ran concurrently.
+ */
 async function unusedPort(): Promise<number> {
-  const { port } = await startFakeServer();
-  const server = servers.pop();
-  await new Promise((r) => server?.close(r));
+  const server = createServer();
+  const port = await new Promise<number>((resolvePromise, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('no port assigned'));
+        return;
+      }
+      resolvePromise(address.port);
+    });
+  });
+  await new Promise((r) => server.close(r));
   return port;
 }

--- a/bin/find-server-cli.test.ts
+++ b/bin/find-server-cli.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawn } from 'child_process';
+import { createServer, type Server } from 'http';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Which running server a command acts on. Every command that needs one picks it
+// through findServerPort, and picking the wrong one is not a failure the user
+// sees: `--stop` reports success for an instance it never touched, and a plain
+// `mdr` attaches to it.
+//
+// Driven through the `__find-server` seam rather than `--stop`, because --stop
+// kills what it finds and also sweeps 5188-5197 for a Vite client, which on a
+// developer's machine is their own dev server.
+
+const BIN = join(__dirname, 'md-redline');
+
+const servers: Server[] = [];
+let scratch: string | null = null;
+
+/**
+ * A server that answers the way mdr does. `checkServer` requires `/api/config`
+ * to return an object with a `homeDir` string, so anything less is not
+ * something the CLI would ever select.
+ */
+function startFakeServer(): Promise<{ port: number }> {
+  return new Promise((resolvePromise, reject) => {
+    const server = createServer((req, res) => {
+      if (req.url === '/api/config') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ homeDir: '/tmp/fake-home' }));
+        return;
+      }
+      res.writeHead(404);
+      res.end();
+    });
+    servers.push(server);
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') {
+        reject(new Error('no port assigned'));
+        return;
+      }
+      resolvePromise({ port: address.port });
+    });
+  });
+}
+
+/** The scratch temp dir for this test, created on first use. */
+function scratchDir(): string {
+  scratch ??= mkdtempSync(join(tmpdir(), 'mdr-find-'));
+  return scratch;
+}
+
+/** Run the seam with the port file redirected into a scratch temp dir. */
+function findServer(env: NodeJS.ProcessEnv = {}): Promise<string> {
+  const dir = scratchDir();
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(process.execPath, [BIN, '__find-server'], {
+      env: {
+        ...process.env,
+        // os.tmpdir() reads TMPDIR on POSIX and TEMP/TMP on Windows, and it is
+        // what decides where the port file lives. Redirected so the test never
+        // reads or writes the one a real mdr on this machine is using.
+        TMPDIR: dir,
+        TEMP: dir,
+        TMP: dir,
+        MD_REDLINE_PORT: '',
+        PORT: '',
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+    child.once('error', reject);
+    child.once('exit', () => resolvePromise(stdout.trim()));
+  });
+}
+
+function writePortFile(port: number): void {
+  writeFileSync(join(scratchDir(), 'md-redline.port'), String(port));
+}
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+  if (scratch) rmSync(scratch, { recursive: true, force: true });
+  scratch = null;
+});
+
+describe('choosing which running server to act on', () => {
+  it('picks the port the user named over the one in the port file', async () => {
+    // The report: two servers up, the port file naming whichever started last.
+    // `MD_REDLINE_PORT=7441 mdr --stop` printed "mdr stopped." while 7441 kept
+    // running and 7440, which the user never named, was the one that died.
+    const named = await startFakeServer();
+    const recorded = await startFakeServer();
+    writePortFile(recorded.port);
+
+    expect(await findServer({ MD_REDLINE_PORT: String(named.port) })).toBe(String(named.port));
+  });
+
+  it('accepts the PORT alias as naming a server too', async () => {
+    const named = await startFakeServer();
+    const recorded = await startFakeServer();
+    writePortFile(recorded.port);
+
+    expect(await findServer({ PORT: String(named.port) })).toBe(String(named.port));
+  });
+
+  it('falls back to the port file when the named server is not answering', async () => {
+    // Naming a port is not a demand that it be the only candidate. A stale
+    // MD_REDLINE_PORT in a shell profile must not stop the CLI finding the
+    // server that is actually running.
+    const recorded = await startFakeServer();
+    writePortFile(recorded.port);
+    const deadPort = await unusedPort();
+
+    expect(await findServer({ MD_REDLINE_PORT: String(deadPort) })).toBe(String(recorded.port));
+  });
+
+  it('still prefers the port file when nothing was named', async () => {
+    // How a server that scanned upward past a busy default gets found at all.
+    const recorded = await startFakeServer();
+    writePortFile(recorded.port);
+
+    expect(await findServer()).toBe(String(recorded.port));
+  });
+
+  it('reports none when the named port is dead and nothing is recorded', async () => {
+    const deadPort = await unusedPort();
+
+    expect(await findServer({ MD_REDLINE_PORT: String(deadPort) })).toBe('none');
+  });
+});
+
+/** A port nothing is listening on: bound, read back, released. */
+async function unusedPort(): Promise<number> {
+  const { port } = await startFakeServer();
+  const server = servers.pop();
+  await new Promise((r) => server?.close(r));
+  return port;
+}

--- a/bin/ports.js
+++ b/bin/ports.js
@@ -17,6 +17,18 @@
  * the prefixed name.
  */
 
+/**
+ * A number a server could actually bind. One definition, because the rule was
+ * written out in three places and they have to change together or the CLI's
+ * idea of a usable port drifts from what this module will accept.
+ *
+ * @param {number} port
+ * @returns {boolean}
+ */
+export function isValidPort(port) {
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
+}
+
 /** 6373 spells "MDR" on a phone keypad, clear of the 3000-3010 range Next/Nest/CRA contend for. */
 export const FALLBACK_PORT = 6373;
 
@@ -37,10 +49,16 @@ export const FALLBACK_PORT = 6373;
  * evaluating, before the startup chain that renders errors as one readable line,
  * and a typo in a port should not brick a local tool.
  *
+ * The fallback is returned as given rather than coerced, so a caller that needs
+ * to distinguish "nobody named a port" from "somebody named the default" can
+ * pass null and be told, instead of decoding a sentinel port number that has to
+ * stay outside the valid range to work.
+ *
+ * @template T
  * @param {Record<string, string | undefined>} env
  * @param {readonly string[]} names Candidates in priority order.
- * @param {number} fallback Used when no candidate holds a usable port.
- * @returns {number} A port between 1 and 65535.
+ * @param {T} fallback Used when no candidate holds a usable port.
+ * @returns {number | T} A port between 1 and 65535, or `fallback`.
  */
 export function resolvePort(env, names, fallback) {
   for (const name of names) {
@@ -50,17 +68,11 @@ export function resolvePort(env, names, fallback) {
     // Number, not parseInt: parseInt('7100nonsense') is 7100, which would start
     // the server somewhere the user never asked for.
     const port = Number(value);
-    if (Number.isInteger(port) && port >= 1 && port <= 65535) return port;
+    if (isValidPort(port)) return port;
     console.warn(`[md-redline] ${name}="${raw}" is not a valid port number; ignoring it.`);
   }
   return fallback;
 }
-
-/**
- * Sentinel for "no candidate held a usable port". Outside 1-65535, so
- * `resolvePort` can never return it from a real value.
- */
-const NO_PORT = -1;
 
 /** Candidates for the API port, in priority order. */
 const API_PORT_NAMES = /** @type {const} */ (['MD_REDLINE_PORT', 'PORT']);
@@ -82,8 +94,7 @@ const API_PORT_NAMES = /** @type {const} */ (['MD_REDLINE_PORT', 'PORT']);
  * @returns {number | null}
  */
 export function resolveNamedApiPort(env = process.env) {
-  const port = resolvePort(env, API_PORT_NAMES, NO_PORT);
-  return port === NO_PORT ? null : port;
+  return resolvePort(env, API_PORT_NAMES, null);
 }
 
 /**
@@ -95,34 +106,4 @@ export function resolveNamedApiPort(env = process.env) {
  */
 export function resolveApiPort(env = process.env) {
   return resolveNamedApiPort(env) ?? FALLBACK_PORT;
-}
-
-/**
- * Ports to probe, in order, when looking for a server that is already running.
- *
- * Order is the whole content of this function, and it is a correctness
- * property rather than a performance one. The port file records whichever
- * server started last, so consulting it first means a command aimed at a
- * specific server acts on a different one and reports success: `--stop` killed
- * the wrong instance, and a plain `mdr` attached to it. A port the user NAMED
- * therefore outranks the recorded one.
- *
- * With nothing named, the port file still comes first, and has to: it is how a
- * server that scanned upward past a busy default is found at all.
- *
- * @param {object} options
- * @param {number | null} options.namedPort Port the user asked for, if any.
- * @param {number | null} options.portFilePort Port recorded by a running server.
- * @param {readonly number[]} options.scanBases Range starts, in order.
- * @param {number} options.scanCount Ports to try from each base.
- * @returns {number[]} Deduped, so a port already tried is not probed twice.
- */
-export function serverProbeOrder({ namedPort, portFilePort, scanBases, scanCount }) {
-  const ordered = [];
-  if (namedPort !== null) ordered.push(namedPort);
-  if (portFilePort !== null) ordered.push(portFilePort);
-  for (const base of scanBases) {
-    for (let offset = 0; offset < scanCount; offset++) ordered.push(base + offset);
-  }
-  return [...new Set(ordered)];
 }

--- a/bin/ports.js
+++ b/bin/ports.js
@@ -57,6 +57,36 @@ export function resolvePort(env, names, fallback) {
 }
 
 /**
+ * Sentinel for "no candidate held a usable port". Outside 1-65535, so
+ * `resolvePort` can never return it from a real value.
+ */
+const NO_PORT = -1;
+
+/** Candidates for the API port, in priority order. */
+const API_PORT_NAMES = /** @type {const} */ (['MD_REDLINE_PORT', 'PORT']);
+
+/**
+ * The API port the environment NAMES, or null when it names none.
+ *
+ * The difference from `resolveApiPort` is the whole point: that one cannot tell
+ * an explicit `MD_REDLINE_PORT=6373` from nothing set at all, because both
+ * arrive as 6373. A caller that needs to know whether the user pointed at a
+ * specific server, rather than accepting whatever is running, has to ask this
+ * instead.
+ *
+ * A value that is set but unusable is not a name: `resolvePort` has already
+ * warned about it and moved on, and treating a typo as "the user named this"
+ * would aim a command at a port nobody asked for.
+ *
+ * @param {Record<string, string | undefined>} [env] Defaults to `process.env`.
+ * @returns {number | null}
+ */
+export function resolveNamedApiPort(env = process.env) {
+  const port = resolvePort(env, API_PORT_NAMES, NO_PORT);
+  return port === NO_PORT ? null : port;
+}
+
+/**
  * The API server's port. `PORT` is a documented alias for `MD_REDLINE_PORT`, kept
  * because it shipped; the prefixed name wins.
  *
@@ -64,5 +94,35 @@ export function resolvePort(env, names, fallback) {
  * @returns {number} A port between 1 and 65535.
  */
 export function resolveApiPort(env = process.env) {
-  return resolvePort(env, ['MD_REDLINE_PORT', 'PORT'], FALLBACK_PORT);
+  return resolveNamedApiPort(env) ?? FALLBACK_PORT;
+}
+
+/**
+ * Ports to probe, in order, when looking for a server that is already running.
+ *
+ * Order is the whole content of this function, and it is a correctness
+ * property rather than a performance one. The port file records whichever
+ * server started last, so consulting it first means a command aimed at a
+ * specific server acts on a different one and reports success: `--stop` killed
+ * the wrong instance, and a plain `mdr` attached to it. A port the user NAMED
+ * therefore outranks the recorded one.
+ *
+ * With nothing named, the port file still comes first, and has to: it is how a
+ * server that scanned upward past a busy default is found at all.
+ *
+ * @param {object} options
+ * @param {number | null} options.namedPort Port the user asked for, if any.
+ * @param {number | null} options.portFilePort Port recorded by a running server.
+ * @param {readonly number[]} options.scanBases Range starts, in order.
+ * @param {number} options.scanCount Ports to try from each base.
+ * @returns {number[]} Deduped, so a port already tried is not probed twice.
+ */
+export function serverProbeOrder({ namedPort, portFilePort, scanBases, scanCount }) {
+  const ordered = [];
+  if (namedPort !== null) ordered.push(namedPort);
+  if (portFilePort !== null) ordered.push(portFilePort);
+  for (const base of scanBases) {
+    for (let offset = 0; offset < scanCount; offset++) ordered.push(base + offset);
+  }
+  return [...new Set(ordered)];
 }

--- a/bin/ports.test.ts
+++ b/bin/ports.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { FALLBACK_PORT, resolveNamedApiPort, serverProbeOrder } from './ports.js';
+
+// resolveApiPort itself is covered in server/env.test.ts, where it is re-exported.
+// What lives here is the pair the CLI needs and the server does not: whether a
+// port was NAMED, and the order to go looking in.
+
+describe('resolveNamedApiPort', () => {
+  it('returns the port when the prefixed name holds one', () => {
+    expect(resolveNamedApiPort({ MD_REDLINE_PORT: '7441' })).toBe(7441);
+  });
+
+  it('accepts the documented PORT alias', () => {
+    expect(resolveNamedApiPort({ PORT: '7100' })).toBe(7100);
+  });
+
+  it('prefers the prefixed name over the alias', () => {
+    expect(resolveNamedApiPort({ MD_REDLINE_PORT: '7441', PORT: '7100' })).toBe(7441);
+  });
+
+  it('is null when nothing is set', () => {
+    expect(resolveNamedApiPort({})).toBeNull();
+  });
+
+  it.each(['', '   '])('treats a blank value (%j) as naming nothing', (blank) => {
+    expect(resolveNamedApiPort({ MD_REDLINE_PORT: blank })).toBeNull();
+  });
+
+  it('reports the default port as named when it was set on purpose', () => {
+    // The distinction this function exists for. resolveApiPort answers 6373 to
+    // both this and an empty environment, which is what made a command aimed at
+    // a specific server indistinguishable from one that would take any server.
+    expect(resolveNamedApiPort({ MD_REDLINE_PORT: String(FALLBACK_PORT) })).toBe(FALLBACK_PORT);
+    expect(resolveNamedApiPort({})).toBeNull();
+  });
+
+  it.each(['nonsense', '0', '65536', '80.5', '-1'])(
+    'does not treat an unusable value (%j) as a name',
+    (value) => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      expect(resolveNamedApiPort({ MD_REDLINE_PORT: value })).toBeNull();
+      expect(warn).toHaveBeenCalled();
+      warn.mockRestore();
+    },
+  );
+
+  it('falls through a typo to the alias behind it', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(resolveNamedApiPort({ MD_REDLINE_PORT: 'nonsense', PORT: '7100' })).toBe(7100);
+    warn.mockRestore();
+  });
+});
+
+describe('serverProbeOrder', () => {
+  const scan = { scanBases: [6373, 3001], scanCount: 3 };
+
+  it('probes a named port before the recorded one', () => {
+    // The bug: two servers up, the port file naming the one that started last.
+    // `MD_REDLINE_PORT=7441 mdr --stop` reported success and stopped 7440.
+    const order = serverProbeOrder({ namedPort: 7441, portFilePort: 7440, ...scan });
+
+    expect(order[0]).toBe(7441);
+    expect(order.indexOf(7441)).toBeLessThan(order.indexOf(7440));
+  });
+
+  it('still probes the recorded port when nothing was named', () => {
+    // Not a fallback worth losing: it is the only way to find a server that
+    // scanned upward past a busy default.
+    const order = serverProbeOrder({ namedPort: null, portFilePort: 6380, ...scan });
+
+    expect(order[0]).toBe(6380);
+  });
+
+  it('scans both ranges in order after the specific candidates', () => {
+    const order = serverProbeOrder({ namedPort: null, portFilePort: null, ...scan });
+
+    expect(order).toEqual([6373, 6374, 6375, 3001, 3002, 3003]);
+  });
+
+  it('probes a port once, however many ways it was reached', () => {
+    // The named port is usually inside the scan range, since resolveApiPort
+    // makes the range start there.
+    const order = serverProbeOrder({ namedPort: 6373, portFilePort: 6374, ...scan });
+
+    expect(order).toEqual([6373, 6374, 6375, 3001, 3002, 3003]);
+    expect(new Set(order).size).toBe(order.length);
+  });
+
+  it('keeps the recorded port ahead of the scan even when the scan would reach it', () => {
+    const order = serverProbeOrder({ namedPort: null, portFilePort: 6375, ...scan });
+
+    expect(order).toEqual([6375, 6373, 6374, 3001, 3002, 3003]);
+  });
+
+  it('is just the scan when there is nothing else to go on', () => {
+    expect(
+      serverProbeOrder({ namedPort: null, portFilePort: null, scanBases: [6373], scanCount: 1 }),
+    ).toEqual([6373]);
+  });
+});

--- a/bin/ports.test.ts
+++ b/bin/ports.test.ts
@@ -1,10 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { FALLBACK_PORT, resolveNamedApiPort, serverProbeOrder } from './ports.js';
+import { FALLBACK_PORT, isValidPort, resolveNamedApiPort } from './ports.js';
 
 // resolveApiPort itself is covered in server/env.test.ts, where it is re-exported.
-// What lives here is the pair the CLI needs and the server does not: whether a
-// port was NAMED, and the order to go looking in.
+// What lives here is what the CLI needs and the server does not: whether a port
+// was NAMED at all. The order to go looking in lives with the code that acts on
+// a running server, in server-control.
+
+// Restored here rather than at the end of each test body: a failing assertion
+// would skip an inline mockRestore and leave console.warn stubbed for every
+// test after it, so the next failure reports with its diagnostics swallowed.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('isValidPort', () => {
+  it.each([1, 80, 6373, 65535])('accepts %i', (port) => {
+    expect(isValidPort(port)).toBe(true);
+  });
+
+  it.each([0, -1, 65536, 80.5, NaN])('rejects %j', (port) => {
+    expect(isValidPort(port)).toBe(false);
+  });
+});
 
 describe('resolveNamedApiPort', () => {
   it('returns the port when the prefixed name holds one', () => {
@@ -41,61 +59,11 @@ describe('resolveNamedApiPort', () => {
       const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
       expect(resolveNamedApiPort({ MD_REDLINE_PORT: value })).toBeNull();
       expect(warn).toHaveBeenCalled();
-      warn.mockRestore();
     },
   );
 
   it('falls through a typo to the alias behind it', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(resolveNamedApiPort({ MD_REDLINE_PORT: 'nonsense', PORT: '7100' })).toBe(7100);
-    warn.mockRestore();
-  });
-});
-
-describe('serverProbeOrder', () => {
-  const scan = { scanBases: [6373, 3001], scanCount: 3 };
-
-  it('probes a named port before the recorded one', () => {
-    // The bug: two servers up, the port file naming the one that started last.
-    // `MD_REDLINE_PORT=7441 mdr --stop` reported success and stopped 7440.
-    const order = serverProbeOrder({ namedPort: 7441, portFilePort: 7440, ...scan });
-
-    expect(order[0]).toBe(7441);
-    expect(order.indexOf(7441)).toBeLessThan(order.indexOf(7440));
-  });
-
-  it('still probes the recorded port when nothing was named', () => {
-    // Not a fallback worth losing: it is the only way to find a server that
-    // scanned upward past a busy default.
-    const order = serverProbeOrder({ namedPort: null, portFilePort: 6380, ...scan });
-
-    expect(order[0]).toBe(6380);
-  });
-
-  it('scans both ranges in order after the specific candidates', () => {
-    const order = serverProbeOrder({ namedPort: null, portFilePort: null, ...scan });
-
-    expect(order).toEqual([6373, 6374, 6375, 3001, 3002, 3003]);
-  });
-
-  it('probes a port once, however many ways it was reached', () => {
-    // The named port is usually inside the scan range, since resolveApiPort
-    // makes the range start there.
-    const order = serverProbeOrder({ namedPort: 6373, portFilePort: 6374, ...scan });
-
-    expect(order).toEqual([6373, 6374, 6375, 3001, 3002, 3003]);
-    expect(new Set(order).size).toBe(order.length);
-  });
-
-  it('keeps the recorded port ahead of the scan even when the scan would reach it', () => {
-    const order = serverProbeOrder({ namedPort: null, portFilePort: 6375, ...scan });
-
-    expect(order).toEqual([6375, 6373, 6374, 3001, 3002, 3003]);
-  });
-
-  it('is just the scan when there is nothing else to go on', () => {
-    expect(
-      serverProbeOrder({ namedPort: null, portFilePort: null, scanBases: [6373], scanCount: 1 }),
-    ).toEqual([6373]);
   });
 });

--- a/bin/server-control.js
+++ b/bin/server-control.js
@@ -1,12 +1,14 @@
 import { execSync } from 'child_process';
 
+import { isValidPort } from './ports.js';
+
 /**
  * @param {number} port
  * @param {NodeJS.Platform} [platform]
  * @returns {string | null} null when the port is not a usable port number
  */
 export function buildKillCommand(port, platform = process.platform) {
-  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  if (!isValidPort(port)) return null;
   if (platform === 'win32') {
     return `netstat -ano | findstr 127.0.0.1:${port} | findstr LISTENING`;
   }
@@ -143,4 +145,34 @@ export async function gracefulShutdown(
     await delay(pollMs);
   }
   return false;
+}
+
+/**
+ * Ports to probe, in order, when looking for a server that is already running.
+ *
+ * Order is the whole content of this function, and it is a correctness
+ * property rather than a performance one. The port file records whichever
+ * server started last, so consulting it first means a command aimed at a
+ * specific server acts on a different one and reports success: `--stop` killed
+ * the wrong instance, and a plain `mdr` attached to it. A port the user NAMED
+ * therefore outranks the recorded one.
+ *
+ * With nothing named, the port file still comes first, and has to: it is how a
+ * server that scanned upward past a busy default is found at all.
+ *
+ * @param {object} options
+ * @param {number | null} options.namedPort Port the user asked for, if any.
+ * @param {number | null} options.portFilePort Port recorded by a running server.
+ * @param {readonly number[]} options.scanBases Range starts, in order.
+ * @param {number} options.scanCount Ports to try from each base.
+ * @returns {number[]} Deduped, so a port already tried is not probed twice.
+ */
+export function serverProbeOrder({ namedPort, portFilePort, scanBases, scanCount }) {
+  const ordered = [];
+  if (namedPort !== null) ordered.push(namedPort);
+  if (portFilePort !== null) ordered.push(portFilePort);
+  for (const base of scanBases) {
+    for (let offset = 0; offset < scanCount; offset++) ordered.push(base + offset);
+  }
+  return [...new Set(ordered)];
 }

--- a/bin/server-control.test.ts
+++ b/bin/server-control.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { buildKillCommand, checkServer, gracefulShutdown, killPort } from './server-control.js';
+import {
+  buildKillCommand,
+  checkServer,
+  gracefulShutdown,
+  killPort,
+  serverProbeOrder,
+} from './server-control.js';
 
 describe('buildKillCommand', () => {
   it('scopes lsof to loopback LISTEN sockets on macOS/Linux', () => {
@@ -208,5 +214,53 @@ describe('gracefulShutdown', () => {
     expect(result).toBe(false);
     // Shouldn't have polled — we bailed early on explicit failure.
     expect(checkServerFn).not.toHaveBeenCalled();
+  });
+});
+
+describe('serverProbeOrder', () => {
+  const scan = { scanBases: [6373, 3001], scanCount: 3 };
+
+  it('probes a named port before the recorded one', () => {
+    // The bug: two servers up, the port file naming the one that started last.
+    // `MD_REDLINE_PORT=7441 mdr --stop` reported success and stopped 7440.
+    const order = serverProbeOrder({ namedPort: 7441, portFilePort: 7440, ...scan });
+
+    expect(order[0]).toBe(7441);
+    expect(order.indexOf(7441)).toBeLessThan(order.indexOf(7440));
+  });
+
+  it('still probes the recorded port when nothing was named', () => {
+    // Not a fallback worth losing: it is the only way to find a server that
+    // scanned upward past a busy default.
+    const order = serverProbeOrder({ namedPort: null, portFilePort: 6380, ...scan });
+
+    expect(order[0]).toBe(6380);
+  });
+
+  it('scans both ranges in order after the specific candidates', () => {
+    const order = serverProbeOrder({ namedPort: null, portFilePort: null, ...scan });
+
+    expect(order).toEqual([6373, 6374, 6375, 3001, 3002, 3003]);
+  });
+
+  it('probes a port once, however many ways it was reached', () => {
+    // The named port is usually inside the scan range, since resolveApiPort
+    // makes the range start there.
+    const order = serverProbeOrder({ namedPort: 6373, portFilePort: 6374, ...scan });
+
+    expect(order).toEqual([6373, 6374, 6375, 3001, 3002, 3003]);
+    expect(new Set(order).size).toBe(order.length);
+  });
+
+  it('keeps the recorded port ahead of the scan even when the scan would reach it', () => {
+    const order = serverProbeOrder({ namedPort: null, portFilePort: 6375, ...scan });
+
+    expect(order).toEqual([6375, 6373, 6374, 3001, 3002, 3003]);
+  });
+
+  it('is just the scan when there is nothing else to go on', () => {
+    expect(
+      serverProbeOrder({ namedPort: null, portFilePort: null, scanBases: [6373], scanCount: 1 }),
+    ).toEqual([6373]);
   });
 });


### PR DESCRIPTION
Closes #36.

`findServerPort` consulted the port file first and returned whatever answered there. The port file records whichever server started most recently, so with two running and an explicit `MD_REDLINE_PORT`, every command that needs a server picked the wrong one: `--stop` printed `mdr stopped.` while the named server kept running and one the user never mentioned died instead, and a plain `mdr` attached to that other instance.

### Knowing that a port was named

`resolveApiPort` cannot say. It answers 6373 both to an explicit `MD_REDLINE_PORT=6373` and to nothing set at all, which is exactly the distinction this needs, so `resolveNamedApiPort` answers `null` for the second. A value that is set but unusable is not a name either: it has already been warned about and passed over, and treating a typo as a request would aim a command at a port nobody asked for.

The order itself is a pure function, because the order **is** the bug: named port, then the recorded one, then the scan ranges, deduped so a port reachable two ways is probed once. With nothing named the port file still comes first, which it has to, since that is how a server that scanned upward past a busy default gets found at all.

### Watching the choice without acting on it

There was no way to observe which server a command picks, because every command that picks one then either kills it or opens a browser at it, and a test can do neither to the machine it runs on. `mdr __find-server` prints the answer and touches nothing, in the shape the file already uses for `__open`, `__port` and `__first-launch`. The tests drive real servers on real ports with the port file redirected through `TMPDIR`, so they never read or write the one belonging to a developer's own mdr.

### Review fixes

A max-effort review caught a regression this change introduced: `--stop` unlinks the port file after killing what it found, which was safe only while the two were the same server by construction. Stopping the server you named was deleting the still-live record of a different one. The file is now removed only when it records what was killed, the same guard `removePortFileIfOwned` already applies on the server's own way out.

Also from that review: `serverProbeOrder` moved to `server-control.js`, since it is server discovery and was sitting in a module whose header promises env resolution shared by three readers, while being tree-shaken out of the server bundle entirely; a `NO_PORT = -1` sentinel deleted in favour of a generic fallback; `isValidPort` replacing a third hand-copy of the same range check; and four test-hygiene fixes, including a `console.warn` restore that a failing assertion would skip, swallowing the diagnostics of every later failure.

### Known, and not newly so

Four pre-existing gaps share one theme, that only `findServerPort` respects the named port: `buildUrl` still prefers the unscoped client-port scan, so `mdr file.md` can open a different instance's frontend; `ensureServerRunning` treats the fallback as authoritative; `--stop` with a named-but-dead port falls back and kills the recorded server (the fallback #36 itself specifies, which is right for opening and arguable for killing); and `--stop` sweeps 5188-5197 for a Vite client, which on a developer's machine is their own dev server. That last one is also why nothing drives `--stop` in tests. Worth one follow-up issue rather than four.

### Verification

`npm run build`, 1942 unit tests, `tsc -b`, `eslint .`, `format:check`.