### PR TITLE
Let mdr_review post into an existing session (carries #72)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -488,9 +488,12 @@ Only one ask can be pending per session at a time.
 
 ```ts
 {
-  filePaths: string[]            // required; absolute paths, length >= 1
+  // Exactly one of these two names the target session:
+  filePaths?: string[]           // absolute paths, length >= 1; opens a new session
+  sessionId?: string             // post into a session that already exists
+
   comments?: Array<{             // new top-level comments
-    filePath: string             // must appear in filePaths[]
+    filePath: string             // must appear in filePaths[] (filePaths form)
     anchor: string               // exact text in the file
     text: string                 // the feedback
     author?: string              // agent name shown in the UI
@@ -507,12 +510,26 @@ Only one ask can be pending per session at a time.
 }
 ```
 
-At least one of `comments[]` or `replies[]` must be non-empty. The tool opens the
-browser at the session URL (`origin: 'agent'`), writes the markers, and returns
-IMMEDIATELY (fire-and-forget). The result instructs the agent to call `mdr_wait`
-with the returned sessionId. Partial-anchor failures are surfaced as
-`failedComments[]` / `failedReplies[]`, and a failed multi-file batch rolls back
-the markers it already wrote.
+At least one of `comments[]` or `replies[]` must be non-empty. Passing both
+`filePaths` and `sessionId` is rejected, as is passing neither.
+
+In the `filePaths` form the tool opens the browser at the session URL
+(`origin: 'agent'`), writes the markers, and returns IMMEDIATELY
+(fire-and-forget). The result instructs the agent to call `mdr_wait` with the
+returned sessionId. Partial-anchor failures are surfaced as `failedComments[]` /
+`failedReplies[]`, and a failed multi-file batch rolls back the markers it
+already wrote.
+
+In the `sessionId` form the batch is posted into the named session and that
+sessionId is returned unchanged — no `grantAccess`, no `createSession`, no
+browser tab. This is the only way to reach the user-origin session an
+`mdr_request_review` handoff opened: `findOpenSession` filters dedupe on origin
+(agent- and user-origin sessions have incompatible terminal-state semantics), so
+the `filePaths` form always mints a second session for a file the user is already
+reading, costing a duplicate tab and a second banner row. Use `sessionId` for
+replying in-thread as work lands. Path validation is the server's: `/agent-comments`
+resolves every path and rejects any outside the named session's `filePaths`, which
+is stricter than the client-side `filePaths[]` membership check.
 
 **`mdr_wait`** — `{ sessionId }`. Blocks (90s re-poll cycle via `/agent-wait`)
 until the user clicks End review. Returns "done, re-read the file(s)" on End

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -531,12 +531,20 @@ replying in-thread as work lands. Path validation is the server's: `/agent-comme
 resolves every path and rejects any outside the named session's `filePaths`, which
 is stricter than the client-side `filePaths[]` membership check.
 
+Do NOT follow a `sessionId`-form post with `mdr_wait` unless you opened that
+session with `mdr_review` yourself. `mdr_wait` long-polls `/agent-wait`, which
+409s on user-origin sessions, so calling it on an `mdr_request_review` handoff
+errors. The result text says which continuation applies; for a handoff it is
+`mdr_request_review` with the same sessionId.
+
 **`mdr_wait`** — `{ sessionId }`. Blocks (90s re-poll cycle via `/agent-wait`)
 until the user clicks End review. Returns "done, re-read the file(s)" on End
 review, a reason-specific message on other terminal paths (cancelled, tab closed,
 agent_silent GC, finished), `pending` when the agent should re-poll, and a
 graceful "session unknown, server may have restarted" result on 404. The two-tool
-flow is always: `mdr_review` (post) → `mdr_wait` (block).
+flow `mdr_review` (post) → `mdr_wait` (block) applies to the `filePaths` form only.
+A `sessionId`-form post into a session you did not open does not get a `mdr_wait`;
+see the caveat under `mdr_review` above.
 
 Server-side GC: if a session has `origin='agent'` and no comments are posted within
 5 minutes with no MCP heartbeat, the session is aborted with `reason='agent_silent'`.

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -2652,7 +2652,7 @@ describe('mdr_review attaching to an existing session (end to end)', () => {
   it('leaves the user session the only open one', async () => {
     const { testApp, reviewSessions, filePath, sessionId } = await seedUserReview();
 
-    await handleReviewToolCall(
+    const result = await handleReviewToolCall(
       {
         sessionId,
         replies: [{ filePath, commentId: 'cmt_seed', text: 'ack', author: 'Claude' }],
@@ -2663,6 +2663,12 @@ describe('mdr_review attaching to an existing session (end to end)', () => {
         baseUrl: 'http://localhost:5188',
       },
     );
+
+    // Without this the session assertion below passes just as happily on a
+    // post that never landed: postReviewBatch reports failure by returning
+    // isError, not by throwing, so a 400 or 404 would leave one open session
+    // and a green test.
+    expect(result.isError).toBeFalsy();
 
     // The defect this fixes: a second session on the same file, which is what
     // put a duplicate tab and a stacked banner row in front of the user.

--- a/server/index.test.ts
+++ b/server/index.test.ts
@@ -21,7 +21,8 @@ import {
   writePortFile,
   type CreateAppOptions,
 } from './index';
-import { addReply, parseComments } from '../src/lib/comment-parser';
+import { addReply, insertComment, parseComments } from '../src/lib/comment-parser';
+import { handleReviewToolCall } from './mcp-stdio/handler';
 
 // Fails ONLY the synchronous boot read of the prefs file, leaving the async
 // read-modify-write path working. That asymmetry is the real shape of the bug:
@@ -2558,6 +2559,141 @@ async function buildTestApp(options: { allowedRoots: string[] }) {
   });
   return { app: testApp, reviewSessions: testReviewSessions };
 }
+
+describe('mdr_review attaching to an existing session (end to end)', () => {
+  /**
+   * A client that speaks to the real Hono app instead of the network. The
+   * handler, the route, the session store, and the on-disk markers are all
+   * the production code; only the transport is swapped, so what these tests
+   * assert is behaviour rather than which methods a mock saw.
+   */
+  function clientOver(testApp: {
+    request: (path: string, init?: RequestInit) => Response | Promise<Response>;
+  }) {
+    const post = async (path: string, body: unknown) => {
+      const res = await testApp.request(path, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const json = (await res.json()) as Record<string, unknown>;
+      if (!res.ok) throw new Error(String(json.error ?? `HTTP ${res.status}`));
+      return json;
+    };
+    return {
+      grantAccess: async () => {},
+      createSession: async (input: { filePaths: string[]; origin?: string }) =>
+        (await post('/api/review-sessions', input)) as unknown as {
+          sessionId: string;
+          url: string;
+        },
+      postReview: async (sessionId: string, args: unknown) =>
+        (await post(`/api/review-sessions/${sessionId}/agent-comments`, {
+          mode: 'review',
+          ...(args as object),
+        })) as unknown as { commentsWritten: number; repliesWritten: number },
+    } as unknown as Parameters<typeof handleReviewToolCall>[1]['client'];
+  }
+
+  async function seedUserReview() {
+    const tmp = await realpath(await mkdtemp(join(tmpdir(), 'mdr-attach-')));
+    const filePath = join(tmp, 'spec.md');
+    const seeded = insertComment(
+      '# Title\n\nThe rate limit is 100 req/min today.\n',
+      'rate limit is 100 req/min',
+      'Is this per-tenant?',
+      'Seth',
+      undefined,
+      undefined,
+      undefined,
+      'cmt_seed',
+    );
+    await writeFile(filePath, seeded, 'utf8');
+
+    const { app: testApp, reviewSessions } = await buildTestApp({ allowedRoots: [tmp] });
+    // origin:'user' is what mdr_request_review opens — the session mdr_review
+    // could not previously reach, because createSession's dedupe filters on
+    // origin and would have minted a second, agent-origin one.
+    const create = await testApp.request('/api/review-sessions', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ filePaths: [filePath], origin: 'user' }),
+    });
+    const { sessionId } = (await create.json()) as { sessionId: string };
+    return { testApp, reviewSessions, filePath, sessionId };
+  }
+
+  it("appends the agent's reply to the user's own comment thread", async () => {
+    const { testApp, filePath, sessionId } = await seedUserReview();
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId,
+        replies: [
+          { filePath, commentId: 'cmt_seed', text: 'Per-tenant. Fixed in §4.', author: 'Claude' },
+        ],
+      },
+      {
+        client: clientOver(testApp),
+        openInBrowser: async () => {
+          throw new Error('must not open a browser tab when attaching to a session');
+        },
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    expect(result.isError).toBeFalsy();
+    const parsed = parseComments(await readFile(filePath, 'utf8'));
+    const thread = parsed.comments.find((c) => c.id === 'cmt_seed');
+    expect(thread?.replies?.map((r) => r.text)).toEqual(['Per-tenant. Fixed in §4.']);
+    expect(thread?.replies?.[0].author).toBe('Claude');
+  });
+
+  it('leaves the user session the only open one', async () => {
+    const { testApp, reviewSessions, filePath, sessionId } = await seedUserReview();
+
+    await handleReviewToolCall(
+      {
+        sessionId,
+        replies: [{ filePath, commentId: 'cmt_seed', text: 'ack', author: 'Claude' }],
+      },
+      {
+        client: clientOver(testApp),
+        openInBrowser: async () => {},
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    // The defect this fixes: a second session on the same file, which is what
+    // put a duplicate tab and a stacked banner row in front of the user.
+    const open = reviewSessions.listOpenSessions();
+    expect(open.map((s) => s.id)).toEqual([sessionId]);
+    expect(open[0].origin).toBe('user');
+  });
+
+  it('rejects a reply aimed at a file outside the session', async () => {
+    const { testApp, filePath, sessionId } = await seedUserReview();
+    const outsider = join(filePath, '..', 'other.md');
+    await writeFile(outsider, '# Other\n', 'utf8');
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId,
+        replies: [{ filePath: outsider, commentId: 'cmt_seed', text: 'ack', author: 'Claude' }],
+      },
+      {
+        client: clientOver(testApp),
+        openInBrowser: async () => {},
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    // Dropping the client-side filePaths membership check does not widen what
+    // an agent can write to: the session's own path list still bounds it.
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not part of this session/);
+  });
+});
 
 describe('POST /api/review-sessions/:id/agent-comments', () => {
   it('inserts agent markers into the file and returns askId', async () => {

--- a/server/mcp-stdio-runtime.test.ts
+++ b/server/mcp-stdio-runtime.test.ts
@@ -668,6 +668,75 @@ describe('handleReviewToolCall (fire-and-forget)', () => {
     } as MdrClient;
   }
 
+  it('attaches to an existing session instead of creating one', async () => {
+    const createSession = vi.fn();
+    const openInBrowser = vi.fn().mockResolvedValue(undefined);
+    const grantAccess = vi.fn();
+    const postReview = vi.fn().mockResolvedValue({ commentsWritten: 0, repliesWritten: 1 });
+    const client = makeReviewClient({ createSession, grantAccess, postReview });
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId: 'rev_user_1',
+        replies: [{ filePath: '/abs/a.md', commentId: 'cmt_1', text: 'ack', author: 'Claude' }],
+      },
+      { client, openInBrowser, baseUrl: 'http://localhost:5188' },
+    );
+
+    expect(createSession).not.toHaveBeenCalled();
+    expect(openInBrowser).not.toHaveBeenCalled();
+    expect(grantAccess).not.toHaveBeenCalled();
+    expect(postReview).toHaveBeenCalledWith('rev_user_1', {
+      comments: undefined,
+      replies: [{ filePath: '/abs/a.md', commentId: 'cmt_1', text: 'ack', author: 'Claude' }],
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain('rev_user_1');
+  });
+
+  it('names the files it posted to when attaching by sessionId', async () => {
+    const client = makeReviewClient({
+      postReview: vi.fn().mockResolvedValue({ commentsWritten: 1, repliesWritten: 1 }),
+    });
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId: 'rev_user_1',
+        comments: [{ filePath: '/abs/a.md', anchor: 'foo', text: 'bar' }],
+        replies: [{ filePath: '/abs/b.md', commentId: 'cmt_1', text: 'ack' }],
+      },
+      {
+        client,
+        openInBrowser: vi.fn().mockResolvedValue(undefined),
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    expect(result.content[0].text).toContain('/abs/a.md');
+    expect(result.content[0].text).toContain('/abs/b.md');
+  });
+
+  it('surfaces a post failure when attaching by sessionId', async () => {
+    const client = makeReviewClient({
+      postReview: vi.fn().mockRejectedValue(new Error('session not found or already finished')),
+    });
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId: 'rev_gone',
+        replies: [{ filePath: '/abs/a.md', commentId: 'cmt_1', text: 'ack' }],
+      },
+      {
+        client,
+        openInBrowser: vi.fn().mockResolvedValue(undefined),
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('session not found or already finished');
+  });
+
   it('posts comments and returns immediately with sessionId and count', async () => {
     const client = makeReviewClient();
     const result = await handleReviewToolCall(

--- a/server/mcp-stdio-runtime.test.ts
+++ b/server/mcp-stdio-runtime.test.ts
@@ -716,6 +716,34 @@ describe('handleReviewToolCall (fire-and-forget)', () => {
     expect(result.content[0].text).toContain('/abs/b.md');
   });
 
+  it('does not tell the agent to call mdr_wait on a session it did not open', async () => {
+    // mdr_wait long-polls /agent-wait, which 409s on user-origin sessions.
+    // The mdr_request_review handoff this form exists to serve IS user-origin,
+    // so the creating form's nudge would send the flagship case into an error.
+    const client = makeReviewClient({
+      postReview: vi.fn().mockResolvedValue({ commentsWritten: 0, repliesWritten: 1 }),
+    });
+
+    const result = await handleReviewToolCall(
+      {
+        sessionId: 'rev_user_1',
+        replies: [{ filePath: '/abs/a.md', commentId: 'cmt_1', text: 'ack' }],
+      },
+      {
+        client,
+        openInBrowser: vi.fn().mockResolvedValue(undefined),
+        baseUrl: 'http://localhost:5188',
+      },
+    );
+
+    const text = result.content[0].text;
+    // The creating form's unconditional instruction must not appear verbatim.
+    expect(text).not.toContain('When you have finished posting all feedback, call mdr_wait');
+    // The user-origin continuation has to be named, since this form cannot
+    // tell which kind of session it was handed.
+    expect(text).toContain('mdr_request_review');
+  });
+
   it('surfaces a post failure when attaching by sessionId', async () => {
     const client = makeReviewClient({
       postReview: vi.fn().mockRejectedValue(new Error('session not found or already finished')),

--- a/server/mcp-stdio-subprocess.test.ts
+++ b/server/mcp-stdio-subprocess.test.ts
@@ -187,6 +187,49 @@ async function waitFor(
     }
   }, 15_000);
 
+  it('advertises mdr_review with an optional sessionId and no required filePaths', async () => {
+    // The reported symptom was read straight off this inventory: mdr_review
+    // exposed no way to name a session, so every reply batch minted one.
+    const child = spawn('node', [BIN, 'mcp'], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, NODE_ENV: 'test' },
+    });
+
+    const stdoutRef = { current: '' };
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdoutRef.current += chunk.toString('utf8');
+    });
+
+    try {
+      child.stdin.write(
+        rpcRequest(1, 'initialize', {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test', version: '0' },
+        }),
+      );
+      await waitFor(stdoutRef, (parsed) => parsed.some((r) => r.id === 1), 5_000);
+      child.stdin.write(rpcRequest(2, 'tools/list'));
+
+      const afterList = await waitFor(stdoutRef, (parsed) => parsed.some((r) => r.id === 2), 5_000);
+      const toolsResp = afterList.find((r) => r.id === 2);
+      const tools = (
+        toolsResp?.result as {
+          tools: Array<{
+            name: string;
+            inputSchema: { properties: Record<string, unknown>; required?: string[] };
+          }>;
+        }
+      ).tools;
+      const review = tools.find((t) => t.name === 'mdr_review');
+      expect(review).toBeDefined();
+      expect(Object.keys(review!.inputSchema.properties)).toContain('sessionId');
+      expect(review!.inputSchema.required ?? []).not.toContain('filePaths');
+    } finally {
+      child.kill();
+    }
+  }, 15_000);
+
   it('dispatches mdr_review to handleReviewToolCall', async () => {
     const child = spawn('node', [BIN, 'mcp'], {
       stdio: ['pipe', 'pipe', 'pipe'],

--- a/server/mcp-stdio/handler.ts
+++ b/server/mcp-stdio/handler.ts
@@ -589,6 +589,7 @@ async function postReviewBatch(
   input: ReviewInput,
   ctx: ToolCallContext,
   fileList: string,
+  nextStep: string,
 ): Promise<ToolCallResult> {
   let postResult: PostReviewResult;
   try {
@@ -618,8 +619,7 @@ async function postReviewBatch(
           `mdr_review: posted ${postResult.commentsWritten} comment(s) and ` +
           `${postResult.repliesWritten} reply(ies) to ${fileList}. ` +
           `Session ID: ${sessionId}. ` +
-          `When you have finished posting all feedback, call mdr_wait with ` +
-          `sessionId "${sessionId}" to block until the user has engaged.`,
+          nextStep,
       },
     ],
   };
@@ -654,7 +654,23 @@ export async function handleReviewToolCall(
   // stricter than the grantAccess roots check the creating form does here.
   if (input.sessionId !== undefined) {
     const fileList = batchFilePaths(input).join(', ');
-    return postReviewBatch(input.sessionId, input, ctx, fileList);
+    // The caller named the session, so only the caller knows where it came
+    // from, and this form cannot tell: /agent-comments returns no origin.
+    // Do NOT assume mdr_wait applies. It rejects user-origin sessions with a
+    // 409 (`/agent-wait only applies to agent-origin sessions`), which is
+    // exactly the mdr_request_review handoff this form exists to serve, so a
+    // blanket nudge would send the flagship case straight into an error.
+    return postReviewBatch(
+      input.sessionId,
+      input,
+      ctx,
+      fileList,
+      `If you opened this session with mdr_review, call mdr_wait with ` +
+        `sessionId "${input.sessionId}" when you have finished posting. If it ` +
+        `came from an mdr_request_review handoff, do NOT call mdr_wait; it ` +
+        `rejects user-origin sessions. Continue with mdr_request_review and ` +
+        `that sessionId instead.`,
+    );
   }
 
   // 1. Grant access
@@ -694,5 +710,12 @@ export async function handleReviewToolCall(
 
   // 3. Post review (always fire-and-forget — no waitForAsk)
   // 4. Return immediately — nudge agent to call mdr_wait
-  return postReviewBatch(session.sessionId, input, ctx, input.filePaths.join(', '));
+  return postReviewBatch(
+    session.sessionId,
+    input,
+    ctx,
+    input.filePaths.join(', '),
+    `When you have finished posting all feedback, call mdr_wait with ` +
+      `sessionId "${session.sessionId}" to block until the user has engaged.`,
+  );
 }

--- a/server/mcp-stdio/handler.ts
+++ b/server/mcp-stdio/handler.ts
@@ -574,12 +574,70 @@ export async function handleWaitToolCall(
   };
 }
 
+/** Distinct file paths a batch touches, in first-mentioned order. */
+function batchFilePaths(input: ReviewInput): string[] {
+  const seen = new Set<string>();
+  for (const item of [...(input.comments ?? []), ...(input.replies ?? [])]) {
+    seen.add(item.filePath);
+  }
+  return [...seen];
+}
+
+/** The shared tail of both mdr_review forms: post the batch, summarize it. */
+async function postReviewBatch(
+  sessionId: string,
+  input: ReviewInput,
+  ctx: ToolCallContext,
+  fileList: string,
+): Promise<ToolCallResult> {
+  let postResult: PostReviewResult;
+  try {
+    postResult = await ctx.client.postReview(sessionId, {
+      comments: input.comments,
+      replies: input.replies,
+    });
+  } catch (err) {
+    const e = err as Error & { failedComments?: number[]; failedReplies?: number[] };
+    const detailParts: string[] = [];
+    if (e.failedComments?.length)
+      detailParts.push(`failedComments: ${JSON.stringify(e.failedComments)}`);
+    if (e.failedReplies?.length)
+      detailParts.push(`failedReplies: ${JSON.stringify(e.failedReplies)}`);
+    const detail = detailParts.length > 0 ? ` ${detailParts.join('; ')}` : '';
+    return {
+      isError: true,
+      content: [{ type: 'text', text: `mdr_review: ${e.message}${detail}` }],
+    };
+  }
+
+  return {
+    content: [
+      {
+        type: 'text',
+        text:
+          `mdr_review: posted ${postResult.commentsWritten} comment(s) and ` +
+          `${postResult.repliesWritten} reply(ies) to ${fileList}. ` +
+          `Session ID: ${sessionId}. ` +
+          `When you have finished posting all feedback, call mdr_wait with ` +
+          `sessionId "${sessionId}" to block until the user has engaged.`,
+      },
+    ],
+  };
+}
+
 /**
  * Handler for the mdr_review tool. The agent calls this to post comments (and
  * optionally replies) to a file and immediately returns. The agent should then
  * call mdr_wait to block until the user has finished engaging.
  *
- * Flow:
+ * Two forms. With `sessionId`, post into a session that already exists and
+ * return it unchanged — no grantAccess, no createSession, no browser tab. This
+ * is the only way to reach the user-origin session an `mdr_request_review`
+ * handoff opened: createSession's dedupe filters on origin, so the filePaths
+ * form below always mints a second session for a file the user is already
+ * reading, costing them a duplicate tab and a stacked banner row.
+ *
+ * With `filePaths`:
  *   1. grantAccess for every file path.
  *   2. createSession with origin='agent'.
  *   3. openInBrowser (non-fatal).
@@ -590,6 +648,15 @@ export async function handleReviewToolCall(
   input: ReviewInput,
   ctx: ToolCallContext,
 ): Promise<ToolCallResult> {
+  // Attach form: the session exists, so skip creation entirely. Access and
+  // session membership are the server's call — it resolves every path and
+  // rejects any that is not in the named session's own filePaths, which is
+  // stricter than the grantAccess roots check the creating form does here.
+  if (input.sessionId !== undefined) {
+    const fileList = batchFilePaths(input).join(', ');
+    return postReviewBatch(input.sessionId, input, ctx, fileList);
+  }
+
   // 1. Grant access
   await ctx.client.grantAccess(input.filePaths);
 
@@ -626,39 +693,7 @@ export async function handleReviewToolCall(
   ctx.sendProgress?.(`mdr: opening review at ${fullUrl}`);
 
   // 3. Post review (always fire-and-forget — no waitForAsk)
-  let postResult: PostReviewResult;
-  try {
-    postResult = await ctx.client.postReview(session.sessionId, {
-      comments: input.comments,
-      replies: input.replies,
-    });
-  } catch (err) {
-    const e = err as Error & { failedComments?: number[]; failedReplies?: number[] };
-    const detailParts: string[] = [];
-    if (e.failedComments?.length)
-      detailParts.push(`failedComments: ${JSON.stringify(e.failedComments)}`);
-    if (e.failedReplies?.length)
-      detailParts.push(`failedReplies: ${JSON.stringify(e.failedReplies)}`);
-    const detail = detailParts.length > 0 ? ` ${detailParts.join('; ')}` : '';
-    return {
-      isError: true,
-      content: [{ type: 'text', text: `mdr_review: ${e.message}${detail}` }],
-    };
-  }
-
   // 4. Return immediately — nudge agent to call mdr_wait
-  const fileList = input.filePaths.join(', ');
-  return {
-    content: [
-      {
-        type: 'text',
-        text:
-          `mdr_review: posted ${postResult.commentsWritten} comment(s) and ` +
-          `${postResult.repliesWritten} reply(ies) to ${fileList}. ` +
-          `Session ID: ${session.sessionId}. ` +
-          `When you have finished posting all feedback, call mdr_wait with ` +
-          `sessionId "${session.sessionId}" to block until the user has engaged.`,
-      },
-    ],
-  };
+  return postReviewBatch(session.sessionId, input, ctx, input.filePaths.join(', '));
 }
+

--- a/server/mcp-stdio/handler.ts
+++ b/server/mcp-stdio/handler.ts
@@ -696,4 +696,3 @@ export async function handleReviewToolCall(
   // 4. Return immediately — nudge agent to call mdr_wait
   return postReviewBatch(session.sessionId, input, ctx, input.filePaths.join(', '));
 }
-

--- a/server/mcp-stdio/server.ts
+++ b/server/mcp-stdio/server.ts
@@ -136,9 +136,11 @@ export async function runMcpServer(opts: RunMcpServerOptions): Promise<void> {
         name: 'mdr_review',
         description:
           'Review markdown files in md-redline (mdr) and leave inline feedback. ' +
-          'Returns IMMEDIATELY after posting (never blocks). The returned `sessionId` ' +
-          'MUST be passed to mdr_wait afterward to block until the user clicks Done — ' +
-          'this is a two-tool flow: mdr_review (post) → mdr_wait (block). Skipping ' +
+          'Returns IMMEDIATELY after posting (never blocks). In the `filePaths` form ' +
+          'the returned `sessionId` MUST be passed to mdr_wait afterward to block until ' +
+          'the user clicks Done — that is a two-tool flow: mdr_review (post) → mdr_wait ' +
+          '(block). This does NOT apply to the `sessionId` form below, which posts into ' +
+          'a session you did not open; mdr_wait rejects user-origin sessions. Skipping ' +
           "mdr_wait leaves a banner on the user's screen until they click Done; you " +
           'will not see their replies or edits before continuing, and any user feedback ' +
           'will be invisible to you for this turn.\n\n' +

--- a/server/mcp-stdio/server.ts
+++ b/server/mcp-stdio/server.ts
@@ -89,8 +89,9 @@ export async function runMcpServer(opts: RunMcpServerOptions): Promise<void> {
           'answer would meaningfully change your edit.\n\n' +
           'Only one mdr_ask can be pending per session at a time. If this returns ' +
           '"a previous mdr_ask is still pending", post a reply to the prior question ' +
-          'via mdr_review (with a `replies:` payload targeting that commentId) — that ' +
-          'resolves the pending ask in-place — and then retry mdr_ask with your new questions.',
+          'via mdr_review — pass this same `sessionId` plus a `replies:` payload ' +
+          'targeting that commentId, which resolves the pending ask in-place without ' +
+          'opening a second session — and then retry mdr_ask with your new questions.',
         inputSchema: {
           type: 'object',
           required: ['sessionId', 'questions'],

--- a/server/mcp-stdio/server.ts
+++ b/server/mcp-stdio/server.ts
@@ -150,16 +150,30 @@ export async function runMcpServer(opts: RunMcpServerOptions): Promise<void> {
           'spans, the renderer will fall back to label/stripped matching.\n\n' +
           'Include `author` on each comment/reply identifying yourself (e.g. ' +
           "'Claude', 'Codex', 'Gemini'). This appears in the mdr UI so the user " +
-          'knows which agent left the feedback.',
+          'knows which agent left the feedback.\n\n' +
+          'To reply inside a review the user already has open — the session from an ' +
+          'mdr_request_review handoff, or one this tool returned earlier — pass ' +
+          '`sessionId` instead of `filePaths`. The batch lands in that session and no ' +
+          'second tab or banner appears. Use it whenever you are replying as you work ' +
+          'rather than posting a fresh review; the filePaths form always opens its own ' +
+          'session.',
         inputSchema: {
           type: 'object',
-          required: ['filePaths'],
           properties: {
             filePaths: {
               type: 'array',
               minItems: 1,
               items: { type: 'string' },
-              description: 'Absolute paths to markdown files to review.',
+              description:
+                'Absolute paths to markdown files to review. Opens a new session. ' +
+                'Omit when passing sessionId.',
+            },
+            sessionId: {
+              type: 'string',
+              description:
+                'Post into this existing session instead of opening a new one. ' +
+                'Accepts the sessionId of an active mdr_request_review handoff or of a ' +
+                'previous mdr_review call. Mutually exclusive with filePaths.',
             },
             comments: {
               type: 'array',

--- a/server/mcp-stdio/types.ts
+++ b/server/mcp-stdio/types.ts
@@ -97,8 +97,7 @@ export interface PostReviewArgs {
   // expectsReply removed — always fire-and-forget
 }
 
-export interface ReviewInput {
-  filePaths: string[];
+interface ReviewPayload {
   comments?: Array<{
     filePath: string;
     anchor: string;
@@ -108,8 +107,26 @@ export interface ReviewInput {
     contextAfter?: string;
   }>;
   replies?: Array<{ filePath: string; commentId: string; text: string; author?: string }>;
-  enableResolve?: boolean;
 }
+
+/**
+ * Two ways to name the session a batch lands in, mutually exclusive:
+ *
+ *   { filePaths }  create-or-attach an agent-origin session for those files.
+ *   { sessionId }  post into a session that already exists — including the
+ *                  user-origin session an `mdr_request_review` handoff opened,
+ *                  which the filePaths form can never reach because dedupe
+ *                  filters on origin. Without this, replying to a review the
+ *                  user is reading costs them a second session, tab, and banner.
+ *
+ * `enableResolve` belongs only to the creating form; an existing session's
+ * resolve mode was fixed when it was created.
+ */
+export type ReviewInput = ReviewPayload &
+  (
+    | { filePaths: string[]; enableResolve?: boolean; sessionId?: never }
+    | { sessionId: string; filePaths?: never; enableResolve?: never }
+  );
 
 export interface WaitInput {
   sessionId: string;

--- a/server/mcp-stdio/validate.test.ts
+++ b/server/mcp-stdio/validate.test.ts
@@ -64,6 +64,50 @@ describe('validateReviewInput', () => {
     if (!res.ok) expect(res.error).toMatch(/comments or replies/);
   });
 
+  it('rejects a malformed sessionId instead of falling through to the create form', () => {
+    // The dangerous shape: an agent whose sessionId came back empty, passing
+    // filePaths alongside it. Selecting the form on validity rather than
+    // presence made this mint the very duplicate session sessionId prevents.
+    for (const bad of ['', 123, null as unknown, {} as unknown]) {
+      const res = validateReviewInput({
+        sessionId: bad,
+        filePaths: ['/tmp/a.md'],
+        replies: [{ filePath: '/tmp/a.md', commentId: 'cmt_1', text: 'r' }],
+      });
+      expect(res.ok, `sessionId ${JSON.stringify(bad)} should be rejected`).toBe(false);
+    }
+  });
+
+  it('rejects an empty filePaths array alongside sessionId', () => {
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      filePaths: [],
+      replies: [{ filePath: '/tmp/a.md', commentId: 'cmt_1', text: 'r' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/either filePaths or sessionId/);
+  });
+
+  it('rejects enableResolve alongside sessionId rather than dropping it', () => {
+    // An existing session keeps the mode it was created with, so silently
+    // discarding the flag would tell the caller nothing went wrong.
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      enableResolve: true,
+      replies: [{ filePath: '/tmp/a.md', commentId: 'cmt_1', text: 'r' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/enableResolve/);
+  });
+
+  it('names both forms when neither filePaths nor sessionId is given', () => {
+    const res = validateReviewInput({
+      comments: [{ filePath: '/tmp/a.md', anchor: 'hi', text: 't' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/sessionId/);
+  });
+
   it('rejects when both comments and replies are empty', () => {
     const res = validateReviewInput({ filePaths: ['/tmp/a.md'] });
     expect(res.ok).toBe(false);

--- a/server/mcp-stdio/validate.test.ts
+++ b/server/mcp-stdio/validate.test.ts
@@ -18,6 +18,52 @@ describe('validateReviewInput', () => {
     expect(res.ok).toBe(true);
   });
 
+  it('accepts sessionId in place of filePaths', () => {
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      replies: [{ filePath: '/tmp/a.md', commentId: 'cmt_1', text: 'r' }],
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) {
+      expect(res.value).toMatchObject({ sessionId: 'rev_1' });
+      expect(res.value).not.toHaveProperty('filePaths');
+    }
+  });
+
+  it('accepts a comment whose filePath is unknown when attaching by sessionId', () => {
+    // With no filePaths to cross-check against, session membership is the
+    // server's call (it rejects paths outside session.filePaths).
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      comments: [{ filePath: '/tmp/anything.md', anchor: 'hi', text: 't' }],
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  it('rejects sessionId and filePaths together', () => {
+    const res = validateReviewInput({
+      sessionId: 'rev_1',
+      filePaths: ['/tmp/a.md'],
+      replies: [{ filePath: '/tmp/a.md', commentId: 'cmt_1', text: 'r' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/either filePaths or sessionId/);
+  });
+
+  it('rejects input with neither filePaths nor sessionId', () => {
+    const res = validateReviewInput({
+      comments: [{ filePath: '/tmp/a.md', anchor: 'hi', text: 't' }],
+    });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/filePaths/);
+  });
+
+  it('still requires comments or replies when attaching by sessionId', () => {
+    const res = validateReviewInput({ sessionId: 'rev_1' });
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toMatch(/comments or replies/);
+  });
+
   it('rejects when both comments and replies are empty', () => {
     const res = validateReviewInput({ filePaths: ['/tmp/a.md'] });
     expect(res.ok).toBe(false);

--- a/server/mcp-stdio/validate.ts
+++ b/server/mcp-stdio/validate.ts
@@ -81,24 +81,46 @@ export function validateRequestReviewInput(raw: unknown): ValidationResult<Reque
   };
 }
 
+/**
+ * Validate a raw mdr_review argument object. Accepts either:
+ *   - { filePaths, enableResolve? } to create-or-attach an agent-origin session
+ *   - { sessionId } to post into a session that already exists
+ *
+ * In the filePaths form, every comment/reply filePath must appear in
+ * filePaths. In the sessionId form there is no such list to check against,
+ * and the server enforces the stronger condition anyway: it rejects any path
+ * outside the named session's own filePaths.
+ */
 export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput> {
   if (typeof raw !== 'object' || raw === null) {
     return { ok: false, error: 'input must be an object' };
   }
   const obj = raw as {
     filePaths?: unknown;
+    sessionId?: unknown;
     comments?: unknown;
     replies?: unknown;
     enableResolve?: unknown;
   };
 
-  if (!Array.isArray(obj.filePaths) || obj.filePaths.length === 0) {
-    return { ok: false, error: 'filePaths must be a non-empty array' };
+  const hasSessionId = typeof obj.sessionId === 'string' && obj.sessionId.length > 0;
+  const hasFilePaths = Array.isArray(obj.filePaths) && obj.filePaths.length > 0;
+  if (hasSessionId && hasFilePaths) {
+    return { ok: false, error: 'provide either filePaths or sessionId, not both' };
   }
-  if (obj.filePaths.some((p) => typeof p !== 'string' || p.length === 0)) {
-    return { ok: false, error: 'filePaths must contain non-empty strings' };
+
+  // `filePathsSet` scopes the per-item filePath check below. Empty in
+  // sessionId mode, where the check is skipped entirely.
+  let filePathsSet: Set<string> | null = null;
+  if (!hasSessionId) {
+    if (!Array.isArray(obj.filePaths) || obj.filePaths.length === 0) {
+      return { ok: false, error: 'filePaths must be a non-empty array' };
+    }
+    if (obj.filePaths.some((p) => typeof p !== 'string' || p.length === 0)) {
+      return { ok: false, error: 'filePaths must contain non-empty strings' };
+    }
+    filePathsSet = new Set(obj.filePaths as string[]);
   }
-  const filePathsSet = new Set(obj.filePaths as string[]);
 
   const hasComments = Array.isArray(obj.comments) && obj.comments.length > 0;
   const hasReplies = Array.isArray(obj.replies) && obj.replies.length > 0;
@@ -119,7 +141,7 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
       if (!c.anchor || !c.text || !c.filePath) {
         return { ok: false, error: `comments[${i}]: filePath, anchor, text must be non-empty` };
       }
-      if (!filePathsSet.has(c.filePath as string)) {
+      if (filePathsSet !== null && !filePathsSet.has(c.filePath as string)) {
         return { ok: false, error: `comments[${i}].filePath not in filePaths` };
       }
       if (c.author !== undefined && typeof c.author !== 'string') {
@@ -155,7 +177,7 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
       if (!r.commentId || !r.text || !r.filePath) {
         return { ok: false, error: `replies[${i}]: fields must be non-empty` };
       }
-      if (!filePathsSet.has(r.filePath as string)) {
+      if (filePathsSet !== null && !filePathsSet.has(r.filePath as string)) {
         return { ok: false, error: `replies[${i}].filePath not in filePaths` };
       }
       if (r.author !== undefined && typeof r.author !== 'string') {
@@ -166,12 +188,19 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
     }
   }
 
+  const payload = {
+    comments: hasComments ? (obj.comments as ReviewInput['comments']) : undefined,
+    replies: hasReplies ? (obj.replies as ReviewInput['replies']) : undefined,
+  };
+
+  if (hasSessionId) {
+    return { ok: true, value: { ...payload, sessionId: obj.sessionId as string } };
+  }
   return {
     ok: true,
     value: {
+      ...payload,
       filePaths: obj.filePaths as string[],
-      comments: hasComments ? (obj.comments as ReviewInput['comments']) : undefined,
-      replies: hasReplies ? (obj.replies as ReviewInput['replies']) : undefined,
       enableResolve: obj.enableResolve === true ? true : undefined,
     },
   };

--- a/server/mcp-stdio/validate.ts
+++ b/server/mcp-stdio/validate.ts
@@ -103,16 +103,47 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
     enableResolve?: unknown;
   };
 
-  const hasSessionId = typeof obj.sessionId === 'string' && obj.sessionId.length > 0;
-  const hasFilePaths = Array.isArray(obj.filePaths) && obj.filePaths.length > 0;
-  if (hasSessionId && hasFilePaths) {
+  // Presence selects the form, NOT validity. Deciding on validity lets a
+  // malformed sessionId fall through to the create form, which mints exactly
+  // the duplicate session this parameter exists to prevent -- silently, and
+  // only when filePaths happens to be supplied too.
+  // `undefined` is the only absence: it is what an omitted JSON key and an
+  // explicitly-undefined JS property both produce. `null` is a value the
+  // caller chose to send, so it lands in the invalid-sessionId branch below
+  // rather than quietly selecting the create form.
+  const hasSessionId = obj.sessionId !== undefined;
+  if (hasSessionId && (typeof obj.sessionId !== 'string' || obj.sessionId.length === 0)) {
+    return { ok: false, error: 'sessionId must be a non-empty string' };
+  }
+  // Presence again, not non-emptiness: `filePaths: []` beside a sessionId is
+  // still a caller asking for both forms at once.
+  if (hasSessionId && obj.filePaths !== undefined) {
     return { ok: false, error: 'provide either filePaths or sessionId, not both' };
   }
+  // Rejected rather than dropped, for the same reason filePaths is: an
+  // existing session keeps the resolve mode it was created with, so honouring
+  // the flag is impossible and ignoring it silently misleads the caller.
+  if (hasSessionId && obj.enableResolve !== undefined) {
+    return {
+      ok: false,
+      error:
+        'enableResolve applies to the filePaths form only; an existing session ' +
+        'keeps the resolve mode it was created with',
+    };
+  }
 
-  // `filePathsSet` scopes the per-item filePath check below. Empty in
+  // `filePathsSet` scopes the per-item filePath check below. Null in
   // sessionId mode, where the check is skipped entirely.
   let filePathsSet: Set<string> | null = null;
   if (!hasSessionId) {
+    if (obj.filePaths === undefined) {
+      return {
+        ok: false,
+        error:
+          'provide filePaths to open a session, or sessionId to post into one ' +
+          'that already exists',
+      };
+    }
     if (!Array.isArray(obj.filePaths) || obj.filePaths.length === 0) {
       return { ok: false, error: 'filePaths must be a non-empty array' };
     }

--- a/server/review-sessions.test.ts
+++ b/server/review-sessions.test.ts
@@ -192,6 +192,32 @@ describe('ReviewSessionStore', () => {
     expect(store.getSession(session.id)?.status).toBe('aborted');
   });
 
+  it('agent posts do not keep a user-origin session alive past the heartbeat timeout', async () => {
+    store.startSweep(10_000);
+
+    const session = store.createSession({
+      filePaths: ['/tmp/a.md'],
+      enableResolve: false,
+      origin: 'user',
+    });
+    store.beginWaitPark(session.id);
+    const waiter = store.waitForSession(session.id);
+
+    // The tab is closed, so no browser heartbeats arrive. The agent keeps
+    // replying in-thread, which mdr_review's sessionId form makes possible in
+    // a loop for the first time. An agent post must not stand in for the
+    // browser here: gcSilentAgentSessions skips user-origin sessions, so this
+    // sweep is the only thing that can ever notice the reader is gone.
+    for (let i = 0; i < 3; i++) {
+      vi.advanceTimersByTime(10 * 60_000);
+      store.recordAgentComments(session.id, 1);
+    }
+    vi.advanceTimersByTime(60_000);
+
+    const result = await waiter;
+    expect(result).toEqual({ status: 'aborted', reason: 'browser_disconnected' });
+  });
+
   it('sweep does not touch done or already-aborted sessions', () => {
     store.startSweep(10_000);
     const a = store.createSession({ filePaths: ['/tmp/a.md'], enableResolve: false });

--- a/server/review-sessions.ts
+++ b/server/review-sessions.ts
@@ -832,7 +832,15 @@ export class ReviewSessionStore {
     // Treat an agent POST as a heartbeat so subsequent batched calls keep
     // finding this session via findOpenSession even if the browser tab is
     // backgrounded and Chrome throttles its setInterval-based heartbeats.
-    s.lastHeartbeatAt = now;
+    //
+    // Agent-origin ONLY. That dedupe is an agent-origin concern, and
+    // user-origin sessions have no second disconnect detector to fall back on:
+    // gcSilentAgentSessions skips them outright, so sweepStale's heartbeat
+    // timeout is the sole path to browser_disconnected. Refreshing it here
+    // would let an agent replying in-thread hold a closed tab's session open
+    // for as long as it keeps posting, and the user's mdr_request_review poll
+    // would never learn the review is dead.
+    if (s.origin === 'agent') s.lastHeartbeatAt = now;
   }
 
   /**


### PR DESCRIPTION
Carries @sethfitz's #72 with review fixes on top, moved here so CI actually runs. #72 has never had a green or red build: workflow runs from a first-time contributor need manual approval on every push, so the branch sat untested.

Seth's commit is preserved as-is, so please merge rather than squash and #72 keeps its merged status.

## What #72 does

`mdr_review` gains an optional `sessionId`, mutually exclusive with `filePaths`. Without it, the tool always called `createSession({origin:'agent'})`, and `findOpenSession` filters dedupe on origin (`server/review-sessions.ts:298`), so the user-origin session an `mdr_request_review` handoff opens was structurally unreachable. An agent replying into a review the user had open got a second session on the same file: a duplicate tab and a second banner row.

Reproduced before merging, with the MCP tool driven directly so agent judgment was out of the loop: a user-origin session plus one `mdr_review` call yields two open sessions on one file, one `user` and one `agent`, and the banner renders a row for each.

## Added here

**`2809e74`** fixes a trailing blank line that failed `format:check`, CI's first step.

**`8c64399`** stops the attach form telling the agent to call `mdr_wait`. It reused the creating form's closing instruction, but `mdr_wait` long-polls `/agent-wait`, which 409s on user-origin sessions (`server/routes/review-sessions.ts:1409`). The `mdr_request_review` handoff the feature exists to serve is user-origin, so following the result text walked the main case into an error. Also scopes the same claim in `mdr_review`'s tool description and fixes a contradiction it left in AGENTS.md.

**`d8051e2`** closes four findings from a review of the branch:

- A present-but-invalid `sessionId` selected the create form, so passing one alongside `filePaths` minted the duplicate session the parameter exists to prevent. Presence now selects the form, not validity.
- `filePaths: []` beside a `sessionId` slipped past the mutual-exclusion check, and `enableResolve` beside one was silently dropped rather than rejected.
- The error for a call carrying neither form named only `filePaths`, steering a caller that meant to attach into opening a session.
- `recordAgentComments` refreshed `lastHeartbeatAt` on every origin, though the justifying comment reasons only about agent-origin dedupe. User-origin sessions have no other disconnect detector, so an agent replying in-thread could hold a closed tab's session open indefinitely. The `sessionId` form is what made this reachable in a loop, since `mdr_ask` blocks.
- Also: `mdr_ask`'s description told the agent to clear a stuck ask via `mdr_review` without naming the `sessionId` form, so following it opened a second session.

Every fix has a test that fails without it, verified by reverting the source and re-running rather than by assertion.

## Verification

`format:check`, `tsc -b`, and `eslint` clean. 1961 unit tests pass, plus the 4 subprocess tests after a build.

## Follow-up

#78 tracks returning the session origin from `/agent-comments`, which would let the attach form state one continuation instead of two.
