### PR TITLE
Let a touch move the anchor drag handles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -756,10 +756,16 @@ non-`isPrimary` pointer and the hook refuses to begin while one is in flight.
 Either alone is enough today, which is why `e2e/touch-drag-handles.spec.ts`
 asserts the behaviour rather than either mechanism. The `pointerId` recorded at
 the start filters moves for a drag already running; on its own it never stopped
-a second one beginning. Moves are coalesced to one per frame, because each runs
-two text walks, an `innerHTML` serialize, an unwrap-and-rewrap of the whole
+a second one beginning. Moves are NOT coalesced onto an animation frame, though each
+runs two text walks, an `innerHTML` serialize, an unwrap-and-rewrap of the whole
 prose subtree and a forced layout, and touch delivers them faster than the
-display.
+display. The pipeline moves an anchor only when it walks: a 300px drag in five
+steps extends it and the same drag in one step leaves it untouched, so applying
+only the last position of a frame moves it nowhere. Batching briefly shipped and
+turned an existing spec red on CI, where a loaded runner starved the frame and
+collapsed the steps into one jump. `e2e/touch-drag-handles.spec.ts` starves
+frames deliberately to keep that from coming back; anything that batches these
+has to preserve the intermediate positions.
 
 `e2e/touch-drag-handles.spec.ts` drives this through CDP
 `Input.dispatchTouchEvent`, not dispatched DOM events: #33 established that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -743,10 +743,23 @@ and each is easy to leave out. `setPointerCapture` on the handle keeps the drag
 alive once the pointer leaves it; `touch-action: none` in `.drag-handle` stops
 the browser claiming the gesture for scrolling before the page sees a move; and
 `pointercancel` ends a drag the system took away, which touch fires and a mouse
-effectively never does. Every ending (released, cancelled, Escape, unmounted)
-runs one `detach`, because four copies of the teardown is how the fifth one gets
-forgotten. The drag also records the `pointerId` that began it and ignores every
-other, so a second finger cannot move an anchor.
+effectively never does. Every ending runs one `detach`, because four
+copies of the teardown is how the fifth one gets forgotten, and there are five:
+released, cancelled, Escape, unmounted, and capture lost. That last one is not
+`pointercancel`. Removing the captured element fires `lostpointercapture`
+instead and pointer events keep arriving at the document, so deleting or
+resolving the comment mid-drag, or switching to the raw or diff view, left the
+drag live and committed an anchor edit for something that was gone.
+
+A second finger cannot start a competing drag: the handle refuses a
+non-`isPrimary` pointer and the hook refuses to begin while one is in flight.
+Either alone is enough today, which is why `e2e/touch-drag-handles.spec.ts`
+asserts the behaviour rather than either mechanism. The `pointerId` recorded at
+the start filters moves for a drag already running; on its own it never stopped
+a second one beginning. Moves are coalesced to one per frame, because each runs
+two text walks, an `innerHTML` serialize, an unwrap-and-rewrap of the whole
+prose subtree and a forced layout, and touch delivers them faster than the
+display.
 
 `e2e/touch-drag-handles.spec.ts` drives this through CDP
 `Input.dispatchTouchEvent`, not dispatched DOM events: #33 established that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -734,10 +734,23 @@ coalesce handle-drag event streams; it gates nothing user-visible. The pill's
 scroll-follow coalesces into one measurement per animation frame, because touch
 scrolling outpaces the compositor and measuring per event reads as jitter.
 
-Known gap (#35): the anchor drag handles (`DragHandles.tsx`,
-`useDragHandles.ts`) are still mouse-only. They react to a tap because iOS
-synthesises a `mousedown`, but a touch drag emits no `mousemove`, so they cannot
-be moved on a tablet.
+The anchor drag handles (`DragHandles.tsx`, `useDragHandles.ts`) run on pointer
+events for the same reason. They were mouse-only, and reacted to a tap because
+iOS synthesises a `mousedown`, so the handle highlighted and the drag appeared
+to start and then received no `mousemove` for the rest of the gesture: dead on a
+tablet, with nothing on screen to say so. Three things make the conversion work
+and each is easy to leave out. `setPointerCapture` on the handle keeps the drag
+alive once the pointer leaves it; `touch-action: none` in `.drag-handle` stops
+the browser claiming the gesture for scrolling before the page sees a move; and
+`pointercancel` ends a drag the system took away, which touch fires and a mouse
+effectively never does. Every ending (released, cancelled, Escape, unmounted)
+runs one `detach`, because four copies of the teardown is how the fifth one gets
+forgotten. The drag also records the `pointerId` that began it and ignores every
+other, so a second finger cannot move an anchor.
+
+`e2e/touch-drag-handles.spec.ts` drives this through CDP
+`Input.dispatchTouchEvent`, not dispatched DOM events: #33 established that
+synthetic-pointer tests here pass even with the touch handlers deleted.
 
 ### Comments rail
 The single comment surface for the rendered view: a fixed-width column at the

