### PR TITLE
Three correctness fixes from a relayed review of 0.8.2..main

### DIFF
--- a/bin/file-lock.js
+++ b/bin/file-lock.js
@@ -301,55 +301,64 @@ export async function acquireFileLock(filePath) {
     installCleanupHandlers();
 
     return async () => {
-      // Before the unlink, not after: whichever of the two paths gets there
-      // first, the other must not try the same removal again.
-      forgetHeldLock(lockPath);
-
-      let holder;
+      // `forgetHeldLock` is deliberately in a finally, not at the top. Dropping
+      // it first empties `heldLocks`, which uninstalls the signal and exit
+      // handlers, and everything below is async: a Ctrl-C anywhere in that
+      // window finds no handler left and strands the lock for LOCK_STALE_MS.
+      // That is the exact failure this module exists to prevent, moved from
+      // acquire to release. Holding it to the end costs nothing, because both
+      // paths check the token before removing anything and treat a missing
+      // file as done, so whichever gets there second finds no work.
       try {
-        holder = await retryTransient(() => readFile(lockPath, 'utf-8'));
-      } catch (err) {
-        // Already gone: released twice, or stolen and released by whoever took
-        // it. Either way there is nothing here to remove.
-        if (errorCode(err) === 'ENOENT') return;
-        // A read that will not succeed proves nothing about who holds the lock,
-        // and unlinking on that evidence is exactly the failure this check
-        // exists to prevent. Leaving it costs one stale window and then clears
-        // on its own; guessing wrong costs mutual exclusion.
-        console.error(
-          `Could not read the lock at ${lockPath} to confirm it is still ` +
-            `ours, so it was left in place; writes are blocked until it ages ` +
-            `out after ${LOCK_STALE_MS}ms:`,
-          err,
-        );
-        return;
-      }
+        let holder;
+        try {
+          holder = await retryTransient(() => readFile(lockPath, 'utf-8'));
+        } catch (err) {
+          // Already gone: released twice, or stolen and released by whoever
+          // took it. Either way there is nothing here to remove.
+          if (errorCode(err) === 'ENOENT') return;
+          // A read that will not succeed proves nothing about who holds the
+          // lock, and unlinking on that evidence is exactly the failure this
+          // check exists to prevent. Leaving it costs one stale window and then
+          // clears on its own; guessing wrong costs mutual exclusion.
+          console.error(
+            `Could not read the lock at ${lockPath} to confirm it is still ` +
+              `ours, so it was left in place; writes are blocked until it ages ` +
+              `out after ${LOCK_STALE_MS}ms:`,
+            err,
+          );
+          return;
+        }
 
-      if (holder !== token) {
-        // Our lock aged past LOCK_STALE_MS while we held it and another writer
-        // took it as abandoned. The write we just finished was NOT serialized
-        // against theirs, and unlinking this would hand a third writer the same
-        // window. Say so: a file that comes back different needs an explanation
-        // somewhere, and this is the only place that has one.
-        console.error(
-          `The lock at ${lockPath} was taken over by another writer while we ` +
-            `held it (ours was idle past ${LOCK_STALE_MS}ms), so this write ` +
-            `was not serialized against theirs. Leaving their lock in place.`,
-        );
-        return;
-      }
+        if (holder !== token) {
+          // Our lock aged past LOCK_STALE_MS while we held it and another
+          // writer took it as abandoned. The write we just finished was NOT
+          // serialized against theirs, and unlinking this would hand a third
+          // writer the same window. Say so: a file that comes back different
+          // needs an explanation somewhere, and this is the only place that has
+          // one.
+          console.error(
+            `The lock at ${lockPath} was taken over by another writer while we ` +
+              `held it (ours was idle past ${LOCK_STALE_MS}ms), so this write ` +
+              `was not serialized against theirs. Leaving their lock in place.`,
+          );
+          return;
+        }
 
-      try {
-        await retryTransient(() => unlink(lockPath));
-      } catch (err) {
-        if (errorCode(err) === 'ENOENT') return;
-        // An orphaned lock blocks every writer, in this process and any other
-        // mdr instance, until it ages out. Never silent.
-        console.error(
-          `Could not release the lock at ${lockPath}; writes are ` +
-            `blocked until it ages out after ${LOCK_STALE_MS}ms:`,
-          err,
-        );
+        try {
+          await retryTransient(() => unlink(lockPath));
+        } catch (err) {
+          if (errorCode(err) === 'ENOENT') return;
+          // An orphaned lock blocks every writer, in this process and any other
+          // mdr instance, until it ages out. Never silent.
+          console.error(
+            `Could not release the lock at ${lockPath}; writes are ` +
+              `blocked until it ages out after ${LOCK_STALE_MS}ms:`,
+            err,
+          );
+        }
+      } finally {
+        forgetHeldLock(lockPath);
       }
     };
   }

