### PR TITLE
Key marker disposal on the document, not on whether a reply was written

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1609,12 +1609,15 @@ From `src/lib/agent-prompts.ts`:
 
 - `buildAddressCommentsPrompt(options)` — generate LLM prompt for addressing review comments
 
-  Both `enableResolve` modes distinguish a comment that wanted a **document
-  edit** from one that only wanted an **answer**. The agent always adds a reply;
-  only the edit case disposes of the marker (removed in remove mode, resolved in
-  resolve mode). A question keeps its marker in both modes, so the answer has
-  somewhere to live. Removing the marker for every addressed comment, which
-  remove mode used to instruct, destroys the question and records no answer.
+  Both `enableResolve` modes dispose of a marker based on whether **the
+  document changed**, never on whether a reply was written. The agent always
+  adds a reply, so "did this only need a reply?" distinguishes nothing; wording
+  the rule that way made an agent keep every marker, and the deletion-request
+  eval fixture dropped from 100% to 60% until it was rekeyed on the document.
+  A comment whose answer is the reply keeps its marker in both modes, so the
+  answer has somewhere to live. Removing the marker for every addressed
+  comment, which remove mode used to instruct, destroys the question and
+  records no answer.
 
 ## Development
 

--- a/e2e/handoff.spec.ts
+++ b/e2e/handoff.spec.ts
@@ -209,8 +209,12 @@ test.describe('Resolve-mode hand-off', () => {
 
     const clipboard = await page.evaluate(() => navigator.clipboard.readText());
     expect(clipboard).toContain('"author":"<your tool name>"');
-    expect(clipboard).toContain('required a document edit, remove the entire');
-    expect(clipboard).toContain('leave the marker in place so I can read your answer');
+    expect(clipboard).toContain('changed the document, remove the entire');
+    expect(clipboard).toContain('leave the marker in place so I can read that answer');
+    // Keyed on the document, never on the reply. Every comment gets a reply
+    // now, so wording it as "only needed a reply" stopped distinguishing
+    // anything and an agent kept every marker.
+    expect(clipboard).not.toContain('only needed a reply');
     // Removal is no longer unconditional.
     expect(clipboard).not.toContain('After addressing a comment, remove the entire');
   });

--- a/src/lib/agent-prompts.test.ts
+++ b/src/lib/agent-prompts.test.ts
@@ -145,7 +145,7 @@ describe('buildAddressCommentsPrompt - answering versus editing', () => {
       commentCounts: new Map([['/tmp/spec.md', 1]]),
       enableResolve: false,
     });
-    expect(prompt).toContain('leave the marker in place so I can read your answer');
+    expect(prompt).toContain('leave the marker in place so I can read that answer');
   });
 
   it('no longer tells non-resolve mode to remove the marker unconditionally', () => {
@@ -156,7 +156,7 @@ describe('buildAddressCommentsPrompt - answering versus editing', () => {
     });
     // The old wording. Removal is now scoped to comments that required an edit.
     expect(prompt).not.toContain('After addressing a comment, remove the entire');
-    expect(prompt).toContain('required a document edit, remove the entire');
+    expect(prompt).toContain('changed the document, remove the entire');
   });
 
   it.each([true, false])(
@@ -185,8 +185,12 @@ describe('buildAddressCommentsPrompt - answering versus editing', () => {
         commentCounts: new Map([['/tmp/spec.md', 1]]),
         enableResolve,
       });
-      expect(prompt).toContain('required a document edit');
-      expect(prompt).toContain('only needed a reply');
+      // Keyed on the document, never on whether a reply was written. Every
+      // comment gets a reply now, so "only needed a reply" stopped
+      // distinguishing anything and every marker was kept.
+      expect(prompt).toContain('changed the document');
+      expect(prompt).toContain('If the document did not change');
+      expect(prompt).not.toContain('only needed a reply');
       expect(prompt).toContain('add a reply to the `replies` array');
     },
   );

