### PR TITLE
Protect an unclosed fence when placing a comment marker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,9 +117,17 @@ highlighting, orphan detection, and agent handoff are unaffected.
 The ranges are computed with regexes, and each container's scan excludes the
 others (a fence line inside frontmatter is YAML, a `<!--` inside a fence is
 sample text). Do not add a fifth exclusion: four rounds of that have already
-happened and the fourth cost a silently lost comment. #30 replaces the
-computation with ranges derived from the parse, and the next container bug to
-land here is the trigger to do it.
+happened and the fourth cost a silently lost comment. #30 tracks replacing the
+computation with ranges derived from the parse.
+
+**Placement alone treats an unclosed fence as running to end of document**
+(`getCodeBlockRanges`'s `unclosedRunsToEof`), because that is how every renderer
+reads one, and without it a marker went into the user's code. Detection is
+deliberately NOT told: teaching it would make every marker below such a fence
+vanish from documents that already contain them. The asymmetry only runs one
+way on purpose. Insertion protecting more than detection sees can only push a
+marker further out, into text detection does read; the reverse, a container
+insertion knows about and detection does not, is what silently loses comments.
 
 ## API endpoints
 

--- a/src/lib/comment-parser.test.ts
+++ b/src/lib/comment-parser.test.ts
@@ -2522,6 +2522,34 @@ describe('insertComment inside fenced code blocks', () => {
       expect(parseComments(result).comments).toHaveLength(1);
     });
 
+    it('does not nest inside an UNCLOSED fence', () => {
+      // The container the scanner could not see. It pushes a range only on
+      // finding a CLOSING fence, so a fence with none protected nothing and the
+      // marker went into the user's code as
+      // `const secret = <!-- @comment{...} -->computeToken()`. Every renderer
+      // reads an unclosed fence as running to the end of the document.
+      const raw = '# T\n\nIntro.\n\n```js\nconst secret = computeToken();\nrun(secret);\n';
+      const result = insertComment(raw, 'computeToken', 'why?');
+
+      expect(result.slice(result.indexOf('```js'))).not.toContain('@comment');
+      expect(parseComments(result).comments).toHaveLength(1);
+      expect(parseComments(result).cleanMarkdown).toBe(raw);
+    });
+
+    it('still READS a marker written after an unclosed fence', () => {
+      // The asymmetry, pinned. Placement treats an unclosed fence as running to
+      // EOF; detection deliberately does not, and must not: teaching it would
+      // make every marker below such a fence disappear from documents that
+      // already contain them. Protecting more than detection sees is the safe
+      // direction, because it can only push a marker OUT into text detection
+      // does read.
+      const existing =
+        '# T\n\n```js\ncode();\n\n<!-- @comment{"id":"e1","anchor":"After","text":"n","author":"A"} -->After\n';
+
+      expect(parseComments(existing).comments).toHaveLength(1);
+      expect(parseComments(existing).comments[0].id).toBe('e1');
+    });
+
     it('does not let a fence line inside frontmatter mis-pair the real fences', () => {
       // `  ```" in a YAML block scalar used to open a range that the real
       // ```js line closed. Everything between them counted as code and the

--- a/src/lib/comment-parser.ts
+++ b/src/lib/comment-parser.ts
@@ -39,7 +39,10 @@ type CommentTransform =
   | { type: 'remove' }
   | { type: 'replace'; comment: MdComment };
 
-function getCodeBlockRanges(rawMarkdown: string): CodeBlockRange[] {
+function getCodeBlockRanges(
+  rawMarkdown: string,
+  { unclosedRunsToEof = false }: { unclosedRunsToEof?: boolean } = {},
+): CodeBlockRange[] {
   const codeBlockRanges: CodeBlockRange[] = [];
   const fenceRegex = /^ {0,3}(`{3,}|~{3,}).*$/gm;
   let fenceMatch: RegExpExecArray | null;
@@ -71,6 +74,17 @@ function getCodeBlockRanges(rawMarkdown: string): CodeBlockRange[] {
       });
       openFence = null;
     }
+  }
+
+  // A fence with no closer runs to the end of the document, which is how every
+  // renderer reads it. Only PLACEMENT is told so, and the asymmetry is
+  // deliberate and one-directional: insertion protecting more than detection
+  // sees can only push a marker further OUT of a container, into text detection
+  // does read. The reverse, teaching detection about a container insertion does
+  // not know, is what silently loses comments, so detection keeps pairing
+  // fences exactly as it does today.
+  if (unclosedRunsToEof && openFence) {
+    codeBlockRanges.push({ start: openFence.start, end: rawMarkdown.length });
   }
 
   return codeBlockRanges;
@@ -867,7 +881,7 @@ export function insertComment(
   let ownLine = false;
   let leadingNewline = false;
   {
-    const fencedRanges = getCodeBlockRanges(cleanMarkdown);
+    const fencedRanges = getCodeBlockRanges(cleanMarkdown, { unclosedRunsToEof: true });
     const frontmatter = getFrontmatterRange(cleanMarkdown);
     // Fenced blocks: before the opening fence.
     for (const range of fencedRanges) {


### PR DESCRIPTION
Addresses the live defect in #30, and deliberately does **not** take that issue's proposed approach. See below.

`getCodeBlockRanges` pushes a range only when it finds a CLOSING fence, so a fence with none protected nothing and `insertComment` wrote the marker into the user's code:

```
const secret = <!-- @comment{"id":"...","anchor":"computeToken",...} -->computeToken();
```

Every renderer reads an unclosed fence as running to the end of the document. Placement now does too.

### Only placement, and that is the whole design

Detection keeps pairing fences exactly as it does today. Teaching it the same rule would make every marker below an unclosed fence disappear from documents that already contain them, which is the silent comment loss this file has a history of.

The asymmetry is safe in one direction only, and this is that direction. Insertion protecting **more** than detection sees can only push a marker further out of a container, into text detection does read. A container insertion knows about and detection does not is the dangerous one. A second test pins the half that must not change, because it is the half a future reader is most likely to "fix".

### Why not the parse-derived rewrite #30 proposes

I built that first, on `fix/parse-derived-container-ranges`, and a max-effort review plus my own verification says it must not ship. It derives containers from mdast node *types*, assuming node boundaries coincide with syntactic containers, and they frequently do not:

- An HTML block absorbs fence lines, so `<details>` around a code block yields no code node and is not itself a comment. The marker goes into the code, detection's scanner still pairs those fences and refuses to see it: **0 comments parsed back, not removable, permanent litter.** That is character-for-character the corruption the rewrite was meant to fix.
- mdast starts a blockquoted or list-nested code node mid-line, so `marker + \n` splits the line and tears the fence out of its container. No longer round-trips.
- An indented `<!-- -->`, an unclosed inline `<!--`, and a malformed marker all produce no html node, so the marker nests inside them.
- Omitting GFM makes a footnote continuation a code container to placement and prose to the renderer.
- The MCP batch path calls `insertComment` in an uncapped loop: 30 comments on a 29.5KB document went 13ms to 592ms, **while holding the per-file write lock** with the user's autosave queued behind it.

The fixed-point loop that rewrite was built around also cannot iterate more than once, since mdast never emits overlapping container ranges. Capping it at a single pass leaves all 309 tests green.

Six symptoms, one root cause. Patching them individually would repeat exactly the four-round history #30 exists to end, so #30 should stay open with that map attached rather than be closed by a rewrite that fails worse than what it replaces.

### What this costs instead

Nothing measurable. No new dependency, no bundle change, no change to `parseComments` on the hot path, insertion cost unchanged. The five shapes above all round-trip and stay removable, exactly as on main.

### Verification

`npm run build`, 1911 unit tests including 305 pre-existing parser cases green and unedited, `tsc -b`, `eslint .`, `format:check`. The regression test fails without the fix; the asymmetry guard passes either way by design.