### PR TITLE
Refuse to release on an eval that predates the prompt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1619,6 +1619,32 @@ From `src/lib/agent-prompts.ts`:
   comment, which remove mode used to instruct, destroys the question and
   records no answer.
 
+### Changing agent-facing text
+
+`src/lib/agent-prompts.ts` and the tool descriptions in
+`server/mcp-stdio/server.ts` are instructions an agent follows, not code. A
+defect in one is prose that reads fine and behaves wrong, so neither types nor
+assertions can see it: a unit test can only confirm the string contains a
+substring, and it did while a contradiction between two numbered steps made an
+agent keep every marker.
+
+Run the eval harness against a change to either, for both shipped-prompt
+agents, and read the per-case scores rather than the average:
+
+```bash
+npm run eval -- --agent claude-cli-remove
+npm run eval -- --agent claude-cli-resolve
+```
+
+When a case scores below 100%, run the same case against the previous wording
+before assuming you caused it. Several fixtures have pre-existing gaps, and the
+difference between "I broke this" and "this was already here" is one control
+run. `scripts/release.mjs` refuses to publish when the newest run for either
+agent predates the last change to these files.
+
+Playwright covers the other half: `e2e/handoff.spec.ts` asserts the prompt's
+wording verbatim, so a reword breaks it and `npm test` alone will not tell you.
+
 ## Development
 
 Prerequisite: Node 20 or newer.

--- a/scripts/eval-freshness.mjs
+++ b/scripts/eval-freshness.mjs
@@ -1,0 +1,114 @@
+// scripts/eval-freshness.mjs
+//
+// Pure decision logic for the release eval gate. CI cannot cover this: it runs
+// `eval:dry`, which validates fixture structure and makes no model calls, so a
+// prompt whose numbered steps contradict each other passes every check the
+// matrix has. That happened, shipped, and was only caught by running a model
+// against it.
+//
+// Kept free of fs/git calls so it can be unit tested; release.mjs collects the
+// timestamps and hands them to evaluateEvalFreshness().
+
+/**
+ * Agents that drive the SHIPPED prompt. A run from any other adapter proves
+ * nothing about it: `claude-cli` carries its own frozen preamble, deliberately
+ * not tracking `buildAddressCommentsPrompt`, which is how a defect in the real
+ * wording once reached a user unnoticed.
+ */
+export const SHIPPED_PROMPT_AGENTS = ['claude-cli-remove', 'claude-cli-resolve'];
+
+/**
+ * Parse an `eval/results/` directory name into a run descriptor.
+ * Shape: `<timestamp>_<agent>_<format>`, e.g.
+ * `2026-08-27T07-03-32_claude-cli-remove_current`. The agent name contains
+ * hyphens, so the split is on `_`, never on `-`.
+ *
+ * @returns {{name: string, agent: string, format: string, ranAt: number}|null}
+ *   `ranAt` is epoch seconds. Null when the name does not parse, so a stray
+ *   directory is ignored rather than counted as a run.
+ */
+export function parseRunDirName(name) {
+  const parts = String(name).split('_');
+  if (parts.length !== 3) return null;
+  const [stamp, agent, format] = parts;
+  // 2026-08-27T07-03-32 -> 2026-08-27T07:03:32
+  const iso = stamp.replace(/T(\d{2})-(\d{2})-(\d{2})$/, 'T$1:$2:$3');
+  if (iso === stamp) return null;
+  const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return null;
+  if (!agent || !format) return null;
+  return { name, agent, format, ranAt: Math.floor(ms / 1000) };
+}
+
+/**
+ * @param {Array<{path: string, changedAt: number|null}>} watched - Files whose
+ *   content is the agent-facing contract, with the epoch-seconds commit time of
+ *   the last change to each. A null `changedAt` means the file has no history
+ *   yet and cannot make anything stale.
+ * @param {Array<{agent: string, ranAt: number}>} runs - Parsed eval results.
+ * @param {{requiredAgents?: string[]}} [options]
+ * @returns {{ok: boolean, reason: 'fresh'|'no-runs'|'stale', message: string,
+ *   stale?: Array<{agent: string, missing: boolean, behind: string[]}>}}
+ */
+export function evaluateEvalFreshness(
+  watched,
+  runs,
+  { requiredAgents = SHIPPED_PROMPT_AGENTS } = {},
+) {
+  const changed = (watched ?? []).filter((w) => typeof w.changedAt === 'number');
+  if (changed.length === 0) {
+    return {
+      ok: true,
+      reason: 'fresh',
+      message: 'No agent-facing files tracked; nothing to gate.',
+    };
+  }
+
+  const newestByAgent = new Map();
+  for (const r of runs ?? []) {
+    if (!r || typeof r.ranAt !== 'number') continue;
+    const prev = newestByAgent.get(r.agent);
+    if (prev === undefined || r.ranAt > prev) newestByAgent.set(r.agent, r.ranAt);
+  }
+
+  if (requiredAgents.every((a) => !newestByAgent.has(a))) {
+    return {
+      ok: false,
+      reason: 'no-runs',
+      message:
+        `No eval results from a shipped-prompt agent (${requiredAgents.join(', ')}). ` +
+        `Run \`npm run eval -- --agent ${requiredAgents[0]}\` before releasing.`,
+    };
+  }
+
+  const stale = [];
+  for (const agent of requiredAgents) {
+    const ranAt = newestByAgent.get(agent);
+    if (ranAt === undefined) {
+      stale.push({ agent, missing: true, behind: changed.map((w) => w.path) });
+      continue;
+    }
+    const behind = changed.filter((w) => w.changedAt > ranAt).map((w) => w.path);
+    if (behind.length > 0) stale.push({ agent, missing: false, behind });
+  }
+
+  if (stale.length === 0) {
+    return {
+      ok: true,
+      reason: 'fresh',
+      message: `Eval is current for ${requiredAgents.join(', ')}.`,
+    };
+  }
+
+  const lines = stale.map((s) =>
+    s.missing
+      ? `  ${s.agent}: never run`
+      : `  ${s.agent}: last run predates ${s.behind.join(', ')}`,
+  );
+  return {
+    ok: false,
+    reason: 'stale',
+    message: `Eval has not been run against the current agent-facing text:\n${lines.join('\n')}`,
+    stale,
+  };
+}