--- a/bin/file-lock.test.ts
+++ b/bin/file-lock.test.ts
@@ -335,6 +335,39 @@ describe('an interrupt while the lock is held', () => {
     await stealer();
   });
 
+  itPosix('keeps handling signals until the lock is actually gone', async () => {
+    // The window between "release started" and "lock file removed". Forgetting
+    // the lock at the top of release empties the held set, which uninstalls
+    // every handler, while the read and unlink that follow are async. A Ctrl-C
+    // in there found nothing installed and stranded the lock for the full stale
+    // window, which is the failure this module exists to prevent, arriving
+    // through release instead of through acquire.
+    const source = `
+      import { acquireFileLock } from ${JSON.stringify(lockModule)};
+      import { chmod } from 'fs/promises';
+      const release = await acquireFileLock(${JSON.stringify(target)});
+      // Make the unlink fail so the release stays open, and report what a
+      // signal arriving right now would find.
+      await chmod(${JSON.stringify(dir)}, 0o500);
+      const pending = release();
+      await new Promise((r) => setImmediate(r));
+      console.log(JSON.stringify({
+        sigint: process.listenerCount('SIGINT'),
+        exit: process.listenerCount('exit'),
+      }));
+      await chmod(${JSON.stringify(dir)}, 0o700);
+      await pending.catch(() => {});
+    `;
+    const child = spawn(process.execPath, ['--input-type=module', '-e', source], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    child.stdout.on('data', (chunk) => (stdout += String(chunk)));
+    await new Promise((resolvePromise) => child.once('close', resolvePromise));
+
+    expect(JSON.parse(stdout)).toEqual({ sigint: 1, exit: 1 });
+  });
+
   itPosix('stops handling signals once the lock is released', async () => {
     // Cleanup that outlives the lock changes how the process dies for reasons
     // unrelated to the lock, and a listener nothing removes is a leak in a

--- a/bin/fs-atomic.js
+++ b/bin/fs-atomic.js
@@ -233,7 +233,9 @@ async function renameIntoPlace(tmpPath, path, content) {
  * module does not own, Claude Desktop's MCP config, because it holds every
  * other server's `env` block and those routinely carry API tokens.
  *
- * Best effort in both directions. No destination yet (the ordinary create) and
+ * Best effort in both directions, but not blind: the stat is retried like every
+ * other call here, so a transient bounce cannot masquerade as "no destination"
+ * and quietly relax the mode. No destination yet (the ordinary create) and
  * there is nothing to copy; a chmod that fails leaves the default, which is
  * never more permissive than what a fresh file would have got anyway, and is
  * not worth failing an otherwise good save over.
@@ -243,12 +245,31 @@ async function renameIntoPlace(tmpPath, path, content) {
  * @returns {Promise<void>}
  */
 async function inheritMode(tmpPath, path) {
+  let existing;
   try {
-    const existing = await stat(path);
-    await chmod(tmpPath, existing.mode & 0o7777);
-  } catch {
-    /* no destination, or a filesystem without modes (Windows) */
+    // Retried like every other syscall here. It was the one exception, and a
+    // bare catch cannot tell "there is no destination" from "a scanner bounced
+    // this call": both skipped the chmod, so a contended save silently RELAXED
+    // the mode it was supposed to carry over. EBUSY on the network and
+    // cloud-sync mounts this module documents is the case that matters, and it
+    // is precisely where a save is most likely to bounce.
+    existing = await retryTransient(() => stat(path));
+  } catch (err) {
+    // ENOENT is the ordinary create, with no destination to inherit from.
+    // Anything else survived the retries, so the mode genuinely cannot be read;
+    // there is still nothing better to do than leave the default, which is
+    // never more permissive than a fresh file would have got.
+    if (errorCode(err) !== 'ENOENT') {
+      console.warn(
+        `[md-redline] could not read the existing mode of ${path} ` +
+          `(${errorCode(err) ?? 'unknown'}); the file keeps default permissions`,
+      );
+    }
+    return;
   }
+  // Best effort: a chmod that fails leaves the default, which is not worth
+  // failing an otherwise good save over.
+  await chmod(tmpPath, existing.mode & 0o7777).catch(() => {});
 }
 
 /**

--- a/e2e/file-watcher.spec.ts
+++ b/e2e/file-watcher.spec.ts
@@ -421,6 +421,59 @@ test.describe('File watcher - external changes', () => {
       .toBe(true);
   });
 
+  test('closing a tab inside the debounce cancels its backfill write', async ({ page }) => {
+    // The backfill waits 2s, and a tab can close inside that window. The timer
+    // lives in App while every close path lives in useTabs, so nothing cancels
+    // it: it fired and PUT pre-close content, with a pre-close expectedMtime,
+    // for a file the reader had already put away.
+    await openFixture(page);
+    // List density renders reply text, which is the signal that the SSE landed.
+    await switchToListDensity(page);
+    await page.waitForTimeout(1500);
+
+    const stampedAt = () =>
+      readFileSync(FIXTURE, 'utf-8').match(/"id":"close-r1"[^}]*"timestamp":"([^"]+)"/)?.[1] ??
+      null;
+
+    writeFileSync(
+      FIXTURE,
+      FIXTURE_ORIGINAL.replace(
+        'valid credentials',
+        `<!-- @comment${JSON.stringify({
+          id: 'close-c1',
+          anchor: 'valid credentials',
+          text: 'How are creds validated?',
+          author: 'Dennis',
+          timestamp: '2025-01-01T00:00:00.000Z',
+          replies: [{ id: 'close-r1', text: 'JWT bearer.', author: 'Agent CLI' }],
+        })} -->valid credentials`,
+      ),
+    );
+
+    // Long enough for the event to land and the write to be scheduled (the
+    // server debounces its watch by 150ms), short enough that the 2s backfill
+    // debounce has not elapsed. Asserting nothing is on disk yet is what keeps
+    // this honest: had the write already happened there would be nothing left
+    // to cancel and this would pass for the wrong reason.
+    await page.waitForTimeout(700);
+    expect(stampedAt()).toBeNull();
+
+    // Close through the tab's own X. Three buttons carry this filename (the
+    // explorer entry, the tab, the X), so a name-based `.first()` reaches the
+    // explorer and closes nothing, which is how this test first passed for the
+    // wrong reason. The tab strip emptying is the signal that it really closed.
+    await page.locator('button.group.rounded-t-md').first().hover();
+    await page
+      .getByRole('button', { name: /test-doc\.md/ })
+      .nth(2)
+      .click();
+    await expect(page.locator('button.group.rounded-t-md')).toHaveCount(0, { timeout: 5_000 });
+
+    // Well past the debounce: nothing may reach disk for a closed tab.
+    await page.waitForTimeout(3500);
+    expect(stampedAt()).toBeNull();
+  });
+
   test('a background tab backfills on the same debounce as the active tab', async ({ page }) => {
     // The two watchers shared the code that stamps arriving replies but not the
     // write that persists it. The active tab waits 2s and writes with a direct

--- a/server/fs-retry.test.ts
+++ b/server/fs-retry.test.ts
@@ -38,6 +38,7 @@ const fault = vi.hoisted(() => ({
   // what makes the cleanup assertions non-vacuous.
   write: { failuresLeft: 0, code: 'ENOSPC' },
   close: { failuresLeft: 0, code: 'EIO' },
+  stat: { failuresLeft: 0, code: 'EBUSY', attempts: 0 },
 }));
 
 function faultError(code: string, detail: string): NodeJS.ErrnoException {
@@ -61,6 +62,15 @@ vi.mock('fs/promises', async (importOriginal) => {
         throw faultError(fault.rename.code, `rename '${from}'`);
       }
       return actual.rename(from, to);
+    },
+    stat: async (path: string) => {
+      if (fault.stat.failuresLeft > 0 && !path.endsWith('.tmp')) {
+        fault.stat.failuresLeft -= 1;
+        fault.stat.attempts += 1;
+        throw faultError(fault.stat.code, `stat '${path}'`);
+      }
+      fault.stat.attempts += 1;
+      return actual.stat(path);
     },
     open: async (path: string, flags: string) => {
       if (path.endsWith('.tmp')) fault.open.attempts += 1;
@@ -126,6 +136,7 @@ beforeEach(async () => {
   fault.open = { failuresLeft: 0, code: 'ENOSPC', attempts: 0 };
   fault.write = { failuresLeft: 0, code: 'ENOSPC' };
   fault.close = { failuresLeft: 0, code: 'EIO' };
+  fault.stat = { failuresLeft: 0, code: 'EBUSY', attempts: 0 };
   for (const entry of await readdir(testDir).catch(() => [] as string[])) {
     await rm(join(testDir, entry), { force: true }).catch(() => {});
   }
@@ -329,6 +340,27 @@ describe('atomicWriteFile', () => {
       // holds every other server's env block, and those carry API tokens.
       await writeFile(docPath, 'old\n', { mode: 0o600 });
       await chmod(docPath, 0o600);
+
+      await atomicWriteFile(docPath, 'new\n');
+
+      expect((await stat(docPath)).mode & 0o777).toBe(0o600);
+      expect(await readFile(docPath, 'utf-8')).toBe('new\n');
+    },
+  );
+
+  it.skipIf(REAL_PLATFORM === 'win32')(
+    'keeps the destination mode through a bounced mode read',
+    async () => {
+      // The mode read was the one syscall here that was not retried, and its
+      // bare catch could not tell a scanner bouncing the call from there being
+      // no destination at all. Both skipped the chmod, so a contended save
+      // silently relaxed 0600 to the temp file's default. EBUSY on a network or
+      // cloud-sync mount is exactly where a save bounces, and
+      // claude_desktop_config.json, which holds other servers' API tokens, goes
+      // out through this path.
+      await writeFile(docPath, 'old\n', { mode: 0o600 });
+      await chmod(docPath, 0o600);
+      fault.stat.failuresLeft = 2;
 
       await atomicWriteFile(docPath, 'new\n');
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -645,6 +645,13 @@ export default function App() {
         path,
         setTimeout(async () => {
           backfillTimersRef.current.delete(path);
+          // The tab can close inside the debounce, and closing does not cancel
+          // this: the timer lives here while every close path lives in useTabs,
+          // and there are five of them, which is the shape that loses one.
+          // Checking here instead covers all five and any later addition. What
+          // it prevents is a PUT of pre-close content, with a pre-close
+          // expectedMtime, for a file the reader has already put away.
+          if (!getTabSnapshot(path)) return;
           try {
             const res = await fetch('/api/file', {
               method: 'PUT',
@@ -667,7 +674,7 @@ export default function App() {
         }, BACKFILL_WRITE_DELAY_MS),
       );
     },
-    [updateTab],
+    [getTabSnapshot, updateTab],
   );
   const handleCopyDocument = useCallback(() => {
     const clean = rawMarkdownRef.current.replace(createCommentMarkerRegex(), '');


### PR DESCRIPTION
An ultra review of `71a1ecd (0.8.2)..3e32088` produced 15 findings, none caught by an existing gate. These are the three correctness ones. The other twelve are recorded in #65.

## The lock's release window strands the lock

`release()` called `forgetHeldLock` first, which empties the held set, which uninstalls the SIGINT/SIGTERM/SIGHUP and `exit` handlers. Everything after that is async. A Ctrl-C between there and the unlink finds nothing installed and leaves the lock for the full 30-second stale window, blocking every `.md-redline.json` writer. That is precisely the failure the module exists to prevent, moved from acquire to release.

Sampled mid-release, before and after:

```
while held  : SIGINT = 1  exit = 1  lock = true
mid-release : SIGINT = 0  exit = 0  lock = true     <- the window
```

The comment arguing for that ordering was mine and it was wrong: both paths check the token before removing anything and treat a missing file as done, so whichever arrives second finds no work. The teardown moves into a `finally`, which also fixes something the original missed entirely, that a stolen or unreadable lock returned early and leaked its entry, leaving the handlers installed for the life of the process.

## A bounced mode read silently relaxed permissions

`inheritMode`'s `stat` was the only syscall in `fs-atomic.js` not wrapped in `retryTransient`, and its bare catch could not distinguish "no destination" from "a scanner bounced this call". Both skipped the `chmod`, so a contended save dropped 0600 to the temp file's default.

AGENTS.md states that guarantee verbatim and names EBUSY on SMB, NFS and the FUSE mounts behind Dropbox, Drive and iCloud as supported conditions, which is exactly where a save bounces. `claude_desktop_config.json` goes out through this path, and it holds every other MCP server's `env` block.

ENOENT stays the quiet ordinary create. Anything surviving the retries now warns rather than passing silently.

## A closed tab still wrote to disk

The backfill's per-path timer lives in `App.tsx` while all five close paths live in `useTabs`, so nothing cancelled it: it fired and PUT pre-close content, with a pre-close `expectedMtime`, for a file the reader had already put away. Guarded inside the timer rather than at five call sites, which is the shape that loses one.

## On the third test

It took three attempts to write honestly, and the reason is worth recording. It passed immediately at first, because `getByRole('button', { name: /test-doc\.md/ })` matches three elements: the explorer entry, the tab, and the tab's close X. `.first()` is the explorer entry, so the middle-click closed nothing and the assertion held for the wrong reason. The sibling test it was copied from has the same defect and only asserts that a dialog does not appear, so it never surfaced.

It now closes through the tab's own X and asserts the tab strip empties.

## Verification

Each fix has a test that fails without it, checked in both directions. `npm run build`, 1946 unit tests, 355 e2e, `tsc -b`, `eslint .`, `format:check`.