### PR TITLE
Cover the branch that refuses to write over an uncheckable prefs file

### DIFF
--- a/bin/prefs-cli.test.ts
+++ b/bin/prefs-cli.test.ts
@@ -3,11 +3,13 @@ import { spawn } from 'child_process';
 import {
   chmodSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from 'fs';
 import { tmpdir } from 'os';
@@ -119,6 +121,38 @@ describe('mdr --restrict', () => {
     expect(readFileSync(join(home, PREFS), 'utf8')).toBe(saved);
     expect(readdirSync(home).filter((e) => e.endsWith('.lock') || e.endsWith('.tmp'))).toEqual([]);
   });
+
+  // Symlinks need a privilege on Windows that CI does not grant, and this is
+  // the only way found to fail the stat WITHOUT also failing the lock one
+  // syscall earlier: the lock is a different path, so it is unaffected.
+  it.skipIf(process.platform === 'win32')(
+    'refuses when the prefs file cannot be checked at all',
+    async () => {
+      // The branch below the "already exists" one: a stat that fails for any
+      // reason other than ENOENT. Absent this guard, an unreadable prefs file
+      // reads as an absent prefs file, and `--restrict` overwrites the trust
+      // settings it exists to protect with an empty list. Nothing covered it,
+      // and the sibling test above says so about itself.
+      //
+      // A symlink pointing at itself is the reachable version. `stat` follows
+      // it, gives up, and reports ELOOP, which is permanent, so `retryTransient`
+      // rethrows on the first attempt.
+      const home = makeHome();
+      symlinkSync(PREFS, join(home, PREFS));
+
+      const result = await runCli(['--restrict'], home);
+
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain('Could not check');
+      expect(result.stderr).toContain('ELOOP');
+      expect(result.stderr).toContain('Refusing to write over a file');
+      // Untouched, and still a symlink: nothing wrote through it or replaced it.
+      expect(lstatSync(join(home, PREFS)).isSymbolicLink()).toBe(true);
+      expect(readdirSync(home).filter((e) => e.endsWith('.lock') || e.endsWith('.tmp'))).toEqual(
+        [],
+      );
+    },
+  );
 
   it.skipIf(!canDenyRead)('refuses when the home directory is unwritable', async () => {
     // Named for what it actually reaches. An unreadable home fails at the


### PR DESCRIPTION
Closes #70.

`enableRestrictedMode` has two refusals. It refuses when `.md-redline.json` already exists, which was tested, and it refuses when the `stat` that would decide fails for any reason other than ENOENT, which was not. The second is the one that matters more: without it an unreadable prefs file reads as an absent prefs file, and `--restrict` overwrites the trust settings it exists to protect with an empty list. Every gate in the repo would stay green.

The sibling test says so about itself:

> Named for what it actually reaches. An unreadable home fails at the LOCK, one syscall before the stat guard, so this does not cover that guard and must not claim to.

## Reaching the branch is the whole problem

The lock and the stat are one syscall apart in the same directory, so every permission trick fails the lock first: the lock takes `.md-redline.json.lock`, and anything that makes the directory unsearchable stops that before the stat is attempted.

A symlink pointing at itself works. `stat` follows it, gives up, and reports **ELOOP**, which is not in the transient set, so `retryTransient` rethrows on the first attempt. The lock is unaffected because it is a different path.

```
Could not check /…/.md-redline.json (ELOOP).
Refusing to write over a file that may hold your trust settings.
exit=1
```

## The issue's suggested approach does not work

#70 proposed reusing the fault injection from `bin/file-lock.test.ts`, on the grounds that the machinery already exists. It does, and it cannot reach here: those tests import the module and mock `fs/promises` **in-process**, while `prefs-cli.test.ts` drives the real binary as a **subprocess**. A mock in the parent means nothing to the child. Worth recording, since "the machinery exists" was the reason this looked cheap.

## Verified by mutation, not by passing

| Mutation | Result |
|---|---|
| Invert the errno comparison, so ELOOP reads as absent | 3 tests fail, including this one |
| Delete the guard entirely, so any error falls through to the write | **This test alone fails** |

The second is the evidence worth having: it shows the branch had zero coverage before and has exactly one test covering it now.

Skipped on Windows, where creating a symlink needs a privilege CI does not grant. That platform reaches this branch through different errnos anyway.

## Verification

`npm run build`, 1947 unit tests, `tsc -b`, `eslint .`, `format:check`.