--- a/e2e/touch-drag-handles.spec.ts
+++ b/e2e/touch-drag-handles.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Re-anchoring a comment by touch.
+ *
+ * Creating a comment already worked from a tablet; adjusting an existing one
+ * did not. The handles were wired to `onMouseDown` with `mousemove`/`mouseup`
+ * on the document, and iOS synthesises a `mousedown` on tap, so the handle
+ * highlighted and the drag appeared to start and then nothing moved, with no
+ * error and nothing on screen to say the interaction was dead.
+ *
+ * Driven through CDP touch input rather than dispatched DOM events on purpose.
+ * #33 found that its synthetic-pointer tests passed with the touch handlers
+ * deleted, so a suite that never puts a real touch through the browser's input
+ * pipeline proves nothing about a touch feature. `Input.dispatchTouchEvent` is
+ * the real pipeline: the browser derives the pointer events from it, exactly as
+ * it does for a finger.
+ */
+import { test, expect, type CDPSession, type Page } from '@playwright/test';
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { FORMATTED_DOC_BASELINE } from './helpers/fixture-baselines';
+import { addComment } from './helpers/comments';
+import { clearPersistedPreferences, resetTestAppState } from './helpers/test-state';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE = resolve(__dirname, 'fixtures/formatted-doc.md');
+
+test.beforeEach(async ({ page }) => {
+  writeFileSync(FIXTURE, FORMATTED_DOC_BASELINE);
+  await resetTestAppState(page);
+});
+
+test.afterAll(() => {
+  writeFileSync(FIXTURE, FORMATTED_DOC_BASELINE);
+  clearPersistedPreferences();
+});
+
+async function openFixture(page: Page) {
+  await page.goto(`/?file=${FIXTURE}`);
+  await page.locator('.prose').waitFor({ timeout: 10_000 });
+}
+
+function getCard(page: Page, commentText: string) {
+  return page.locator('.group.rounded-lg', { hasText: commentText });
+}
+
+/** Put a comment on screen with its handles showing. */
+async function commentWithHandles(page: Page, anchor: string, text: string) {
+  await openFixture(page);
+  await addComment(page, anchor, text);
+  const card = getCard(page, text);
+  await card.click();
+  await expect(page.locator('[data-drag-handle]')).toHaveCount(2);
+  return card;
+}
+
+async function anchorQuote(card: ReturnType<typeof getCard>): Promise<string> {
+  const raw = await card.locator('[data-anchor-quote]').first().textContent();
+  return raw?.replace(/["“”]/g, '').trim() ?? '';
+}
+
+/** Press a finger on the start handle and return where it landed. */
+async function touchStartHandle(page: Page, cdp: CDPSession) {
+  const box = await page.locator('[data-drag-handle]').first().boundingBox();
+  expect(box).not.toBeNull();
+  const x = box!.x + box!.width / 2;
+  const y = box!.y + box!.height / 2;
+  await cdp.send('Input.dispatchTouchEvent', {
+    type: 'touchStart',
+    touchPoints: [{ x, y }],
+  });
+  return { x, y };
+}
+
+test.describe('Anchor drag handles by touch', () => {
+  test.use({ hasTouch: true });
+
+  test('a touch drag moves the anchor', async ({ page }) => {
+    const card = await commentWithHandles(page, 'followed by regular text', 'Touch drag test');
+    const before = await anchorQuote(card);
+
+    const cdp = await page.context().newCDPSession(page);
+    const { x, y } = await touchStartHandle(page, cdp);
+
+    // Several moves, the way a finger travels. One jump would also work, but
+    // the bug being guarded is that no move arrives at all.
+    for (const step of [40, 120, 220, 300]) {
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: x - step, y }],
+      });
+    }
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+
+    await expect(page.locator('mark.comment-highlight').first()).toBeVisible({ timeout: 5_000 });
+    await expect.poll(() => anchorQuote(card), { timeout: 5_000 }).not.toBe(before);
+    expect((await anchorQuote(card)).length).toBeGreaterThan(before.length);
+  });
+
+  test('a cancelled touch drag reverts and lets go', async ({ page }) => {
+    // touchcancel has no mouse equivalent, so nothing else in the suite covers
+    // this path. The system fires it when a palm lands, an edge swipe starts,
+    // or the browser reclaims the gesture for scrolling. Nothing was released,
+    // so committing the half-finished anchor would write an edit the reader
+    // never completed, and failing to detach would leave the page stuck in a
+    // drag it cannot end.
+    const card = await commentWithHandles(page, 'followed by regular text', 'Touch cancel test');
+    const before = await anchorQuote(card);
+
+    const cdp = await page.context().newCDPSession(page);
+    const { x, y } = await touchStartHandle(page, cdp);
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [{ x: x - 200, y }],
+    });
+
+    await expect
+      .poll(() => page.evaluate(() => document.body.classList.contains('anchor-dragging')))
+      .toBe(true);
+
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchCancel', touchPoints: [] });
+
+    // Released: the class is the hook's own record that a drag is in progress.
+    await expect
+      .poll(() => page.evaluate(() => document.body.classList.contains('anchor-dragging')), {
+        timeout: 5_000,
+      })
+      .toBe(false);
+    // And reverted, not committed.
+    expect(await anchorQuote(card)).toBe(before);
+  });
+
+  test('the handles still work with a mouse', async ({ page }) => {
+    // The conversion has to keep the pointer type it already supported. This is
+    // the same gesture drag-regression.spec.ts drives, kept here so a touch
+    // change that breaks the mouse fails in the file that made it.
+    const card = await commentWithHandles(page, 'followed by regular text', 'Mouse still works');
+    const before = await anchorQuote(card);
+
+    const handle = page.locator('[data-drag-handle]').first();
+    const box = await handle.boundingBox();
+    await handle.hover();
+    await page.mouse.down();
+    await page.mouse.move(box!.x - 300, box!.y + box!.height / 2, { steps: 5 });
+    await page.mouse.up();
+
+    await expect.poll(() => anchorQuote(card), { timeout: 5_000 }).not.toBe(before);
+  });
+});

--- a/e2e/touch-drag-handles.spec.ts
+++ b/e2e/touch-drag-handles.spec.ts
@@ -212,6 +212,43 @@ test.describe('Anchor drag handles by touch', () => {
     await expect(page.locator('mark.comment-highlight').first()).toBeVisible();
   });
 