--- a/src/lib/agent-prompts.ts
+++ b/src/lib/agent-prompts.ts
@@ -23,9 +23,16 @@ export function buildAddressCommentsPrompt({
   // Without that split, non-resolve mode instructed an agent to remove the
   // marker for every comment it addressed, which silently destroyed any
   // comment that was a question and recorded no answer anywhere.
+  //
+  // The test is whether the DOCUMENT CHANGED, never whether a reply was
+  // written. An earlier wording said to keep the marker when a comment "only
+  // needed a reply", which stopped distinguishing anything the moment the
+  // reply step above became unconditional: every comment gets a reply now, so
+  // an agent reading that kept every marker. Measured on the deletion-request
+  // eval fixture, which went from 100% to 60% until this was reworded.
   const afterAction = enableResolve
-    ? 'After addressing a comment that required a document edit, resolve it by setting `"status":"resolved"` and `"resolved":true` in the marker JSON. If a comment only needed a reply (e.g. answering a question), leave it open.'
-    : 'After addressing a comment that required a document edit, remove the entire `<!-- @comment{...} -->` marker from the file. If a comment only needed a reply (e.g. answering a question), leave the marker in place so I can read your answer.';
+    ? 'If addressing the comment changed the document, resolve it by setting `"status":"resolved"` and `"resolved":true` in the marker JSON. If the document did not change, because the comment asked a question and your reply is the answer, leave it open.'
+    : 'If addressing the comment changed the document, remove the entire `<!-- @comment{...} -->` marker from the file. If the document did not change, because the comment asked a question and your reply is the answer, leave the marker in place so I can read that answer.';
 
   // Shared by both modes. The reply is where an answer lives, and in
   // non-resolve mode it is the only place it can live, since the marker for


### PR DESCRIPTION
Regression from #81, found by running the eval harness that #81 itself made capable of finding it.

## What broke

The two halves of that change contradicted each other.

Step 3 of the hand-off prompt tells the agent to add a reply to **every** comment it addresses. Step 4 then said to keep the marker when a comment "only needed a reply". Once replying is unconditional, that condition reads as always true, so an agent keeps every marker.

On a deletion request the agent deleted the section and then kept a marker whose anchor no longer existed: parsing 0/1, anchorIntegrity 0/1, case overall 60%.

Before #81, replying was resolve-mode-only, so "only needed a reply" distinguished something real. Making the reply step universal without rekeying the disposal rule is what broke it.

## The fix

Marker disposal now turns on whether **the document changed**, which is observable and independent of whether a reply was written:

> If addressing the comment changed the document, remove the entire `<!-- @comment{...} -->` marker from the file. If the document did not change, because the comment asked a question and your reply is the answer, leave the marker in place so I can read that answer.

Both modes carried the same latent ambiguity, so both are reworded. AGENTS.md records the rule and why it is keyed this way.

## Measured, not asserted

Full remove-mode suite against the shipped prompt:

| | Parse | Exec | Integ | Anchor | Overall |
|---|---|---|---|---|---|
| As merged in #81 | 94% | 94% | 100% | 67% | 95% |
| This PR | 100% | 94% | 100% | 100% | 97% |

`06-deletion-request` is back to 100% with the marker correctly removed. `17-question-comment` still answers the question and keeps its marker, so the fix this corrects is intact.

Each claim above is a run, including the control: the three imperfect cases were re-run against the pre-fix prompt to establish which were regressions and which were not.

## Two gaps that are not from this change

`08-large-file` at 75% and `10-frontmatter` at 80%, both execution-dimension misses, both scoring identically against the pre-fix prompt. They predate this work and have never been measured before, because the default eval agent runs a hardcoded preamble rather than the shipped prompt. Worth a look, not a blocker here.

## Why nothing else caught it

Three adversarial review passes read the prose as coherent, and the unit tests assert that the prompt string contains a substring, which it did. A contradiction between two numbered steps only becomes visible when a model follows them.

That is a reasonable argument for running `npm run eval` on changes to `buildAddressCommentsPrompt` rather than leaving it to be remembered.
