### PR TITLE
Correct a flake claim I could not reproduce

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -764,12 +764,13 @@ scroll-follow coalesces into one measurement per animation frame, because touch
 scrolling outpaces the compositor and measuring per event reads as jitter.
 
 The anchor drag handles (`DragHandles.tsx`, `useDragHandles.ts`) run on pointer
-events for the same reason. Their `pointerdown` stops propagating, which is
-load-bearing rather than incidental: `useSelection`'s document listener bumps a
-gesture epoch that invalidates any in-flight selection timer, and a press on a
-handle is not a new selection gesture. Letting it through made comment creation
-flaky on a heavy document, measured at one to two flakes in five runs against
-none. They were mouse-only, and reacted to a tap because
+events for the same reason. Their `pointerdown` stops propagating, and that is a
+reasoned choice rather than a measured one: `useSelection`'s document listener
+bumps a gesture epoch that invalidates any in-flight selection timer, and a
+press on a handle is not a new selection gesture. A review argued for letting it
+through, because the same listener names `[data-drag-handle]` in its
+preserved-selection selector; that concern is filed and unresolved. Both
+arrangements pass 20 consecutive runs of the heaviest insertion spec. They were mouse-only, and reacted to a tap because
 iOS synthesises a `mousedown`, so the handle highlighted and the drag appeared
 to start and then received no `mousemove` for the rest of the gesture: dead on a
 tablet, with nothing on screen to say so. Three things make the conversion work

--- a/src/components/DragHandles.tsx
+++ b/src/components/DragHandles.tsx
@@ -28,17 +28,19 @@ export function DragHandles({ startPos, endPos, onPointerDown }: DragHandlesProp
     // movement afterwards went on re-anchoring the comment with nothing held.
     if (!e.isPrimary || e.button !== 0) return;
 
-    // Both, and the stopPropagation is load-bearing. A code review argued for
-    // dropping it, because `useSelection` listens for pointerdown on the
-    // document and names [data-drag-handle] in the selector deciding which
-    // gestures may keep the current selection, so it looks starved. Letting the
-    // event through instead made comment creation flaky on a heavy document:
-    // that listener bumps a gesture epoch which invalidates any in-flight
-    // selection timer, and a press on a handle is not a new selection gesture.
-    // Measured over five runs each, on the stress spec's Mermaid-heavy fixture:
-    // clean with this line, one to two flakes without it. The listener was
-    // written for a world where handles emit no pointerdown, and this keeps
-    // that true rather than half-changing it.
+    // Both. The stopPropagation is kept on reasoning, not measurement: the
+    // first thing `useSelection`'s document listener does is bump a gesture
+    // epoch that invalidates any in-flight selection timer, and a press on a
+    // drag handle is not a new selection gesture. That listener was written for
+    // a world where handles emit no pointerdown, and this keeps it true rather
+    // than half-changing it.
+    //
+    // A code review argued the opposite, since the same listener names
+    // [data-drag-handle] in the selector deciding which gestures may keep the
+    // current selection, so stopping the event looks like starving it. That
+    // concern is real and unresolved: see the linked issue. Both arrangements
+    // pass 20 consecutive runs of the heaviest insertion spec, so nothing here
+    // is settled by a flake rate.
     e.preventDefault();
     e.stopPropagation();
 


### PR DESCRIPTION
Docs and comments only. No behaviour change.

#61 justified keeping `stopPropagation` on a drag handle's `pointerdown` with a measurement: "one to two flakes in five runs against none". That claim is wrong and it is written into `DragHandles.tsx` and AGENTS.md as fact, so this removes it.

## What re-running showed

| Commit | Runs | Result |
|---|---|---|
| `3e32088` (before all merges) | 5 | 5 passed (21.8s) |
| `3e32088` | 8 | **2 flaky**, 6 passed (1.1m) |
| `3e32088` | 8 | 8 passed (34.8s) |
| `3e32088` | 20 | 20 passed (1.4m) |
| current main | 8 | **1 flaky**, 7 passed |
| current main | 20 | 20 passed (1.4m) |

The same commit gives 5/5, 8/8, 20/20 and 2-flaky-in-8 depending on what else the machine is doing. The flakes in my original bisection appeared while full e2e suites were running in parallel. A 5-run sample cannot distinguish a 0% failure rate from roughly 15%, so the bisection that pinned this on #56 was reading noise.

## What changes

The comment in `DragHandles.tsx` and the paragraph in AGENTS.md now say the line is kept on reasoning rather than measurement, and name the counter-argument as open rather than closed. The reasoning is unchanged and was always the stronger half: `useSelection`'s document listener bumps a gesture epoch as its first act, which invalidates any in-flight selection timer, and a press on a drag handle is not a new selection gesture.

The code stays as it is. It is the conservative state, matching what the listener was written around, and nothing measured argues against it.

## Related

- #62, the review's opposite concern, still open and now corrected in the same way.
- #63, the underlying test's baseline flakiness, filed with the run-by-run numbers.