--- a/scripts/eval-freshness.test.ts
+++ b/scripts/eval-freshness.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+// @ts-expect-error - plain .mjs helper without type declarations
+import {
+  evaluateEvalFreshness,
+  parseRunDirName,
+  SHIPPED_PROMPT_AGENTS,
+} from './eval-freshness.mjs';
+
+const T = (iso: string) => Math.floor(Date.parse(iso) / 1000);
+const PROMPT = 'src/lib/agent-prompts.ts';
+const TOOLS = 'server/mcp-stdio/server.ts';
+
+function run(agent: string, iso: string) {
+  return { agent, ranAt: T(iso) };
+}
+
+describe('parseRunDirName', () => {
+  it('reads the timestamp, agent and format out of a results directory', () => {
+    expect(parseRunDirName('2026-08-27T07-03-32_claude-cli-remove_current')).toMatchObject({
+      agent: 'claude-cli-remove',
+      format: 'current',
+      ranAt: T('2026-08-27T07:03:32'),
+    });
+  });
+
+  it('keeps hyphenated agent names intact', () => {
+    // Splitting on '-' would turn claude-cli-remove into three fields and
+    // silently attribute the run to an agent that does not exist.
+    expect(parseRunDirName('2026-01-02T03-04-05_claude-cli-resolve_current')?.agent).toBe(
+      'claude-cli-resolve',
+    );
+  });
+
+  it('ignores anything that is not a run directory', () => {
+    for (const bad of ['', 'README.md', 'two_parts', 'a_b_c_d', 'notatime_claude-cli_current']) {
+      expect(parseRunDirName(bad)).toBeNull();
+    }
+  });
+});
+
+describe('evaluateEvalFreshness', () => {
+  const bothFresh = [
+    run('claude-cli-remove', '2026-08-27T10:00:00'),
+    run('claude-cli-resolve', '2026-08-27T10:00:00'),
+  ];
+
+  it('passes when every required agent ran after the last prompt change', () => {
+    const res = evaluateEvalFreshness(
+      [{ path: PROMPT, changedAt: T('2026-08-27T09:00:00') }],
+      bothFresh,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.reason).toBe('fresh');
+  });
+
+  it('fails when the prompt changed after the newest run', () => {
+    const res = evaluateEvalFreshness(
+      [{ path: PROMPT, changedAt: T('2026-08-27T11:00:00') }],
+      bothFresh,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('stale');
+    expect(res.message).toContain(PROMPT);
+  });
+
+  it('fails when only one branch of the prompt has been exercised', () => {
+    // Both modes ship. A remove-mode run says nothing about the resolve
+    // wording, which is now the default a reader gets.
+    const res = evaluateEvalFreshness(
+      [{ path: PROMPT, changedAt: T('2026-08-27T09:00:00') }],
+      [run('claude-cli-remove', '2026-08-27T10:00:00')],
+    );
+    expect(res.ok).toBe(false);
+    expect(res.stale).toEqual([{ agent: 'claude-cli-resolve', missing: true, behind: [PROMPT] }]);
+  });
+
+  it('does not accept a run from the frozen baseline agent', () => {
+    // `claude-cli` carries its own hardcoded preamble and deliberately does
+    // not track the shipped prompt, so its score proves nothing about it.
+    const res = evaluateEvalFreshness(
+      [{ path: PROMPT, changedAt: T('2026-08-27T09:00:00') }],
+      [run('claude-cli', '2026-08-27T23:00:00')],
+    );
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('no-runs');
+  });
+
+  it('gates on the tool descriptions too, not just the hand-off prompt', () => {
+    // Tool descriptions are the same class of agent-facing text; a wrong one
+    // sent "I want to review X" to the tool that posts the agent's own
+    // comments.
+    const res = evaluateEvalFreshness(
+      [
+        { path: PROMPT, changedAt: T('2026-08-27T09:00:00') },
+        { path: TOOLS, changedAt: T('2026-08-27T11:00:00') },
+      ],
+      bothFresh,
+    );
+    expect(res.ok).toBe(false);
+    expect(res.message).toContain(TOOLS);
+    expect(res.message).not.toContain(PROMPT);
+  });
+
+  it('takes the newest run per agent, not the first it sees', () => {
+    const res = evaluateEvalFreshness(
+      [{ path: PROMPT, changedAt: T('2026-08-27T09:30:00') }],
+      [
+        run('claude-cli-remove', '2026-08-26T10:00:00'),
+        run('claude-cli-remove', '2026-08-27T10:00:00'),
+        run('claude-cli-resolve', '2026-08-27T10:00:00'),
+      ],
+    );
+    expect(res.ok).toBe(true);
+  });
+
+  it('passes when no watched file has any history', () => {
+    expect(evaluateEvalFreshness([{ path: PROMPT, changedAt: null }], []).ok).toBe(true);
+  });
+
+  it('reports no-runs when the results directory is empty', () => {
+    const res = evaluateEvalFreshness([{ path: PROMPT, changedAt: T('2026-08-27T09:00:00') }], []);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('no-runs');
+    expect(res.message).toContain('npm run eval');
+  });
+
+  it('exports the shipped-prompt agents it gates on', () => {
+    expect(SHIPPED_PROMPT_AGENTS).toEqual(['claude-cli-remove', 'claude-cli-resolve']);
+  });
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -16,13 +16,18 @@
 // local iteration or an offline emergency. Real releases never set this.
 
 import { spawnSync } from 'node:child_process';
-import { readFileSync, writeFileSync, unlinkSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, unlinkSync, existsSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import * as readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 
 import { evaluateCiRuns } from './ci-status.mjs';
+import {
+  evaluateEvalFreshness,
+  parseRunDirName,
+  SHIPPED_PROMPT_AGENTS,
+} from './eval-freshness.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -179,6 +184,82 @@ function verifyCiGreen() {
     );
   }
   console.log(`  ✓ ${result.message} (${shortSha})`);
+}
+
+/**
+ * Files whose CONTENT is an instruction an agent follows. A defect in one is
+ * not a type error or a failing assertion; it is prose that reads fine and
+ * behaves wrong, so nothing in the CI matrix can see it.
+ */
+const AGENT_FACING_FILES = ['src/lib/agent-prompts.ts', 'server/mcp-stdio/server.ts'];
+
+/**
+ * Gate the release on the eval harness having been run against the current
+ * agent-facing text.
+ *
+ * CI cannot do this. It runs `eval:dry`, which validates fixture structure and
+ * makes no model calls, so a prompt whose numbered steps contradict each other
+ * goes green on the full matrix. That is not hypothetical: a change telling the
+ * agent to reply to every comment, paired with a rule that kept the marker when
+ * a comment "only needed a reply", made that condition always true. Every
+ * marker was kept, the deletion-request fixture fell from 100% to 60%, and it
+ * shipped past three adversarial reviews and a green matrix. One model run
+ * found it.
+ *
+ * Release is the right place for the check rather than per-PR CI: eval costs
+ * real model calls and its scores move between runs, so it would block PRs at
+ * random, but a release is deliberate and a human reads the number.
+ *
+ * What this does NOT verify: which prompt a run actually exercised. It compares
+ * a run's timestamp against the last commit touching the watched files, so a
+ * deliberate control run against a reverted prompt satisfies it. That is a real
+ * workflow, since comparing before and after is how you tell a regression from
+ * a pre-existing gap, so re-run against HEAD before releasing. Closing the hole
+ * properly means the runner recording a fingerprint of the prompt it built, and
+ * the gate comparing that instead of a clock.
+ *
+ * Uncommitted edits to a watched file cannot slip past: preflight() already
+ * refuses to release from a dirty tree, so the last commit time is the content.
+ */
+function verifyEvalFresh() {
+  if (process.env.RELEASE_SKIP_EVAL_CHECK === '1') {
+    console.log('\n→ Skipping eval gate (RELEASE_SKIP_EVAL_CHECK=1)');
+    console.warn('  ! Publishing without confirming the eval ran against the current prompt.');
+    return;
+  }
+
+  console.log('\n→ Verifying eval was run against the current agent-facing text');
+
+  const watched = AGENT_FACING_FILES.map((path) => {
+    let out = '';
+    try {
+      out = run('git', ['log', '-1', '--format=%ct', '--', path], { capture: true }).trim();
+    } catch {
+      out = '';
+    }
+    return { path, changedAt: out === '' ? null : Number(out) };
+  });
+
+  const resultsDir = join(PROJECT_ROOT, 'eval', 'results');
+  let runs = [];
+  if (existsSync(resultsDir)) {
+    runs = readdirSync(resultsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .map((d) => parseRunDirName(d.name))
+      .filter(Boolean);
+  }
+
+  const result = evaluateEvalFreshness(watched, runs);
+  if (!result.ok) {
+    throw new Error(
+      `Eval gate failed: ${result.message}\n` +
+        `Run it for each shipped-prompt agent, e.g.\n` +
+        SHIPPED_PROMPT_AGENTS.map((a) => `  npm run eval -- --agent ${a}`).join('\n') +
+        `\nRead the per-case scores, not just the average; a single dimension can drop while the total still looks healthy.\n` +
+        `If you are genuinely unable to run it, set RELEASE_SKIP_EVAL_CHECK=1 to bypass (not recommended).`,
+    );
+  }
+  console.log(`  ✓ ${result.message}`);
 }
 
 function readPackageVersion() {
@@ -411,6 +492,7 @@ async function main() {
   preflight();
   runLocalUnitTests();
   verifyCiGreen();
+  verifyEvalFresh();
 
   const currentVersion = readPackageVersion();
   const nextVersion = computeNextVersion(type);


### PR DESCRIPTION
CI runs `eval:dry`, which validates fixture structure and makes no model calls. So a prompt whose numbered steps contradict each other passes the entire matrix.

That is not hypothetical. #81 told the agent to reply to every comment it addresses, while keeping a rule that preserved the marker when a comment "only needed a reply". Once replying is unconditional that condition is always true, so an agent kept every marker. The deletion-request fixture fell from 100% to 60%. It shipped past three adversarial reviews and a green matrix, and #82 fixed it only because a model was run against it.

## What this adds

`verifyEvalFresh()` sits beside `verifyCiGreen()` and refuses to publish when the newest eval run for either shipped-prompt agent predates the last commit touching `src/lib/agent-prompts.ts` or the tool descriptions in `server/mcp-stdio/server.ts`.

Decision logic is in `scripts/eval-freshness.mjs` with 12 tests, matching how `ci-status.mjs` is split from its I/O.

**Release rather than per-PR CI, deliberately.** Eval costs real model calls and its scores move between runs, so it would red PRs at random. A release is already a deliberate moment where a human reads the number.

**Only `claude-cli-remove` and `claude-cli-resolve` count.** The default `claude-cli` adapter carries its own frozen preamble and does not track the shipped prompt, which is how the original defect reached a user. Accepting its score would make the gate look satisfied while proving nothing. Both are required because both branches ship, and resolve mode is now the default.

## What it does not do, recorded in the code

It cannot tell which prompt a run exercised. It compares a run's timestamp against the last commit touching the watched files, so a control run against a deliberately reverted prompt satisfies it. That is a real workflow, since comparing before and after is how you tell a regression from a pre-existing gap, so re-run against HEAD before releasing. Closing it properly means the runner recording a fingerprint of the prompt it built.

Uncommitted edits cannot slip past: `preflight()` already refuses to release from a dirty tree, so the last commit time is the content.

It also says nothing about the scores themselves, which still need reading per case.

## What running it immediately found

`claude-cli-resolve` had never been run. Not stale, never. The prompt branch that is now the default had never been measured by anything.

Running it surfaced a pre-existing 60% on `16-restructuring-rewrite`: parsing and anchor integrity perfect, execution 0%. The agent resolved all three markers with replies and left the original text in the document, which is to say it reported three comments done without making the edits. A control run against the older wording produced identical failures, so it predates this work.

That is a sample of one, on the hardest fixture in the set, and it is the only resolve-mode fixture there is. Worth following up with real coverage of the default mode rather than reading much into it yet.

AGENTS.md records the workflow next to the prompt builder, including running the control before assuming you caused a drop.
