### PR TITLE
Let mdr_review post into an existing session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,9 +488,12 @@ Only one ask can be pending per session at a time.
 
 ```ts
 {
-  filePaths: string[]            // required; absolute paths, length >= 1
+  // Exactly one of these two names the target session:
+  filePaths?: string[]           // absolute paths, length >= 1; opens a new session
+  sessionId?: string             // post into a session that already exists
+
   comments?: Array<{             // new top-level comments
-    filePath: string             // must appear in filePaths[]
+    filePath: string             // must appear in filePaths[] (filePaths form)
     anchor: string               // exact text in the file
     text: string                 // the feedback
     author?: string              // agent name shown in the UI
@@ -507,12 +510,26 @@ Only one ask can be pending per session at a time.
 }
 ```
 
-At least one of `comments[]` or `replies[]` must be non-empty. The tool opens the
-browser at the session URL (`origin: 'agent'`), writes the markers, and returns
-IMMEDIATELY (fire-and-forget). The result instructs the agent to call `mdr_wait`
-with the returned sessionId. Partial-anchor failures are surfaced as
-`failedComments[]` / `failedReplies[]`, and a failed multi-file batch rolls back
-the markers it already wrote.
+At least one of `comments[]` or `replies[]` must be non-empty. Passing both
+`filePaths` and `sessionId` is rejected, as is passing neither.
+
+In the `filePaths` form the tool opens the browser at the session URL
+(`origin: 'agent'`), writes the markers, and returns IMMEDIATELY
+(fire-and-forget). The result instructs the agent to call `mdr_wait` with the
+returned sessionId. Partial-anchor failures are surfaced as `failedComments[]` /
+`failedReplies[]`, and a failed multi-file batch rolls back the markers it
+already wrote.
+
+In the `sessionId` form the batch is posted into the named session and that
+sessionId is returned unchanged — no `grantAccess`, no `createSession`, no
+browser tab. This is the only way to reach the user-origin session an
+`mdr_request_review` handoff opened: `findOpenSession` filters dedupe on origin
+(agent- and user-origin sessions have incompatible terminal-state semantics), so
+the `filePaths` form always mints a second session for a file the user is already
+reading, costing a duplicate tab and a second banner row. Use `sessionId` for
+replying in-thread as work lands. Path validation is the server's: `/agent-comments`
+resolves every path and rejects any outside the named session's `filePaths`, which
+is stricter than the client-side `filePaths[]` membership check.
 
 **`mdr_wait`** — `{ sessionId }`. Blocks (90s re-poll cycle via `/agent-wait`)
 until the user clicks End review. Returns "done, re-read the file(s)" on End

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -21,7 +21,8 @@ import {
   writePortFile,
   type CreateAppOptions,
 } from './index';
-import { addReply, parseComments } from '../src/lib/comment-parser';
+import { addReply, insertComment, parseComments } from '../src/lib/comment-parser';
+import { handleReviewToolCall } from './mcp-stdio/handler';
 
 // Fails ONLY the synchronous boot read of the prefs file, leaving the async
 // read-modify-write path working. That asymmetry is the real shape of the bug:
@@ -2558,6 +2559,141 @@ async function buildTestApp(options: { allowedRoots: string[] }) {
   });
   return { app: testApp, reviewSessions: testReviewSessions };
 }