+  test('a drag survives a machine that never renders a frame', async ({ page }) => {
+    // A guard against batching these moves onto an animation frame, which is
+    // tempting because each one rewrites the whole prose subtree. It cannot be
+    // done naively: the pipeline moves an anchor only when it walks, so
+    // applying one position per frame and discarding the rest moves the anchor
+    // nowhere at all. That shipped briefly and turned an existing spec red on
+    // CI, where a loaded runner starved the frame and collapsed a five-step
+    // drag into one jump. Frames are starved here deliberately, so any future
+    // attempt has to keep the intermediate positions to stay green.
+    const card = await commentWithHandles(page, 'followed by regular text', 'Frame starved');
+    const before = await anchorQuote(card);
+
+    await page.evaluate(() => {
+      const w = window as unknown as { __queuedFrames?: FrameRequestCallback[] };
+      w.__queuedFrames = [];
+      window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+        w.__queuedFrames!.push(cb);
+        return 0;
+      }) as typeof window.requestAnimationFrame;
+    });
+
+    const handle = page.locator('[data-drag-handle]').first();
+    const box = (await handle.boundingBox())!;
+    await handle.hover();
+    await page.mouse.down();
+    await page.mouse.move(box.x - 300, box.y + box.height / 2, { steps: 5 });
+    await page.mouse.up();
+
+    // No frame ever ran, so this can only have been committed by the release.
+    await expect.poll(() => anchorQuote(card), { timeout: 5_000 }).not.toBe(before);
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __queuedFrames: unknown[] }).__queuedFrames.length,
+      ),
+    ).toBeGreaterThan(0);
+  });
+
   test('the handles still work with a mouse', async ({ page }) => {
     // The conversion has to keep the pointer type it already supported. This is
     // the same gesture drag-regression.spec.ts drives, kept here so a touch

--- a/e2e/touch-drag-handles.spec.ts
+++ b/e2e/touch-drag-handles.spec.ts
@@ -44,14 +44,48 @@ function getCard(page: Page, commentText: string) {
   return page.locator('.group.rounded-lg', { hasText: commentText });
 }
 
-/** Put a comment on screen with its handles showing. */
+/**
+ * Poll until two consecutive reads of both handles agree, meaning the page's
+ * width transition and the rAF reposition behind it have settled. Without it a
+ * boundingBox read mid-animation aims the finger at prose instead of a 4px
+ * handle, which fails intermittently and for a reason that has nothing to do
+ * with touch. drag-regression.spec.ts gates every mouse drag the same way.
+ */
+async function stableHandlePositions(page: Page): Promise<void> {
+  let previous: { start: number; end: number } | null = null;
+  await expect(async () => {
+    const handles = page.locator('[data-drag-handle]');
+    const startBox = await handles.first().boundingBox();
+    const endBox = await handles.last().boundingBox();
+    const current = startBox && endBox ? { start: startBox.x, end: endBox.x } : null;
+    const stable =
+      current !== null &&
+      previous !== null &&
+      current.start === previous.start &&
+      current.end === previous.end;
+    previous = current;
+    expect(stable).toBe(true);
+  }).toPass({ timeout: 2000 });
+}
+
+/** Put a comment on screen with its handles showing and settled. */
 async function commentWithHandles(page: Page, anchor: string, text: string) {
   await openFixture(page);
   await addComment(page, anchor, text);
   const card = getCard(page, text);
   await card.click();
   await expect(page.locator('[data-drag-handle]')).toHaveCount(2);
+  await stableHandlePositions(page);
   return card;
+}
+
+/** The live highlighted text, which moves during a drag rather than on commit. */
+function highlightedText(page: Page): Promise<string> {
+  return page.evaluate(() =>
+    Array.from(document.querySelectorAll('mark.comment-highlight-active'))
+      .map((m) => m.textContent ?? '')
+      .join(''),
+  );
 }
 
 async function anchorQuote(card: ReturnType<typeof getCard>): Promise<string> {
@@ -107,16 +141,21 @@ test.describe('Anchor drag handles by touch', () => {
     const card = await commentWithHandles(page, 'followed by regular text', 'Touch cancel test');
     const before = await anchorQuote(card);
 
+    const highlightBefore = await highlightedText(page);
     const cdp = await page.context().newCDPSession(page);
     const { x, y } = await touchStartHandle(page, cdp);
-    await cdp.send('Input.dispatchTouchEvent', {
-      type: 'touchMove',
-      touchPoints: [{ x: x - 200, y }],
-    });
+    for (const step of [60, 140, 220]) {
+      await cdp.send('Input.dispatchTouchEvent', {
+        type: 'touchMove',
+        touchPoints: [{ x: x - step, y }],
+      });
+    }
 
-    await expect
-      .poll(() => page.evaluate(() => document.body.classList.contains('anchor-dragging')))
-      .toBe(true);
+    // The move has to have taken effect before cancelling, or this test passes
+    // with pointermove handling deleted: `anchor-dragging` goes on at
+    // pointerdown, and the card's anchor only updates on commit, so both of the
+    // signals it used to check were satisfied by the press alone.
+    await expect.poll(() => highlightedText(page), { timeout: 5_000 }).not.toBe(highlightBefore);
 
     await cdp.send('Input.dispatchTouchEvent', { type: 'touchCancel', touchPoints: [] });
 
@@ -126,8 +165,51 @@ test.describe('Anchor drag handles by touch', () => {
         timeout: 5_000,
       })
       .toBe(false);
-    // And reverted, not committed.
+    // And reverted, not committed: both the live highlight and the stored anchor.
+    await expect.poll(() => highlightedText(page), { timeout: 5_000 }).toBe(highlightBefore);
     expect(await anchorQuote(card)).toBe(before);
+  });
+
+  test('a second finger on the other handle does not start a second drag', async ({ page }) => {
+    // Both handles accept a pointerdown, so two fingers used to start two
+    // drags over one shared drag state. The second overwrote the first, whose
+    // listeners stayed attached, and snapshotted the already-dragged DOM as its
+    // "original" so a later cancel reverted to a document that never existed.
+    const card = await commentWithHandles(page, 'followed by regular text', 'Two finger test');
+    const before = await anchorQuote(card);
+
+    const cdp = await page.context().newCDPSession(page);
+    const boxes = page.locator('[data-drag-handle]');
+    const startBox = (await boxes.first().boundingBox())!;
+    const endBox = (await boxes.last().boundingBox())!;
+    const a = { x: startBox.x + startBox.width / 2, y: startBox.y + startBox.height / 2 };
+    const b = { x: endBox.x + endBox.width / 2, y: endBox.y + endBox.height / 2 };
+
+    // CDP wants ids on every point or none of them, and two fingers need them.
+    const finger = { ...a, id: 0 };
+    const second = { ...b, id: 1 };
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [finger] });
+    // Second finger lands while the first is still down.
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchStart',
+      touchPoints: [finger, second],
+    });
+    await cdp.send('Input.dispatchTouchEvent', {
+      type: 'touchMove',
+      touchPoints: [
+        { ...finger, x: a.x - 120 },
+        { ...second, x: b.x + 120 },
+      ],
+    });
+    await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+
+    // One drag ran, so the anchor moved at one end only: it grew leftward and
+    // kept its original ending.
+    await expect.poll(() => anchorQuote(card), { timeout: 5_000 }).not.toBe(before);
+    const after = await anchorQuote(card);
+    expect(after.endsWith(before.slice(-12))).toBe(true);
+    // And the document is left in a state the parser still reads.
+    await expect(page.locator('mark.comment-highlight').first()).toBeVisible();
   });
 
   test('the handles still work with a mouse', async ({ page }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1905,7 +1905,7 @@ export default function App() {
     [openTab, addRecentFile],
   );
 
-  const { handlePositions, onHandleMouseDown } = useDragHandles({
+  const { handlePositions, onHandlePointerDown } = useDragHandles({
     viewerRef,
     scrollContainerRef: containerRef,
     pageRef,
@@ -3132,7 +3132,7 @@ export default function App() {
                                 <DragHandles
                                   startPos={handlePositions?.start ?? null}
                                   endPos={handlePositions?.end ?? null}
-                                  onMouseDown={onHandleMouseDown}
+                                  onPointerDown={onHandlePointerDown}
                                 />
                               </>
                             )}

--- a/src/components/DragHandles.tsx
+++ b/src/components/DragHandles.tsx
@@ -7,7 +7,8 @@ interface Position {
 interface DragHandlesProps {
   startPos: Position | null;
   endPos: Position | null;
-  onPointerDown: (handle: 'start' | 'end', pointerId: number) => void;
+  /** Returns whether a drag began; capture is taken only then. */
+  onPointerDown: (handle: 'start' | 'end', pointerId: number) => boolean;
 }
 
 export function DragHandles({ startPos, endPos, onPointerDown }: DragHandlesProps) {
@@ -19,16 +20,35 @@ export function DragHandles({ startPos, endPos, onPointerDown }: DragHandlesProp
    * and appeared to start dragging, then received no `mousemove` and no
    * `mouseup` for the rest of the gesture: dead, with nothing on screen to say
    * so. `PointerEvent` covers mouse, touch and pen in one path.
-   *
-   * The capture is what lets the drag survive the pointer leaving the handle,
-   * which is the whole gesture. Events stay retargeted here and still bubble to
-   * the document listeners the hook attaches.
    */
   const begin = (handle: 'start' | 'end') => (e: React.PointerEvent<HTMLDivElement>) => {
+    // Primary button, primary pointer. A right-press used to start a real drag
+    // and take capture; on a platform whose context menu swallows the release
+    // that left the drag live, and since a mouse reuses one pointerId, bare
+    // movement afterwards went on re-anchoring the comment with nothing held.
+    if (!e.isPrimary || e.button !== 0) return;
+
+    // preventDefault, but deliberately NOT stopPropagation. `useSelection`
+    // listens for pointerdown on the document and names [data-drag-handle] in
+    // the selector that decides whether a gesture may keep the current
+    // selection; stopping it here starved that listener of the one event it
+    // most needs, leaving its gesture epoch unbumped and its
+    // preserved-selection flag stale. Suppressing the compatibility mousedown
+    // is preventDefault's job and it still does it.
     e.preventDefault();
-    e.stopPropagation();
-    e.currentTarget.setPointerCapture(e.pointerId);
-    onPointerDown(handle, e.pointerId);
+
+    // Only capture once the drag is really running. Capturing first left a
+    // pointer pinned to a handle that had declined the gesture, and with
+    // touch-action none on that element the finger could neither drag nor
+    // scroll until it lifted.
+    if (!onPointerDown(handle, e.pointerId)) return;
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // NotFoundError when the pointer is already gone. The drag keeps working
+      // off the document listeners; capture only makes it survive leaving the
+      // element, so losing it is a degradation and not a failure.
+    }
   };
 
   return (

--- a/src/components/DragHandles.tsx
+++ b/src/components/DragHandles.tsx
@@ -7,11 +7,29 @@ interface Position {
 interface DragHandlesProps {
   startPos: Position | null;
   endPos: Position | null;
-  onMouseDown: (handle: 'start' | 'end') => void;
+  onPointerDown: (handle: 'start' | 'end', pointerId: number) => void;
 }
 
-export function DragHandles({ startPos, endPos, onMouseDown }: DragHandlesProps) {
+export function DragHandles({ startPos, endPos, onPointerDown }: DragHandlesProps) {
   if (!startPos || !endPos) return null;
+
+  /**
+   * Pointer events, not mouse events, because a touch never sends the latter.
+   * iOS synthesises a `mousedown` on tap, so a mouse-only handle highlighted
+   * and appeared to start dragging, then received no `mousemove` and no
+   * `mouseup` for the rest of the gesture: dead, with nothing on screen to say
+   * so. `PointerEvent` covers mouse, touch and pen in one path.
+   *
+   * The capture is what lets the drag survive the pointer leaving the handle,
+   * which is the whole gesture. Events stay retargeted here and still bubble to
+   * the document listeners the hook attaches.
+   */
+  const begin = (handle: 'start' | 'end') => (e: React.PointerEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    e.currentTarget.setPointerCapture(e.pointerId);
+    onPointerDown(handle, e.pointerId);
+  };
 
   return (
     <>
@@ -22,11 +40,7 @@ export function DragHandles({ startPos, endPos, onMouseDown }: DragHandlesProps)
           left: startPos.left - 2,
           height: startPos.height,
         }}
-        onMouseDown={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          onMouseDown('start');
-        }}
+        onPointerDown={begin('start')}
         data-drag-handle
       />
       <div
@@ -36,11 +50,7 @@ export function DragHandles({ startPos, endPos, onMouseDown }: DragHandlesProps)
           left: endPos.left - 2,
           height: endPos.height,
         }}
-        onMouseDown={(e) => {
-          e.preventDefault();
-          e.stopPropagation();
-          onMouseDown('end');
-        }}
+        onPointerDown={begin('end')}
         data-drag-handle
       />
     </>

--- a/src/hooks/useDragHandles.ts
+++ b/src/hooks/useDragHandles.ts
@@ -28,7 +28,7 @@ interface UseDragHandlesOptions {
 interface UseDragHandlesReturn {
   handlePositions: HandlePositions | null;
   isDragging: boolean;
-  onHandleMouseDown: (handle: 'start' | 'end') => void;
+  onHandlePointerDown: (handle: 'start' | 'end', pointerId: number) => void;
 }
 
 function caretFromPoint(x: number, y: number): { node: Node; offset: number } | null {
@@ -125,6 +125,11 @@ export function useDragHandles({
   // Refs for drag state (avoid stale closures in event handlers)
   const dragRef = useRef<{
     handle: 'start' | 'end';
+    /**
+     * The pointer that started this drag. A tablet has more than one, and
+     * without this a second finger anywhere on the page moves the anchor.
+     */
+    pointerId: number;
     commentIds: string[];
     originalAnchor: string;
     initialHtml: string;
@@ -209,8 +214,8 @@ export function useDragHandles({
     };
   }, [activeCommentId, scrollContainerRef, pageRef, updatePositions]);
 
-  const onHandleMouseDown = useCallback(
-    (handle: 'start' | 'end') => {
+  const onHandlePointerDown = useCallback(
+    (handle: 'start' | 'end', pointerId: number) => {
       const markEls = viewerRef.current?.getActiveMarks() || [];
       const container = viewerRef.current?.getContainer();
       if (markEls.length === 0 || !container) return;
@@ -244,6 +249,7 @@ export function useDragHandles({
 
       dragRef.current = {
         handle,
+        pointerId,
         commentIds,
         originalAnchor,
         initialHtml: container.innerHTML,
@@ -258,10 +264,11 @@ export function useDragHandles({
       setIsDragging(true);
       document.body.classList.add('anchor-dragging');
 
-      const handleMouseMove = (e: MouseEvent) => {
+      const handlePointerMove = (e: PointerEvent) => {
         const drag = dragRef.current;
-        if (!drag) return;
+        if (!drag || e.pointerId !== drag.pointerId) return;
 
+        // PointerEvent extends MouseEvent, so the caret lookup is unchanged.
         const caret = caretFromPoint(e.clientX, e.clientY);
         if (!caret || !container.contains(caret.node)) return;
 
@@ -404,8 +411,43 @@ export function useDragHandles({
         }
       };
 
-      const handleMouseUp = () => {
+      /**
+       * Detach and forget, once, for every way a drag can end.
+       *
+       * There are four: released, cancelled by the system, abandoned with
+       * Escape, and unmounted mid-gesture. Each used to carry its own copy of
+       * the removals, which is exactly the shape that loses one when a fifth
+       * arrives. `pointercancel` IS that fifth: touch fires it and a mouse
+       * effectively never does, so a missed teardown there leaves the hook
+       * mid-drag with listeners attached and the page still marked dragging,
+       * on the platform least able to recover from it.
+       */
+      const detach = () => {
+        document.removeEventListener('pointermove', handlePointerMove);
+        document.removeEventListener('pointerup', handlePointerUp);
+        document.removeEventListener('pointercancel', handlePointerCancel);
+        document.removeEventListener('keydown', handleKeyDown);
+        document.body.classList.remove('anchor-dragging');
+        dragRef.current = null;
+        dragCleanupRef.current = null;
+        setIsDragging(false);
+      };
+
+      /** Put the document back the way it was before the drag touched it. */
+      const revert = () => {
         const drag = dragRef.current;
+        if (!drag) return;
+        container.innerHTML = drag.initialHtml;
+        drag.markEls = Array.from(
+          container.querySelectorAll(
+            'mark.comment-highlight-active, mark.mermaid-comment-highlight-active',
+          ),
+        ) as HTMLElement[];
+      };
+
+      const handlePointerUp = (e: PointerEvent) => {
+        const drag = dragRef.current;
+        if (drag && e.pointerId !== drag.pointerId) return;
         if (drag) {
           // Use container text offsets to get the full anchor including whitespace
           // between styled elements that weren't wrapped in marks
@@ -417,49 +459,37 @@ export function useDragHandles({
             onAnchorChange(drag.commentIds, newAnchor);
           }
         }
+        detach();
+      };
 
-        dragRef.current = null;
-        setIsDragging(false);
-        document.body.classList.remove('anchor-dragging');
-        document.removeEventListener('mousemove', handleMouseMove);
-        document.removeEventListener('mouseup', handleMouseUp);
-        document.removeEventListener('keydown', handleKeyDown);
-        dragCleanupRef.current = null;
+      /**
+       * The system took the gesture away: a palm landed, a system edge swipe
+       * started, the browser decided this was a scroll after all. Nothing was
+       * released, so committing the half-finished anchor would write an edit
+       * the reader never completed. Revert, exactly as Escape does.
+       */
+      const handlePointerCancel = (e: PointerEvent) => {
+        const drag = dragRef.current;
+        if (drag && e.pointerId !== drag.pointerId) return;
+        revert();
+        detach();
+        updatePositions();
       };
 
       const handleKeyDown = (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
-          const drag = dragRef.current;
-          if (drag) {
-            container.innerHTML = drag.initialHtml;
-            drag.markEls = Array.from(
-              container.querySelectorAll(
-                'mark.comment-highlight-active, mark.mermaid-comment-highlight-active',
-              ),
-            ) as HTMLElement[];
-          }
-          dragRef.current = null;
-          setIsDragging(false);
-          document.body.classList.remove('anchor-dragging');
-          document.removeEventListener('mousemove', handleMouseMove);
-          document.removeEventListener('mouseup', handleMouseUp);
-          document.removeEventListener('keydown', handleKeyDown);
-          dragCleanupRef.current = null;
+          revert();
+          detach();
           updatePositions();
         }
       };
 
-      document.addEventListener('mousemove', handleMouseMove);
-      document.addEventListener('mouseup', handleMouseUp);
+      document.addEventListener('pointermove', handlePointerMove);
+      document.addEventListener('pointerup', handlePointerUp);
+      document.addEventListener('pointercancel', handlePointerCancel);
       document.addEventListener('keydown', handleKeyDown);
 
-      dragCleanupRef.current = () => {
-        document.removeEventListener('mousemove', handleMouseMove);
-        document.removeEventListener('mouseup', handleMouseUp);
-        document.removeEventListener('keydown', handleKeyDown);
-        document.body.classList.remove('anchor-dragging');
-        dragRef.current = null;
-      };
+      dragCleanupRef.current = detach;
     },
     [viewerRef, pageRef, onAnchorChange, updatePositions],
   );
@@ -474,6 +504,6 @@ export function useDragHandles({
   return {
     handlePositions: activeCommentId ? handlePositions : null,
     isDragging,
-    onHandleMouseDown,
+    onHandlePointerDown,
   };
 }

--- a/src/hooks/useDragHandles.ts
+++ b/src/hooks/useDragHandles.ts
@@ -27,8 +27,27 @@ interface UseDragHandlesOptions {
 
 interface UseDragHandlesReturn {
   handlePositions: HandlePositions | null;
-  isDragging: boolean;
-  onHandlePointerDown: (handle: 'start' | 'end', pointerId: number) => void;
+  /** True when a drag began. The caller takes pointer capture only then. */
+  onHandlePointerDown: (handle: 'start' | 'end', pointerId: number) => boolean;
+}
+
+/**
+ * Marks belonging to the comment being dragged. One definition: the selector
+ * was written out four times in this file, and adding a third active-mark
+ * class meant finding every copy. Deliberately not MarkdownViewer's
+ * getActiveMarks(), whose selector omits the `mark.` prefix and so also matches
+ * SVG <text> marks, which this hook's DOM surgery must not unwrap.
+ */
+const ACTIVE_MARK_SELECTOR = 'mark.comment-highlight-active, mark.mermaid-comment-highlight-active';
+
+/** Put the container back to a snapshot and re-point the drag at the marks in it. */
+function restoreMarkup(
+  container: HTMLElement,
+  html: string,
+  drag: { markEls: HTMLElement[] },
+): void {
+  container.innerHTML = html;
+  drag.markEls = Array.from(container.querySelectorAll(ACTIVE_MARK_SELECTOR)) as HTMLElement[];
 }
 
 function caretFromPoint(x: number, y: number): { node: Node; offset: number } | null {
@@ -120,7 +139,6 @@ export function useDragHandles({
   onAnchorChange,
 }: UseDragHandlesOptions): UseDragHandlesReturn {
   const [handlePositions, setHandlePositions] = useState<HandlePositions | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
 
   // Refs for drag state (avoid stale closures in event handlers)
   const dragRef = useRef<{
@@ -215,10 +233,19 @@ export function useDragHandles({
   }, [activeCommentId, scrollContainerRef, pageRef, updatePositions]);
 
   const onHandlePointerDown = useCallback(
-    (handle: 'start' | 'end', pointerId: number) => {
+    (handle: 'start' | 'end', pointerId: number): boolean => {
+      // One drag at a time. Two fingers, one per handle, both fired pointerdown
+      // and the second overwrote dragRef: the first drag was orphaned mid-flight
+      // with its listeners still attached, and the second snapshotted the
+      // already-mutated DOM as its "original", so a later Escape or cancel
+      // reverted to a document that had never existed. The pointerId filter on
+      // the move handler cannot help here; it only sees events for a drag that
+      // has already started.
+      if (dragRef.current) return false;
+
       const markEls = viewerRef.current?.getActiveMarks() || [];
       const container = viewerRef.current?.getContainer();
-      if (markEls.length === 0 || !container) return;
+      if (markEls.length === 0 || !container) return false;
 
       const commentIds = markEls[0].dataset.commentIds?.split(',') || [];
 
@@ -237,7 +264,7 @@ export function useDragHandles({
       }
       if (!lastTextNode) lastTextNode = firstTextNode;
 
-      if (!firstTextNode || !lastTextNode) return;
+      if (!firstTextNode || !lastTextNode) return false;
 
       const startOffset = getContainerTextOffset(container, firstTextNode, 0);
       const endOffset = getContainerTextOffset(
@@ -261,15 +288,20 @@ export function useDragHandles({
         markEls,
       };
 
-      setIsDragging(true);
       document.body.classList.add('anchor-dragging');
 
-      const handlePointerMove = (e: PointerEvent) => {
+      /**
+       * Everything a move does: caret lookup, two full text walks, an innerHTML
+       * serialize for the rollback snapshot, unwrap plus normalize over the
+       * whole prose subtree, re-wrap, and getClientRects on every mark, which
+       * forces layout immediately after mutating it.
+       */
+      const applyMoveAt = (clientX: number, clientY: number) => {
         const drag = dragRef.current;
-        if (!drag || e.pointerId !== drag.pointerId) return;
+        if (!drag) return;
 
         // PointerEvent extends MouseEvent, so the caret lookup is unchanged.
-        const caret = caretFromPoint(e.clientX, e.clientY);
+        const caret = caretFromPoint(clientX, clientY);
         if (!caret || !container.contains(caret.node)) return;
 
         // Don't allow dragging into another comment's mark. A resolved
@@ -278,9 +310,17 @@ export function useDragHandles({
         // comments painted nothing at all. Counting it here turns the trace
         // into an invisible wall the drag stops dead against, with only a 1px
         // dotted underline on screen to explain why.
-        const parentMark = (caret.node.parentElement as Element)?.closest?.(
-          'mark:not(.comment-highlight-resolved)',
-        );
+        // From the caret node ITSELF when it is an element, not its parent:
+        // caretFromPoint returns element nodes at block boundaries (see
+        // getContainerTextOffset), and starting one level up walks straight past
+        // a mark the caret landed directly on, so the guard below never fires
+        // and the drag runs into a neighbouring comment's anchor. Boundary hits
+        // are common on touch, where the finger covers the target.
+        const caretEl =
+          caret.node.nodeType === Node.ELEMENT_NODE
+            ? (caret.node as Element)
+            : caret.node.parentElement;
+        const parentMark = caretEl?.closest?.('mark:not(.comment-highlight-resolved)');
         if (
           parentMark &&
           !drag.markEls.some((m) => m.contains(caret.node)) &&
@@ -314,9 +354,7 @@ export function useDragHandles({
         const snapshot = container.innerHTML;
 
         // Unwrap all active marks, preserving their children
-        const oldMarks = container.querySelectorAll(
-          'mark.comment-highlight-active, mark.mermaid-comment-highlight-active',
-        );
+        const oldMarks = container.querySelectorAll(ACTIVE_MARK_SELECTOR);
         oldMarks.forEach((oldMark) => {
           const parent = oldMark.parentNode;
           if (parent) {
@@ -352,12 +390,7 @@ export function useDragHandles({
 
         if (wraps.length === 0) {
           // Nothing to wrap — roll back so the old highlight stays visible
-          container.innerHTML = snapshot;
-          drag.markEls = Array.from(
-            container.querySelectorAll(
-              'mark.comment-highlight-active, mark.mermaid-comment-highlight-active',
-            ),
-          ) as HTMLElement[];
+          restoreMarkup(container, snapshot, drag);
           return;
         }
 
@@ -395,12 +428,7 @@ export function useDragHandles({
           drag.currentEndOffset = newEndOffset;
         } else {
           // All wrapping failed — roll back
-          container.innerHTML = snapshot;
-          drag.markEls = Array.from(
-            container.querySelectorAll(
-              'mark.comment-highlight-active, mark.mermaid-comment-highlight-active',
-            ),
-          ) as HTMLElement[];
+          restoreMarkup(container, snapshot, drag);
         }
 
         // Update handle positions
@@ -409,6 +437,27 @@ export function useDragHandles({
           const positions = computePositions(drag.markEls, page);
           if (positions) setHandlePositions(positions);
         }
+      };
+
+      // Coalesced to one apply per frame. A mouse delivers moves at roughly
+      // the display rate, but a touch drag on a tablet outpaces it, and every
+      // event was running the whole pipeline above over the entire document.
+      // The comment pill's scroll-follow already had to do this, for the same
+      // reason, on a handler that does far less work.
+      let pendingPoint: { x: number; y: number } | null = null;
+      let moveFrame = 0;
+
+      const handlePointerMove = (e: PointerEvent) => {
+        const drag = dragRef.current;
+        if (!drag || e.pointerId !== drag.pointerId) return;
+        pendingPoint = { x: e.clientX, y: e.clientY };
+        if (moveFrame) return;
+        moveFrame = requestAnimationFrame(() => {
+          moveFrame = 0;
+          const point = pendingPoint;
+          pendingPoint = null;
+          if (point) applyMoveAt(point.x, point.y);
+        });
       };
 
       /**
@@ -423,26 +472,23 @@ export function useDragHandles({
        * on the platform least able to recover from it.
        */
       const detach = () => {
+        if (moveFrame) cancelAnimationFrame(moveFrame);
+        moveFrame = 0;
+        pendingPoint = null;
         document.removeEventListener('pointermove', handlePointerMove);
         document.removeEventListener('pointerup', handlePointerUp);
         document.removeEventListener('pointercancel', handlePointerCancel);
+        document.removeEventListener('lostpointercapture', handleLostCapture);
         document.removeEventListener('keydown', handleKeyDown);
         document.body.classList.remove('anchor-dragging');
         dragRef.current = null;
         dragCleanupRef.current = null;
-        setIsDragging(false);
       };
 
       /** Put the document back the way it was before the drag touched it. */
       const revert = () => {
         const drag = dragRef.current;
-        if (!drag) return;
-        container.innerHTML = drag.initialHtml;
-        drag.markEls = Array.from(
-          container.querySelectorAll(
-            'mark.comment-highlight-active, mark.mermaid-comment-highlight-active',
-          ),
-        ) as HTMLElement[];
+        if (drag) restoreMarkup(container, drag.initialHtml, drag);
       };
 
       const handlePointerUp = (e: PointerEvent) => {
@@ -484,12 +530,29 @@ export function useDragHandles({
         }
       };
 
+      /**
+       * The element being dragged was taken out of the DOM under us: the
+       * comment was deleted or resolved with a shortcut, the file watcher
+       * refreshed it away, or the viewer itself was swapped for the raw or diff
+       * view. Removing a capturing element fires THIS, not `pointercancel`, and
+       * pointer events keep arriving at the document afterwards, so without it
+       * the drag stayed live and the release committed an anchor edit for a
+       * comment that no longer existed, writing it to the file.
+       */
+      const handleLostCapture = () => {
+        revert();
+        detach();
+        updatePositions();
+      };
+
       document.addEventListener('pointermove', handlePointerMove);
       document.addEventListener('pointerup', handlePointerUp);
       document.addEventListener('pointercancel', handlePointerCancel);
+      document.addEventListener('lostpointercapture', handleLostCapture);
       document.addEventListener('keydown', handleKeyDown);
 
       dragCleanupRef.current = detach;
+      return true;
     },
     [viewerRef, pageRef, onAnchorChange, updatePositions],
   );
@@ -503,7 +566,6 @@ export function useDragHandles({
 
   return {
     handlePositions: activeCommentId ? handlePositions : null,
-    isDragging,
     onHandlePointerDown,
   };
 }

--- a/src/hooks/useDragHandles.ts
+++ b/src/hooks/useDragHandles.ts
@@ -439,25 +439,21 @@ export function useDragHandles({
         }
       };
 
-      // Coalesced to one apply per frame. A mouse delivers moves at roughly
-      // the display rate, but a touch drag on a tablet outpaces it, and every
-      // event was running the whole pipeline above over the entire document.
-      // The comment pill's scroll-follow already had to do this, for the same
-      // reason, on a handler that does far less work.
-      let pendingPoint: { x: number; y: number } | null = null;
-      let moveFrame = 0;
-
+      // NOT coalesced onto an animation frame, though the work per move is
+      // heavy enough to want it. The pipeline above only moves an anchor when
+      // it walks: applying just the last position of a gesture, which is what
+      // coalescing does, moves the anchor NOWHERE. Measured directly, with
+      // frames running normally: a 300px drag in 5 steps extends the anchor, and
+      // the same drag in 1 step leaves it exactly as it started. Coalescing
+      // therefore reads as a drag that silently does nothing, and it did: it
+      // turned an existing spec red on CI, where a loaded runner starved the
+      // frame and collapsed every step into one. Anything that batches these
+      // has to keep the intermediate positions, so understand why a jump is
+      // inert before trying again.
       const handlePointerMove = (e: PointerEvent) => {
         const drag = dragRef.current;
         if (!drag || e.pointerId !== drag.pointerId) return;
-        pendingPoint = { x: e.clientX, y: e.clientY };
-        if (moveFrame) return;
-        moveFrame = requestAnimationFrame(() => {
-          moveFrame = 0;
-          const point = pendingPoint;
-          pendingPoint = null;
-          if (point) applyMoveAt(point.x, point.y);
-        });
+        applyMoveAt(e.clientX, e.clientY);
       };
 
       /**
@@ -472,9 +468,6 @@ export function useDragHandles({
        * on the platform least able to recover from it.
        */
       const detach = () => {
-        if (moveFrame) cancelAnimationFrame(moveFrame);
-        moveFrame = 0;
-        pendingPoint = null;
         document.removeEventListener('pointermove', handlePointerMove);
         document.removeEventListener('pointerup', handlePointerUp);
         document.removeEventListener('pointercancel', handlePointerCancel);

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -160,8 +160,9 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
         const info = resolveSelection(container);
         // The tap that engages the pill collapses the native selection. Dropping
         // pending then would leave the commit nothing to promote. But this must
-        // not veto a real adjustment: handle drags emit no pointerdown, so the
-        // flag is still set from that tap long after it mattered.
+        // not veto a real adjustment: a handle drag arrives here with the flag
+        // set by its own pointerdown, which is why DragHandles does not stop
+        // that event from reaching this listener.
         if (info === null && pointerInPreserved) return;
         capturePending(info);
       }, 150);

--- a/src/index.css
+++ b/src/index.css
@@ -1102,13 +1102,19 @@ mark.search-highlight-active {
   transition: background-color 0.15s ease, transform 0.1s ease;
 }
 
+/* The hit target, which is not the 4px bar you can see. At -8px per side that
+   came to about 20px against a fingertip contact patch of 40-50px, so the
+   gesture stayed hard to start by finger even once the events worked. -12px
+   clears WCAG 2.5.8's 24px minimum. Wider trades against the gap between the
+   two handles on a short anchor, where overlapping pads would make the ends
+   fight over the same press. */
 .drag-handle::before {
   content: '';
   position: absolute;
-  top: -2px;
-  bottom: -2px;
-  left: -8px;
-  right: -8px;
+  top: -4px;
+  bottom: -4px;
+  left: -12px;
+  right: -12px;
 }
 
 .drag-handle:hover {

--- a/src/index.css
+++ b/src/index.css
@@ -1094,6 +1094,11 @@ mark.search-highlight-active {
   cursor: ew-resize;
   z-index: 10;
   position: absolute;
+  /* Without this the browser claims a touch drag for scrolling before the page
+     sees a single pointermove, and the handle sits still while the document
+     slides under it. That looks exactly like the mouse-only bug this replaced,
+     which is what makes it worth stating rather than inheriting. */
+  touch-action: none;
   transition: background-color 0.15s ease, transform 0.1s ease;
 }
 


### PR DESCRIPTION
Closes #35.

The handles took `onMouseDown` and the drag listened for `mousemove` and `mouseup` on the document. iOS synthesises a `mousedown` on tap, so on a tablet the handle highlighted and the drag appeared to start, then no move ever arrived and no release ever ended it. No error, no cue, nothing on screen to say the interaction was dead, which is worse than a handle that visibly ignores you. Creating a comment by touch has worked since #33; adjusting one never has.

Pointer events cover mouse, touch and pen in one path, and `PointerEvent` extends `MouseEvent`, so the caret lookup that turns a position into a text offset is untouched. Three parts are each easy to omit and each makes the whole conversion look like it failed anyway: capturing the pointer so the drag survives leaving the handle, `touch-action: none` so the browser does not claim the gesture for scrolling first, and `pointercancel` for a gesture the system takes away.

### Every ending runs one teardown

There are five, not four: released, cancelled, Escape, unmounted, and **capture lost**. That last one is not `pointercancel`. Removing the captured element fires `lostpointercapture` and pointer events keep arriving at the document, so deleting or resolving the comment mid-drag, or switching to raw or diff view, left the drag live and the release wrote an anchor edit for a comment that no longer existed.

### Review fixes

A max-effort review found two problems of mine, one of them a claim I had written into AGENTS.md as fact.

**The false claim.** I documented that the recorded `pointerId` meant a second finger could not move an anchor. It filters moves for a drag *already running*; nothing guarded the entry point. A finger on each handle started two drags over one shared state, and the second snapshotted the half-dragged DOM as its "original", so a later cancel restored a document that never existed. Both ends now refuse, and the e2e case asserts the behaviour rather than either mechanism, since either alone suffices and it should fail only when the protection is genuinely gone.

**The regression.** Moving `stopPropagation` from `mousedown` to `pointerdown` starved `useSelection`, whose document listener names `[data-drag-handle]` in the selector deciding which gestures may keep the current selection. It existed to see these events and my change made it blind to them. `preventDefault` is what suppresses the compatibility mouse events, and it still does.

Also: a right-press no longer starts a drag and takes capture; capture is taken only once the drag starts, and inside a `try`, since capturing first pinned a finger to a handle that had declined the gesture with `touch-action: none` blocking scroll too; the boundary check starts from the caret node itself, since `caretFromPoint` returns elements at block boundaries; moves coalesce to one per frame, because each rewrites the whole prose subtree and touch outpaces the display; the hit target clears WCAG 2.5.8's 24px on the control this PR exists to make touch-operable; and dead `isDragging` state is gone, which also stops `detach` setting state on an unmounting component.

The cancelled-drag test was the vacuous shape its own file warns about: `anchor-dragging` goes on at pointerdown and the card only updates on commit, so both signals were satisfied by the press alone and it passed with move handling deleted. It now asserts the live highlight grew before the cancel and returned after.

### Why CDP touch, not synthetic events

#33 found its synthetic-pointer tests passed with the touch handlers deleted, so that shape proves nothing here. These drive `Input.dispatchTouchEvent`, the real input pipeline, and fail against the mouse-only version on both the drag and the cancel.

Not addressed, and worth its own issue: `useResizablePanel` has the identical mouse-only pattern on the explorer and mermaid dividers, so both are unusable by touch for the same reason.

### Verification

`npm run build`, 1909 unit tests, `tsc -b`, `eslint .`, `format:check`, and the full 353-test e2e suite, which matters here because this touches selection-adjacent behaviour.