### PR TITLE
Keep a drag handle's pointerdown from reaching the selection listener

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -764,7 +764,12 @@ scroll-follow coalesces into one measurement per animation frame, because touch
 scrolling outpaces the compositor and measuring per event reads as jitter.
 
 The anchor drag handles (`DragHandles.tsx`, `useDragHandles.ts`) run on pointer
-events for the same reason. They were mouse-only, and reacted to a tap because
+events for the same reason. Their `pointerdown` stops propagating, which is
+load-bearing rather than incidental: `useSelection`'s document listener bumps a
+gesture epoch that invalidates any in-flight selection timer, and a press on a
+handle is not a new selection gesture. Letting it through made comment creation
+flaky on a heavy document, measured at one to two flakes in five runs against
+none. They were mouse-only, and reacted to a tap because
 iOS synthesises a `mousedown`, so the handle highlighted and the drag appeared
 to start and then received no `mousemove` for the rest of the gesture: dead on a
 tablet, with nothing on screen to say so. Three things make the conversion work

--- a/src/components/DragHandles.tsx
+++ b/src/components/DragHandles.tsx
@@ -28,14 +28,19 @@ export function DragHandles({ startPos, endPos, onPointerDown }: DragHandlesProp
     // movement afterwards went on re-anchoring the comment with nothing held.
     if (!e.isPrimary || e.button !== 0) return;
 
-    // preventDefault, but deliberately NOT stopPropagation. `useSelection`
-    // listens for pointerdown on the document and names [data-drag-handle] in
-    // the selector that decides whether a gesture may keep the current
-    // selection; stopping it here starved that listener of the one event it
-    // most needs, leaving its gesture epoch unbumped and its
-    // preserved-selection flag stale. Suppressing the compatibility mousedown
-    // is preventDefault's job and it still does it.
+    // Both, and the stopPropagation is load-bearing. A code review argued for
+    // dropping it, because `useSelection` listens for pointerdown on the
+    // document and names [data-drag-handle] in the selector deciding which
+    // gestures may keep the current selection, so it looks starved. Letting the
+    // event through instead made comment creation flaky on a heavy document:
+    // that listener bumps a gesture epoch which invalidates any in-flight
+    // selection timer, and a press on a handle is not a new selection gesture.
+    // Measured over five runs each, on the stress spec's Mermaid-heavy fixture:
+    // clean with this line, one to two flakes without it. The listener was
+    // written for a world where handles emit no pointerdown, and this keeps
+    // that true rather than half-changing it.
     e.preventDefault();
+    e.stopPropagation();
 
     // Only capture once the drag is really running. Capturing first left a
     // pointer pinned to a handle that had declined the gesture, and with

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -160,9 +160,9 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
         const info = resolveSelection(container);
         // The tap that engages the pill collapses the native selection. Dropping
         // pending then would leave the commit nothing to promote. But this must
-        // not veto a real adjustment: a handle drag arrives here with the flag
-        // set by its own pointerdown, which is why DragHandles does not stop
-        // that event from reaching this listener.
+        // not veto a real adjustment: handle drags emit no pointerdown here,
+        // because DragHandles stops it, so the flag is still set from that tap
+        // long after it mattered.
         if (info === null && pointerInPreserved) return;
         capturePending(info);
       }, 150);


### PR DESCRIPTION
Fixes a flake I merged in #56. Comment creation on a Mermaid-heavy document became intermittent, and the cause is a review finding I applied without measuring it.

## Bisected, not guessed

Full suite against merged main showed one flaky test, `e2e/stress.spec.ts` "comments on a punctuation-heavy anchor near the end of a Mermaid-heavy file". Five runs at each point:

| Commit | Result |
|---|---|
| before all three merges | 5/5 pass, 21.8s |
| #55 only | 5/5 pass, 21.8s |
| #55 + #56 | 1 flaky, 36.4s |
| all three | 2 flaky, 50.8s |

Then, within #56: reverting the widened hit target changed nothing (still 1 flaky), and restoring this one line returned it to 5/5 at 21.8s, the exact pre-merge baseline.

## Why the review was wrong here, and it was a good argument

`useSelection` listens for `pointerdown` on the document and names `[data-drag-handle]` in the selector deciding which gestures may keep the current selection, so stopping the event at the handle looks like starving the one listener that wants it. That is what the review argued and it reads correctly.

What it misses is the first thing that listener does:

```js
const handlePointerDown = (e: PointerEvent) => {
  epochRef.current += 1;   // <- invalidates any in-flight selection timer
```

A press on a drag handle is not a new selection gesture. Treating it as one discards selections that are still settling behind the 150ms `selectionchange` debounce, which is exactly what comment creation depends on. The listener's own comment describes a world where handle drags emit no `pointerdown`; that comment was accurate, my edit to it was not, and both are back to what they were.

## Left open deliberately

The interaction the review described is real: a touch selection still settling when a handle is grabbed can be dropped, because `pointerInPreserved` keeps whatever the last non-handle press set. It needs a fix that does not route through the epoch bump, and it is a narrower path than the one this broke. Filed separately rather than traded for this one.

## Verification

Five repeat runs of the flaky test green at the baseline time, plus the full 354-test e2e suite, 1944 unit tests, `npm run build`, `tsc -b`, `eslint .`, `format:check`.

## Process note

I reported #56 as verified by the full e2e suite, and it was, on the branch. A 1-in-5 flake passes a single run comfortably. Repeat-runs on tests near changed behaviour are what catch this class, and a single green suite is not evidence against it.