+
+describe('mdr_review attaching to an existing session (end to end)', () => {
+  /**
+   * A client that speaks to the real Hono app instead of the network. The
+   * handler, the route, the session store, and the on-disk markers are all
+   * the production code; only the transport is swapped, so what these tests
+   * assert is behaviour rather than which methods a mock saw.
+   */
+  function clientOver(testApp: {
+    request: (path: string, init?: RequestInit) => Response | Promise<Response>;
+  }) {
+    const post = async (path: string, body: unknown) => {
+      const res = await testApp.request(path, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const json = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) throw new Error(String(json.error ?? `HTTP ${res.status}`));
+      return json;
+    };
+    return {
+      grantAccess: async () => {},
+      createSession: async (input: { filePaths: string[]; origin?: string }) =>
+        (await post('/api/review-sessions', input)) as unknown as {
+          sessionId: string;
+          url: string;
+        },
+      postReview: async (sessionId: string, args: unknown) =>
+        (await post(`/api/review-sessions/${sessionId}/agent-comments`, {
+          mode: 'review',
+          ...(args as object),
+        })) as unknown as { commentsWritten: number; repliesWritten: number },
+    } as unknown as Parameters<typeof handleReviewToolCall>[1]['client'];
+  }
+
+  async function seedUserReview() {
+    const tmp = await realpath(await mkdtemp(join(tmpdir(), 'mdr-attach-')));
+    const filePath = join(tmp, 'spec.md');
+    const seeded = insertComment(
+      '# Title\n\nThe rate limit is 100 req/min today.\n',
+      'rate limit is 100 req/min',
+      'Is this per-tenant?',
+      'Seth',
+      undefined,
+      undefined,
+      undefined,
+      'cmt_seed',
+    );
+    await writeFile(filePath, seeded, 'utf8');
+
+    const { app: testApp, reviewSessions } = await buildTestApp({ allowedRoots: [tmp] });
+    // origin:'user' is what mdr_request_review opens — the session mdr_review
+    // could not previously reach, because createSession's dedupe filters on
+    // origin and would have minted a second, agent-origin one.
+    const create = await testApp.request('/api/review-sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ filePaths: [filePath], origin: 'user' }),
+    });
+    const { sessionId } = (await create.json()) as { sessionId: string };
+    return { testApp, reviewSessions, filePath, sessionId };
+  }
+
+  it("appends the agent's reply to the user's own comment thread", async () => {
+    const { testApp, filePath, sessionId } = await seedUserReview();
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId,
+        replies: [
+          { filePath, commentId: 'cmt_seed', text: 'Per-tenant. Fixed in §4.', author: 'Claude' },
+        ],
+      },
+      {
+        client: clientOver(testApp),
+        openInBrowser: async () => {
+          throw new Error('must not open a browser tab when attaching to a session');
+        },
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    expect(result.isError).toBeFalsy();
+    const parsed = parseComments(await readFile(filePath, 'utf8'));
+    const thread = parsed.comments.find((c) => c.id === 'cmt_seed');
+    expect(thread?.replies?.map((r) => r.text)).toEqual(['Per-tenant. Fixed in §4.']);
+    expect(thread?.replies?.[0].author).toBe('Claude');
+  });
+
+  it('leaves the user session the only open one', async () => {
+    const { testApp, reviewSessions, filePath, sessionId } = await seedUserReview();
+
+    await handleReviewToolCall(
+      {
+        sessionId,
+        replies: [{ filePath, commentId: 'cmt_seed', text: 'ack', author: 'Claude' }],
+      },
+      {
+        client: clientOver(testApp),
+        openInBrowser: async () => {},
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    // The defect this fixes: a second session on the same file, which is what
+    // put a duplicate tab and a stacked banner row in front of the user.
+    const open = reviewSessions.listOpenSessions();
+    expect(open.map((s) => s.id)).toEqual([sessionId]);
+    expect(open[0].origin).toBe('user');
+  });
+
+  it('rejects a reply aimed at a file outside the session', async () => {
+    const { testApp, filePath, sessionId } = await seedUserReview();
+    const outsider = join(filePath, '..', 'other.md');
+    await writeFile(outsider, '# Other\n', 'utf8');
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId,
+        replies: [{ filePath: outsider, commentId: 'cmt_seed', text: 'ack', author: 'Claude' }],
+      },
+      {
+        client: clientOver(testApp),
+        openInBrowser: async () => {},
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    // Dropping the client-side filePaths membership check does not widen what
+    // an agent can write to: the session's own path list still bounds it.
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not part of this session/);
+  });
+});
 
 describe('POST /api/review-sessions/:id/agent-comments', () => {
   it('inserts agent markers into the file and returns askId', async () => {

--- a/server/mcp-stdio-runtime.test.ts
+++ b/server/mcp-stdio-runtime.test.ts
@@ -668,6 +668,75 @@ describe('handleReviewToolCall (fire-and-forget)', () => {
     } as MdrClient;
   }
 
+  it('attaches to an existing session instead of creating one', async () => {
+    const createSession = vi.fn();
+    const openInBrowser = vi.fn().mockResolvedValue(undefined);
+    const grantAccess = vi.fn();
+    const postReview = vi.fn().mockResolvedValue({ commentsWritten: 0, repliesWritten: 1 });
+    const client = makeReviewClient({ createSession, grantAccess, postReview });
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId: 'rev_user_1',
+        replies: [{ filePath: '/abs/a.md', commentId: 'cmt_1', text: 'ack', author: 'Claude' }],
+      },
+      { client, openInBrowser, baseUrl: 'http://localhost:5188' },
+    );
+
+    expect(createSession).not.toHaveBeenCalled();
+    expect(openInBrowser).not.toHaveBeenCalled();
+    expect(grantAccess).not.toHaveBeenCalled();
+    expect(postReview).toHaveBeenCalledWith('rev_user_1', {
+      comments: undefined,
+      replies: [{ filePath: '/abs/a.md', commentId: 'cmt_1', text: 'ack', author: 'Claude' }],
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('rev_user_1');
+  });
+
+  it('names the files it posted to when attaching by sessionId', async () => {
+    const client = makeReviewClient({
+      postReview: vi.fn().mockResolvedValue({ commentsWritten: 1, repliesWritten: 1 }),
+    });
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId: 'rev_user_1',
+        comments: [{ filePath: '/abs/a.md', anchor: 'foo', text: 'bar' }],
+        replies: [{ filePath: '/abs/b.md', commentId: 'cmt_1', text: 'ack' }],
+      },
+      {
+        client,
+        openInBrowser: vi.fn().mockResolvedValue(undefined),
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    expect(result.content[0].text).toContain('/abs/a.md');
+    expect(result.content[0].text).toContain('/abs/b.md');
+  });
+
+  it('surfaces a post failure when attaching by sessionId', async () => {
+    const client = makeReviewClient({
+      postReview: vi.fn().mockRejectedValue(new Error('session not found or already finished')),
+    });
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId: 'rev_gone',
+        replies: [{ filePath: '/abs/a.md', commentId: 'cmt_1', text: 'ack' }],
+      },
+      {
+        client,
+        openInBrowser: vi.fn().mockResolvedValue(undefined),
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('session not found or already finished');
+  });
+
   it('posts comments and returns immediately with sessionId and count', async () => {
     const client = makeReviewClient();
     const result = await handleReviewToolCall(

--- a/server/mcp-stdio-subprocess.test.ts
+++ b/server/mcp-stdio-subprocess.test.ts
@@ -187,6 +187,49 @@ async function waitFor(
     }
   }, 15_000);
 
+  it('advertises mdr_review with an optional sessionId and no required filePaths', async () => {
+    // The reported symptom was read straight off this inventory: mdr_review
+    // exposed no way to name a session, so every reply batch minted one.
+    const child = spawn('node', [BIN, 'mcp'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, NODE_ENV: 'test' },
+    });
+
+    const stdoutRef = { current: '' };
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutRef.current += chunk.toString('utf8');
+    });
+
+    try {
+      child.stdin.write(
+        rpcRequest(1, 'initialize', {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0' },
+        }),
+      );
+      await waitFor(stdoutRef, (parsed) => parsed.some((r) => r.id === 1), 5_000);
+      child.stdin.write(rpcRequest(2, 'tools/list'));
+
+      const afterList = await waitFor(stdoutRef, (parsed) => parsed.some((r) => r.id === 2), 5_000);
+      const toolsResp = afterList.find((r) => r.id === 2);
+      const tools = (
+        toolsResp?.result as {
+          tools: Array<{
+            name: string;
+            inputSchema: { properties: Record<string, unknown>; required?: string[] };
+          }>;
+        }
+      ).tools;
+      const review = tools.find((t) => t.name === 'mdr_review');
+      expect(review).toBeDefined();
+      expect(Object.keys(review!.inputSchema.properties)).toContain('sessionId');
+      expect(review!.inputSchema.required ?? []).not.toContain('filePaths');
+    } finally {
+      child.kill();
+    }
+  }, 15_000);
+
   it('dispatches mdr_review to handleReviewToolCall', async () => {
     const child = spawn('node', [BIN, 'mcp'], {
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/server/mcp-stdio/handler.ts
+++ b/server/mcp-stdio/handler.ts
@@ -574,12 +574,70 @@ export async function handleWaitToolCall(
   };
 }
 
+/** Distinct file paths a batch touches, in first-mentioned order. */
+function batchFilePaths(input: ReviewInput): string[] {
+  const seen = new Set<string>();
+  for (const item of [...(input.comments ?? []), ...(input.replies ?? [])]) {
+    seen.add(item.filePath);
+  }
+  return [...seen];
+}
+
+/** The shared tail of both mdr_review forms: post the batch, summarize it. */
+async function postReviewBatch(
+  sessionId: string,
+  input: ReviewInput,
+  ctx: ToolCallContext,
+  fileList: string,
+): Promise<ToolCallResult> {
+  let postResult: PostReviewResult;
+  try {
+    postResult = await ctx.client.postReview(sessionId, {
+      comments: input.comments,
+      replies: input.replies,
+    });
+  } catch (err) {
+    const e = err as Error & { failedComments?: number[]; failedReplies?: number[] };
+    const detailParts: string[] = [];
+    if (e.failedComments?.length)
+      detailParts.push(`failedComments: ${JSON.stringify(e.failedComments)}`);
+    if (e.failedReplies?.length)
+      detailParts.push(`failedReplies: ${JSON.stringify(e.failedReplies)}`);
+    const detail = detailParts.length > 0 ? ` ${detailParts.join('; ')}` : '';
+    return {
+      isError: true,
+      content: [{ type: 'text', text: `mdr_review: ${e.message}${detail}` }],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          `mdr_review: posted ${postResult.commentsWritten} comment(s) and ` +
+          `${postResult.repliesWritten} reply(ies) to ${fileList}. ` +
+          `Session ID: ${sessionId}. ` +
+          `When you have finished posting all feedback, call mdr_wait with ` +
+          `sessionId "${sessionId}" to block until the user has engaged.`,
+      },
+    ],
+  };
+}
+
 /**
  * Handler for the mdr_review tool. The agent calls this to post comments (and
  * optionally replies) to a file and immediately returns. The agent should then
  * call mdr_wait to block until the user has finished engaging.
  *
- * Flow:
+ * Two forms. With `sessionId`, post into a session that already exists and
+ * return it unchanged — no grantAccess, no createSession, no browser tab. This
+ * is the only way to reach the user-origin session an `mdr_request_review`
+ * handoff opened: createSession's dedupe filters on origin, so the filePaths
+ * form below always mints a second session for a file the user is already
+ * reading, costing them a duplicate tab and a stacked banner row.
+ *
+ * With `filePaths`:
  *   1. grantAccess for every file path.
  *   2. createSession with origin='agent'.
  *   3. openInBrowser (non-fatal).
@@ -590,6 +648,15 @@ export async function handleReviewToolCall(
   input: ReviewInput,
   ctx: ToolCallContext,
 ): Promise<ToolCallResult> {
+  // Attach form: the session exists, so skip creation entirely. Access and
+  // session membership are the server's call — it resolves every path and
+  // rejects any that is not in the named session's own filePaths, which is
+  // stricter than the grantAccess roots check the creating form does here.
+  if (input.sessionId !== undefined) {
+    const fileList = batchFilePaths(input).join(', ');
+    return postReviewBatch(input.sessionId, input, ctx, fileList);
+  }
+
   // 1. Grant access
   await ctx.client.grantAccess(input.filePaths);
 
@@ -626,39 +693,7 @@ export async function handleReviewToolCall(
   ctx.sendProgress?.(`mdr: opening review at ${fullUrl}`);
 
   // 3. Post review (always fire-and-forget — no waitForAsk)
-  let postResult: PostReviewResult;
-  try {
-    postResult = await ctx.client.postReview(session.sessionId, {
-      comments: input.comments,
-      replies: input.replies,
-    });
-  } catch (err) {
-    const e = err as Error & { failedComments?: number[]; failedReplies?: number[] };
-    const detailParts: string[] = [];
-    if (e.failedComments?.length)
-      detailParts.push(`failedComments: ${JSON.stringify(e.failedComments)}`);
-    if (e.failedReplies?.length)
-      detailParts.push(`failedReplies: ${JSON.stringify(e.failedReplies)}`);
-    const detail = detailParts.length > 0 ? ` ${detailParts.join('; ')}` : '';
-    return {
-      isError: true,
-      content: [{ type: 'text', text: `mdr_review: ${e.message}${detail}` }],
-    };
-  }
-
   // 4. Return immediately — nudge agent to call mdr_wait
-  const fileList = input.filePaths.join(', ');
-  return {
-    content: [
-      {
-        type: 'text',
-        text:
-          `mdr_review: posted ${postResult.commentsWritten} comment(s) and ` +
-          `${postResult.repliesWritten} reply(ies) to ${fileList}. ` +
-          `Session ID: ${session.sessionId}. ` +
-          `When you have finished posting all feedback, call mdr_wait with ` +
-          `sessionId "${session.sessionId}" to block until the user has engaged.`,
-      },
-    ],
-  };
+  return postReviewBatch(session.sessionId, input, ctx, input.filePaths.join(', '));
 }
+

--- a/server/mcp-stdio/server.ts
+++ b/server/mcp-stdio/server.ts
@@ -150,16 +150,30 @@ export async function runMcpServer(opts: RunMcpServerOptions): Promise<void> {
           'spans, the renderer will fall back to label/stripped matching.\n\n' +
           'Include `author` on each comment/reply identifying yourself (e.g. ' +
           "'Claude', 'Codex', 'Gemini'). This appears in the mdr UI so the user " +
-          'knows which agent left the feedback.',
+          'knows which agent left the feedback.\n\n' +
+          'To reply inside a review the user already has open — the session from an ' +
+          'mdr_request_review handoff, or one this tool returned earlier — pass ' +
+          '`sessionId` instead of `filePaths`. The batch lands in that session and no ' +
+          'second tab or banner appears. Use it whenever you are replying as you work ' +
+          'rather than posting a fresh review; the filePaths form always opens its own ' +
+          'session.',
         inputSchema: {
           type: 'object',
-          required: ['filePaths'],
           properties: {
             filePaths: {
               type: 'array',
               minItems: 1,
               items: { type: 'string' },
-              description: 'Absolute paths to markdown files to review.',
+              description:
+                'Absolute paths to markdown files to review. Opens a new session. ' +
+                'Omit when passing sessionId.',
+            },
+            sessionId: {
+              type: 'string',
+              description:
+                'Post into this existing session instead of opening a new one. ' +
+                'Accepts the sessionId of an active mdr_request_review handoff or of a ' +
+                'previous mdr_review call. Mutually exclusive with filePaths.',
             },
             comments: {
               type: 'array',

--- a/server/mcp-stdio/types.ts
+++ b/server/mcp-stdio/types.ts
@@ -97,8 +97,7 @@ export interface PostReviewArgs {
   // expectsReply removed — always fire-and-forget
 }
 
-export interface ReviewInput {
-  filePaths: string[];
+interface ReviewPayload {
   comments?: Array<{
     filePath: string;
     anchor: string;
@@ -108,8 +107,26 @@ export interface ReviewInput {
     contextAfter?: string;
   }>;
   replies?: Array<{ filePath: string; commentId: string; text: string; author?: string }>;
-  enableResolve?: boolean;
 }
+
+/**
+ * Two ways to name the session a batch lands in, mutually exclusive:
+ *
+ *   { filePaths }  create-or-attach an agent-origin session for those files.
+ *   { sessionId }  post into a session that already exists — including the
+ *                  user-origin session an `mdr_request_review` handoff opened,
+ *                  which the filePaths form can never reach because dedupe
+ *                  filters on origin. Without this, replying to a review the
+ *                  user is reading costs them a second session, tab, and banner.
+ *
+ * `enableResolve` belongs only to the creating form; an existing session's
+ * resolve mode was fixed when it was created.
+ */
+export type ReviewInput = ReviewPayload &
+  (
+    | { filePaths: string[]; enableResolve?: boolean; sessionId?: never }
+    | { sessionId: string; filePaths?: never; enableResolve?: never }
+  );
 
 export interface WaitInput {
   sessionId: string;

--- a/server/mcp-stdio/validate.test.ts
+++ b/server/mcp-stdio/validate.test.ts
@@ -18,6 +18,52 @@ describe('validateReviewInput', () => {
     expect(res.ok).toBe(true);
   });
 
+  it('accepts sessionId in place of filePaths', () => {
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      replies: [{ filePath: '/tmp/a.md', commentId: 'cmt_1', text: 'r' }],
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value).toMatchObject({ sessionId: 'rev_1' });
+      expect(res.value).not.toHaveProperty('filePaths');
+    }
+  });
+
+  it('accepts a comment whose filePath is unknown when attaching by sessionId', () => {
+    // With no filePaths to cross-check against, session membership is the
+    // server's call (it rejects paths outside session.filePaths).
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      comments: [{ filePath: '/tmp/anything.md', anchor: 'hi', text: 't' }],
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects sessionId and filePaths together', () => {
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      filePaths: ['/tmp/a.md'],
+      replies: [{ filePath: '/tmp/a.md', commentId: 'cmt_1', text: 'r' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/either filePaths or sessionId/);
+  });
+
+  it('rejects input with neither filePaths nor sessionId', () => {
+    const res = validateReviewInput({
+      comments: [{ filePath: '/tmp/a.md', anchor: 'hi', text: 't' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/filePaths/);
+  });
+
+  it('still requires comments or replies when attaching by sessionId', () => {
+    const res = validateReviewInput({ sessionId: 'rev_1' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/comments or replies/);
+  });
+
   it('rejects when both comments and replies are empty', () => {
     const res = validateReviewInput({ filePaths: ['/tmp/a.md'] });
     expect(res.ok).toBe(false);

--- a/server/mcp-stdio/validate.ts
+++ b/server/mcp-stdio/validate.ts
@@ -81,24 +81,46 @@ export function validateRequestReviewInput(raw: unknown): ValidationResult<Reque
   };
 }
 
+/**
+ * Validate a raw mdr_review argument object. Accepts either:
+ *   - { filePaths, enableResolve? } to create-or-attach an agent-origin session
+ *   - { sessionId } to post into a session that already exists
+ *
+ * In the filePaths form, every comment/reply filePath must appear in
+ * filePaths. In the sessionId form there is no such list to check against,
+ * and the server enforces the stronger condition anyway: it rejects any path
+ * outside the named session's own filePaths.
+ */
 export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput> {
   if (typeof raw !== 'object' || raw === null) {
     return { ok: false, error: 'input must be an object' };
   }
   const obj = raw as {
     filePaths?: unknown;
+    sessionId?: unknown;
     comments?: unknown;
     replies?: unknown;
     enableResolve?: unknown;
   };
 
-  if (!Array.isArray(obj.filePaths) || obj.filePaths.length === 0) {
-    return { ok: false, error: 'filePaths must be a non-empty array' };
+  const hasSessionId = typeof obj.sessionId === 'string' && obj.sessionId.length > 0;
+  const hasFilePaths = Array.isArray(obj.filePaths) && obj.filePaths.length > 0;
+  if (hasSessionId && hasFilePaths) {
+    return { ok: false, error: 'provide either filePaths or sessionId, not both' };
   }
-  if (obj.filePaths.some((p) => typeof p !== 'string' || p.length === 0)) {
-    return { ok: false, error: 'filePaths must contain non-empty strings' };
+
+  // `filePathsSet` scopes the per-item filePath check below. Empty in
+  // sessionId mode, where the check is skipped entirely.
+  let filePathsSet: Set<string> | null = null;
+  if (!hasSessionId) {
+    if (!Array.isArray(obj.filePaths) || obj.filePaths.length === 0) {
+      return { ok: false, error: 'filePaths must be a non-empty array' };
+    }
+    if (obj.filePaths.some((p) => typeof p !== 'string' || p.length === 0)) {
+      return { ok: false, error: 'filePaths must contain non-empty strings' };
+    }
+    filePathsSet = new Set(obj.filePaths as string[]);
   }
-  const filePathsSet = new Set(obj.filePaths as string[]);
 
   const hasComments = Array.isArray(obj.comments) && obj.comments.length > 0;
   const hasReplies = Array.isArray(obj.replies) && obj.replies.length > 0;
@@ -119,7 +141,7 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
       if (!c.anchor || !c.text || !c.filePath) {
         return { ok: false, error: `comments[${i}]: filePath, anchor, text must be non-empty` };
       }
-      if (!filePathsSet.has(c.filePath as string)) {
+      if (filePathsSet !== null && !filePathsSet.has(c.filePath as string)) {
         return { ok: false, error: `comments[${i}].filePath not in filePaths` };
       }
       if (c.author !== undefined && typeof c.author !== 'string') {
@@ -155,7 +177,7 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
       if (!r.commentId || !r.text || !r.filePath) {
         return { ok: false, error: `replies[${i}]: fields must be non-empty` };
       }
-      if (!filePathsSet.has(r.filePath as string)) {
+      if (filePathsSet !== null && !filePathsSet.has(r.filePath as string)) {
         return { ok: false, error: `replies[${i}].filePath not in filePaths` };
       }
       if (r.author !== undefined && typeof r.author !== 'string') {
@@ -166,12 +188,19 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
     }
   }
 
+  const payload = {
+    comments: hasComments ? (obj.comments as ReviewInput['comments']) : undefined,
+    replies: hasReplies ? (obj.replies as ReviewInput['replies']) : undefined,
+  };
+
+  if (hasSessionId) {
+    return { ok: true, value: { ...payload, sessionId: obj.sessionId as string } };
+  }
   return {
     ok: true,
     value: {
+      ...payload,
       filePaths: obj.filePaths as string[],
-      comments: hasComments ? (obj.comments as ReviewInput['comments']) : undefined,
-      replies: hasReplies ? (obj.replies as ReviewInput['replies']) : undefined,
       enableResolve: obj.enableResolve === true ? true : undefined,
     },
   };


### PR DESCRIPTION
This fixes the bug and includes the report that found it.

## The change

`mdr_review` gains an optional `sessionId`, mutually exclusive with `filePaths`. With it, the batch posts straight into the named session and that sessionId is returned unchanged — no `grantAccess`, no `createSession`, no browser tab.

Path validation in that form moves to the server, which is stricter than what it replaces: `/agent-comments` resolves every path and rejects any outside the named session's own `filePaths`, where the client-side check only compared against the caller's own `filePaths` list.

`AGENTS.md` documents both forms and why the origin split makes the second one necessary.

## Tests

Twelve added, ten of which fail with the source reverted and the tests kept — verified by checking out the four source files from the parent commit and re-running, not by assertion. Two are behaviour-preservation guards that pass either way; they are marked so the count is not read as twelve proofs.

**Behaviour, end to end** — `index.test.ts` (3 added, 3 gating). These drive `handleReviewToolCall` against the real Hono app: real route, real session store, real markers on disk, only the transport swapped. No mocks, so what they assert is what the change does rather than which methods a fake saw.

- the agent's reply is appended to the user's own comment thread, with its author, in a session created with `origin: 'user'` — the session `mdr_request_review` opens and the old code structurally could not reach
- after the post, that user session is still the only open one — the duplicate session is the defect that put a second tab and a stacked banner row in front of the user
- a reply aimed at a file outside the session is rejected, so dropping the client-side `filePaths` membership check did not widen what an agent can write to

**Contract** — `mcp-stdio-subprocess.test.ts` (1 added, 1 gating): the advertised schema exposes `sessionId` and no longer requires `filePaths` — the inventory the bug was originally read off.

**Units** — `validate.test.ts` (5 added, 4 gating): sessionId accepted in place of filePaths; an unknown comment filePath accepted when attaching by sessionId; the two together rejected; comments/replies still required; *(guard)* neither one rejected, already true before. `mcp-stdio-runtime.test.ts` (3 added, 2 gating): the attach form calls neither `createSession`, `grantAccess`, nor `openInBrowser` and posts to the supplied sessionId; the result names the files it posted to; *(guard)* a post failure still surfaces as an error.

Two caveats on the verification itself. The subprocess test was written after the schema change rather than before it, so I mutated `required` back to `['filePaths']` and confirmed it fails (`expected [ 'filePaths' ] to not include 'filePaths'`) before restoring. And that suite skips itself unless `dist/mcp-stdio.js` is newer than the sources — it reported "4 skipped" until I built the bundle, so a green run there proves nothing on its own.

Full suite after: 96 files, 1959 tests, 0 skipped. Lint clean, all three tsconfigs clean.

---

# Report

### What happens

`mdr_review` had no `sessionId` parameter, so it always created its own session. `handleReviewToolCall` called `createSession({ origin: 'agent' })` unconditionally, and `findOpenSession` filters candidates on origin because agent- and user-origin sessions have divergent terminal semantics. A session opened by `mdr_request_review` is user-origin, so `mdr_review` could never reuse it — the dedupe was structurally unable to match.

An agent replying into a review the user opened therefore got a second session on the same file: a second browser tab, and a second "…is reviewing" row stacked above the document (`ReviewBanner` renders one row per open agent session — `src/App.tsx:2893`).

From the server's own tool inventory, before this change:

```
mdr_request_review   sessionId optional
mdr_ask              sessionId required
mdr_wait             sessionId required
mdr_review           properties: comments, enableResolve, filePaths, replies
                     required:   [filePaths]        <- no sessionId
```

### Why it bites

The workflow it blocks is an agent working a review incrementally: the user comments on section three while the agent acts on section two, and the agent replies in-thread as each item lands. That is the pattern anchored comments are best at. Before this change the first reply cost the user a tab and a banner row, so the agent batched replies to the end — which is what threads exist to avoid.

### Reproduction

Session state is the ground truth here. Tab and banner counts are downstream of it and confounded by which MCP client drives the calls (see Notes).

```
1. mdr_request_review --file-paths /abs/doc.md          -> session rev_A
2. mdr_review --file-paths /abs/doc.md \
     --replies '[{"filePath":"/abs/doc.md","commentId":"<id>",
                  "text":"ack","author":"Claude"}]'      -> session rev_B
3. curl -s localhost:$PORT/api/review-sessions \
     | jq '.sessions[] | {id, origin, clientId, filePaths}'
```

Two open sessions on one file, `origin: "user"` and `origin: "agent"`. Step 2 also opened a tab and added a banner row above the document the user was already reading.

### The fix

An optional `sessionId` on `mdr_review`, with `filePaths` becoming optional in that case as it already is on `mdr_request_review`. When `sessionId` is present, skip `grantAccess`, `createSession`, and `openBrowserOnce`, and POST straight to `/api/review-sessions/:id/agent-comments` with `mode: 'review'`.

That endpoint already accepted review-mode posts into a user-origin session: the comment at `server/routes/review-sessions.ts:543` records that ask-mode is allowed on both origins, and review-mode carries no counterpart restriction. The server could already place a reply inside a live user-origin session — the caller just could not name which one.

Suppressing the browser open for reply-only calls is not a cheaper half-measure. A reply-only call still mints a session, and the session is what stacks the banner row; the tab is secondary. Naming the session is the fix.

### Notes on reproducing

Session and tab accumulation depends on which MCP client drives the calls, so a maintainer who does not see a pile-up is not failing to reproduce. Dedupe keys on (filePaths, origin, clientId), and `clientId` is `mcp_${randomUUID()}` minted per `mdr mcp` process (`server/mcp-stdio/client.ts:19`). A bridge that spawns a fresh `mdr mcp` per call misses dedupe every time and accumulates a session per call; under a long-lived client the 2nd..Nth `mdr_review` with the same `filePaths` return `created: false` and open nothing, since an agent POST bumps the session heartbeat precisely so batched calls keep deduping (`server/review-sessions.ts:832`). The origin-split session above is client-independent; the accumulation is not.

One premise of the above, since it is easy to assume otherwise: the document does reload. Agent writes call `notifyFileChanged` (`server/index.ts:566`), which broadcasts to every SSE client watching the path, and the UI holds that watcher on `/api/watch` (`src/App.tsx:1702`), so replies render live in the window the user is looking at. An agent still should not hand-edit a file mid-review, but the reason is not staleness: an out-of-band write reaches the browser and never reaches the session state machine. `deliverInlineAskReplies` is called from the save route (`server/index.ts:886`), `/finish`, and `/agent-done` — never from the watcher — so bytes the UI writes resolve a pending `mdr_ask` and identical bytes written out-of-band render in the document and resolve nothing. Nothing in the tool descriptions predicts that asymmetry; that one is tracked separately.

### Version

Reported against md-redline 0.8.3, macOS, driven over stdio MCP.
