### PR TITLE
Open the viewer's context menu on a text selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -730,28 +730,60 @@ after typing) closes the form as usual.
 The viewer's own menu (Comment, Templates, Copy) opens from the painted mark,
 not from the native range. `handleContextMenu` in `MarkdownViewer` checks
 `SELECTION_MARK_SELECTOR` before it falls back to `window.getSelection()`,
-because the range is gone by then: painting `mark.selection-highlight` replaces
-the selected text nodes and collapses it. Testing the range alone is what left
-this menu unreachable from March until it was fixed; a reader got the browser's
-menu instead.
+because the range is gone by then.
+
+The reason is worth stating precisely, because it decides which layer a fix
+belongs in: committing a selection re-runs the render layout effect, whose deps
+include `selectionText`, and that effect's first act is
+`container.innerHTML = sanitizeRenderedMarkdown(html)`. The whole subtree is
+replaced, so the native Range dies there, before `wrapText` paints any mark.
+Switching the highlight to the CSS Custom Highlight API to avoid wrapping text
+nodes would therefore change nothing: the range would still be destroyed by the
+rebuild above it. Testing the range alone is what left this menu unreachable
+from March until it was fixed; a reader got the browser's menu instead.
 
 Two things keep the selection alive long enough for the menu to act on it, and
 both are load-bearing:
 
-- `useSelection`'s `handleMouseUp` ignores any non-primary button. Otherwise the
-  right-click's own mouseup resolves the collapsed range, gets null, and clears
-  the selection the menu was opened on. This also makes the fix independent of
-  event order, which matters because Windows fires `contextmenu` after mouseup
-  rather than before it.
-- The menu root carries `data-preserve-selection`, so picking an item does not
-  clear the selection before the item's click handler runs. `Copy` closes over
-  a captured `SelectionInfo` and would survive either way; `Comment` reads live
-  state and would not.
+- `useSelection`'s `handleMouseUp` ignores a non-primary button **that lands on
+  the selection's own mark**. Otherwise the right-click's own mouseup resolves
+  the collapsed range, gets null, and clears the selection the menu was opened
+  on. This also makes the fix independent of event order, which matters because
+  Windows fires `contextmenu` after mouseup rather than before it. Sparing every
+  secondary press everywhere is wrong in the other direction: the selection then
+  outlives a right-click on unrelated text, its pill floats over that text, and
+  the next menu builds on the stale selection instead of what was pointed at.
+- The viewer's menu carries `data-preserve-selection` (the `preserveSelection`
+  prop, set on that instance only), so picking an item does not clear the
+  selection before the item's click handler runs. Two listeners have to respect
+  it, not one: `useSelection`'s mouseup, and `CommentForm`'s dismissal, which
+  with quick comment on is watching an already-open composer.
+- `Comment` commits the selection the menu captured, through `adoptSelection`,
+  rather than locking whatever is live at click time. Locking live state means
+  that if anything cleared the selection in between, `lockedRef` is set with
+  nothing committed and never released, and every later selection in the
+  document is silently ignored: the reader sees the menu stop appearing and has
+  no way to know Escape releases it. The explorer, tab and sidebar
+  menus deliberately do not: they have no items that act on the selection, and
+  sparing them would keep a stale selection alive through clicks that should end
+  it.
 
-`CommentForm`'s click-outside dismissal ignores button 2 for the same reason: a
-right-click on your own selection is an outside mousedown, and with quick
-comment on it would otherwise cancel the composer and take the selection with
-it. Middle-click still dismisses.
+`CommentForm`'s click-outside dismissal spares a press that lands on the
+selection's mark, or inside any surface carrying `data-preserve-selection`
+(the menu itself), for the same reason: with quick comment on, the composer is
+open the moment you select, and a press on your own selection would otherwise
+cancel it and take the selection with it. Tested by target rather than by
+button, because a touch long-press opens the same menu and its compatibility
+mousedown reports button 0, indistinguishable from a left-click. The check runs
+after the containment test, so a right-click anywhere else still dismisses an
+empty composer rather than leaving it floating.
+
+**Shift+right-click** returns before every branch, so the browser's own menu is
+never suppressed. That matches what the chord already means in Chrome on
+Windows and Linux, and it is the escape hatch to Inspect on a painted highlight.
+It is gated on `button === 2`: Shift+F10 is the standard keyboard chord for the
+context menu and arrives with `shiftKey` set and button 0, so testing `shiftKey`
+alone would lock keyboard users out of this menu entirely.
 
 `onContextMenu` returns whether it opened a menu, and the viewer calls
 `preventDefault` only when it did. The consumer refuses a mark whose comment is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -778,6 +778,16 @@ mousedown reports button 0, indistinguishable from a left-click. The check runs
 after the containment test, so a right-click anywhere else still dismisses an
 empty composer rather than leaving it floating.
 
+**Only one surface at a time.** The pill and this menu both carry Comment and
+the same templates, and the menu's submenu opens straight over the pill's own
+template row, so `CommentForm` takes a `hidden` prop (App passes
+`viewerCtxMenu.isOpen`) and renders nothing while the menu is up. It covers the
+expanded composer too: rendering null is not unmounting, so a half-written
+comment survives and comes back when the menu closes without ending the
+selection, Copy being the everyday case. Symmetrically, an open overlay closes
+every context menu (the `activeModal` effect in App), so the palette, settings
+and the file opener never render on top of a live menu.
+
 **Shift+right-click** returns before every branch, so the browser's own menu is
 never suppressed. That matches what the chord already means in Chrome on
 Windows and Linux, and it is the escape hatch to Inspect on a painted highlight.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -725,6 +725,46 @@ While a template prefill sits untouched in the full comment form, Escape
 clears the prefill and keeps the form open; a second Escape (or an Escape
 after typing) closes the form as usual.
 
+### Right-clicking a selection
+
+The viewer's own menu (Comment, Templates, Copy) opens from the painted mark,
+not from the native range. `handleContextMenu` in `MarkdownViewer` checks
+`SELECTION_MARK_SELECTOR` before it falls back to `window.getSelection()`,
+because the range is gone by then: painting `mark.selection-highlight` replaces
+the selected text nodes and collapses it. Testing the range alone is what left
+this menu unreachable from March until it was fixed; a reader got the browser's
+menu instead.
+
+Two things keep the selection alive long enough for the menu to act on it, and
+both are load-bearing:
+
+- `useSelection`'s `handleMouseUp` ignores any non-primary button. Otherwise the
+  right-click's own mouseup resolves the collapsed range, gets null, and clears
+  the selection the menu was opened on. This also makes the fix independent of
+  event order, which matters because Windows fires `contextmenu` after mouseup
+  rather than before it.
+- The menu root carries `data-preserve-selection`, so picking an item does not
+  clear the selection before the item's click handler runs. `Copy` closes over
+  a captured `SelectionInfo` and would survive either way; `Comment` reads live
+  state and would not.
+
+`CommentForm`'s click-outside dismissal ignores button 2 for the same reason: a
+right-click on your own selection is an outside mousedown, and with quick
+comment on it would otherwise cancel the composer and take the selection with
+it. Middle-click still dismisses.
+
+`onContextMenu` returns whether it opened a menu, and the viewer calls
+`preventDefault` only when it did. The consumer refuses a mark whose comment is
+already gone, and a selection type it has no `SelectionInfo` for; suppressing
+the native menu for a menu that never appears would leave the reader with no
+menu at all, no Copy, no spellcheck, no Inspect, and nothing on screen saying
+why. Falling back to the browser's menu is the correct answer there.
+
+Precedence is unchanged: the comment-highlight branch runs first, so a selection
+that overlaps an existing anchor opens the comment menu (Edit / Reply / Delete),
+not the selection menu. A right-click on text with nothing selected also reaches
+the browser's menu, since neither branch matches.
+
 ### Copying a document selection
 The rendered view paints the pending selection as `mark.selection-highlight`
 (`MarkdownViewer.tsx`), which replaces the selected text nodes and collapses the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -745,8 +745,11 @@ from March until it was fixed; a reader got the browser's menu instead.
 Two things keep the selection alive long enough for the menu to act on it, and
 both are load-bearing:
 
-- `useSelection`'s `handleMouseUp` ignores a non-primary button **that lands on
-  the selection's own mark**. Otherwise the right-click's own mouseup resolves
+- `useSelection`'s `handleMouseUp` ignores **the platform's secondary click when
+  it lands on the selection's own mark** (`isSecondaryClick`: button 2, plus
+  macOS ctrl+click, which arrives with `button: 0`, so testing the button alone
+  misses the gesture most Mac users make. The middle button is deliberately not
+  included: it opens no menu, so it should clear like any other press). Otherwise the right-click's own mouseup resolves
   the collapsed range, gets null, and clears the selection the menu was opened
   on. This also makes the fix independent of event order, which matters because
   Windows fires `contextmenu` after mouseup rather than before it. Sparing every
@@ -778,15 +781,31 @@ mousedown reports button 0, indistinguishable from a left-click. The check runs
 after the containment test, so a right-click anywhere else still dismisses an
 empty composer rather than leaving it floating.
 
-**Only one surface at a time.** The pill and this menu both carry Comment and
-the same templates, and the menu's submenu opens straight over the pill's own
+**Only one surface at a time.** The pill and this menu both carry Comment, and
+the menu used to open its template submenu straight over the pill's own
 template row, so `CommentForm` takes a `hidden` prop (App passes
-`viewerCtxMenu.isOpen`) and renders nothing while the menu is up. It covers the
-expanded composer too: rendering null is not unmounting, so a half-written
-comment survives and comes back when the menu closes without ending the
-selection, Copy being the everyday case. Symmetrically, an open overlay closes
-every context menu (the `activeModal` effect in App), so the palette, settings
-and the file opener never render on top of a live menu.
+`viewerCtxMenu.isOpen`) and renders nothing while the menu is up. It covers the expanded
+composer too, hidden with `visibility` rather than by returning null: a
+discarded node comes back one line tall with no caret, because `useAutoResize`
+only runs on input and the focus effect only on expand. The browser blurs what
+it hides, so `CommentForm` puts focus back when the surface returns. Symmetrically, an open overlay closes every
+context menu (the effect in App keyed on `activeModal` and `drawerOpen`), so the
+palette, settings, the file opener and the comments drawer never render on top
+of a live menu. A tab switch closes it too: its items hold a `SelectionInfo`
+captured in the document being left.
+
+**The menu carries Comment and Copy, not templates.** It listed the same eight
+templates the pill does, which made one label mean two things: the pill's
+prefill the composer, the menu's posted immediately. Prefilling from the menu
+instead only moved the damage one step earlier, since it overwrites a draft
+already in the composer. Comment opens the composer, and the templates live
+there, one step further along a path the reader is already on.
+
+**A menu resolved from a live range carries that range's text** (`liveText` on
+`ViewerContextMenuInfo`), and the consumer refuses when it does not match the
+committed selection. While a selection is locked a fresh drag never reaches the
+app, so the two hold different text, and a menu built from the committed one
+would sit over one passage while every item acted on another.
 
 **Shift+right-click** returns before every branch, so the browser's own menu is
 never suppressed. That matches what the chord already means in Chrome on

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -4,6 +4,7 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { TEST_DOC_2_BASELINE, TEST_DOC_BASELINE } from './helpers/fixture-baselines';
 import { clearPersistedPreferences, resetTestAppState } from './helpers/test-state';
+import { withMod } from './helpers/shortcuts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_1 = resolve(__dirname, 'fixtures/test-doc.md');
@@ -150,8 +151,10 @@ test.describe('Context menu on a text selection', () => {
 
     // The menu's items act on the selection. If the right-click's own mouseup
     // clears it, the menu is left floating over text it can no longer touch.
+    // The painted mark is the evidence here: the pill is deliberately hidden
+    // while the menu is up (see the one-surface test below), so its absence
+    // would prove nothing either way.
     await expect(page.locator('mark.selection-highlight').first()).toBeVisible();
-    await expect(page.locator('[data-comment-form]')).toBeVisible();
   });
 
   test('Comment in the selection menu opens the composer on that selection', async ({ page }) => {
@@ -258,6 +261,86 @@ test.describe('Context menu on a text selection', () => {
     await page.keyboard.press('Escape');
     const second = await openSelectionMenu(page, 'bcrypt');
     await expect(second).toBeVisible();
+  });
+
+  test('the pill hides while the menu is open, and comes back when it closes', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await openFixture(page);
+    await selectText(page, 'valid credentials');
+    await expect(page.locator('[data-comment-form]')).toBeVisible({ timeout: 5000 });
+
+    const menu = page.locator('.context-menu-enter');
+    await page.locator('mark.selection-highlight').first().click({ button: 'right' });
+
+    // One surface at a time: both carry Comment and the same templates, and the
+    // submenu opens straight over the pill's own template row.
+    await expect(menu).toBeVisible();
+    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+
+    // Copy closes the menu without ending the selection, so the pill returns.
+    await menu.getByText('Copy', { exact: true }).click();
+    await expect(menu).toHaveCount(0);
+    await expect(page.locator('[data-comment-form]')).toBeVisible();
+  });
+
+  test('an expanded composer hides too, and comes back with its draft', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.request.put('/api/preferences', { data: { settings: { quickComment: true } } });
+    await openFixture(page);
+    await selectText(page, 'valid credentials');
+    const draft = page.getByPlaceholder('Add your comment...');
+    await expect(draft).toBeVisible({ timeout: 5000 });
+    await draft.fill('half a thought');
+
+    const menu = page.locator('.context-menu-enter');
+    await page.locator('mark.selection-highlight').first().click({ button: 'right' });
+    await expect(menu).toBeVisible();
+    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+
+    // Hidden, not unmounted: the component keeps its state while it renders
+    // nothing, so the half-written comment is still there afterwards.
+    await menu.getByText('Copy', { exact: true }).click();
+    await expect(menu).toHaveCount(0);
+    await expect(draft).toBeVisible();
+    await expect(draft).toHaveValue('half a thought');
+  });
+
+  test('opening an overlay closes the context menu', async ({ page }) => {
+    await openFixture(page);
+    const menu = await openSelectionMenu(page, 'valid credentials');
+    await expect(menu).toBeVisible();
+
+    await page.keyboard.press(withMod('k'));
+
+    // Two stacked surfaces again otherwise: the palette renders over a menu
+    // that is still live underneath it.
+    await expect(page.getByPlaceholder('Type a command...')).toBeVisible({ timeout: 5000 });
+    await expect(menu).toHaveCount(0);
+  });
+
+  test('a right-click that is not on a selection leaves the browser menu alone', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await page.evaluate(() => {
+      (window as unknown as { __prevented: boolean | null }).__prevented = null;
+      document.addEventListener('contextmenu', (e) => {
+        (window as unknown as { __prevented: boolean | null }).__prevented = e.defaultPrevented;
+      });
+    });
+
+    await page.locator('.prose p').first().click({ button: 'right' });
+
+    await expect(page.locator('.context-menu-enter')).toHaveCount(0);
+    expect(
+      await page.evaluate(() => (window as unknown as { __prevented: boolean | null }).__prevented),
+    ).toBe(false);
   });
 
   test('Copy in the selection menu puts the selected text on the clipboard', async ({

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -3,7 +3,7 @@ import { writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { TEST_DOC_2_BASELINE, TEST_DOC_BASELINE } from './helpers/fixture-baselines';
-import { resetTestAppState } from './helpers/test-state';
+import { clearPersistedPreferences, resetTestAppState } from './helpers/test-state';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE_1 = resolve(__dirname, 'fixtures/test-doc.md');
@@ -20,6 +20,9 @@ test.beforeEach(async ({ page }) => {
 test.afterAll(() => {
   writeFileSync(FIXTURE_1, FIXTURE_1_ORIGINAL);
   writeFileSync(FIXTURE_2, FIXTURE_2_ORIGINAL);
+  // The quick-comment test persists a setting, and the prefs file is shared
+  // with every later spec (workers: 1). Six specs do not reset in beforeEach.
+  clearPersistedPreferences();
 });
 
 async function openFixture(page: Page, fixture: string = FIXTURE_1) {
@@ -199,6 +202,62 @@ test.describe('Context menu on a text selection', () => {
     expect(
       await page.evaluate(() => (window as unknown as { __prevented: boolean | null }).__prevented),
     ).toBe(false);
+  });
+
+  test('right-clicking away from the selection clears it, as any click does', async ({ page }) => {
+    await openFixture(page);
+    await selectText(page, 'valid credentials');
+    await expect(page.locator('mark.selection-highlight').first()).toBeVisible({ timeout: 5000 });
+
+    // Sparing every secondary button everywhere would leave this selection
+    // committed while its pill floats over unrelated text, and the next menu
+    // would build on it instead of on what the reader just pointed at.
+    await page.locator('.prose h1').first().click({ button: 'right' });
+
+    await expect(page.locator('mark.selection-highlight')).toHaveCount(0);
+    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+  });
+
+  test('Shift+right-click leaves the browser menu alone', async ({ page }) => {
+    await openFixture(page);
+    await page.evaluate(() => {
+      (window as unknown as { __prevented: boolean | null }).__prevented = null;
+      document.addEventListener('contextmenu', (e) => {
+        (window as unknown as { __prevented: boolean | null }).__prevented = e.defaultPrevented;
+      });
+    });
+    await selectText(page, 'valid credentials');
+    await expect(page.locator('mark.selection-highlight').first()).toBeVisible({ timeout: 5000 });
+
+    await page
+      .locator('mark.selection-highlight')
+      .first()
+      .click({ button: 'right', modifiers: ['Shift'] });
+
+    await expect(page.locator('.context-menu-enter')).toHaveCount(0);
+    expect(
+      await page.evaluate(() => (window as unknown as { __prevented: boolean | null }).__prevented),
+    ).toBe(false);
+  });
+
+  test('Comment from the menu opens the composer and leaves selection usable after', async ({
+    page,
+  }) => {
+    // Quick comment on: the composer is already open when the menu is used, so
+    // the mousedown that picks an item is an outside press on an empty form.
+    await page.request.put('/api/preferences', { data: { settings: { quickComment: true } } });
+    await openFixture(page);
+    const menu = await openSelectionMenu(page, 'valid credentials');
+    await menu.getByText('Comment', { exact: true }).click();
+
+    await expect(page.getByPlaceholder('Add your comment...')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('mark.selection-highlight').first()).toBeVisible();
+
+    // And the next selection still works: a lock taken on a cleared selection
+    // is never released, so everything after it is silently ignored.
+    await page.keyboard.press('Escape');
+    const second = await openSelectionMenu(page, 'bcrypt');
+    await expect(second).toBeVisible();
   });
 
   test('Copy in the selection menu puts the selected text on the clipboard', async ({

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -278,7 +278,7 @@ test.describe('Context menu on a text selection', () => {
     // One surface at a time: both carry Comment and the same templates, and the
     // submenu opens straight over the pill's own template row.
     await expect(menu).toBeVisible();
-    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+    await expect(page.locator('[data-comment-form]')).toBeHidden();
 
     // Copy closes the menu without ending the selection, so the pill returns.
     await menu.getByText('Copy', { exact: true }).click();
@@ -301,7 +301,7 @@ test.describe('Context menu on a text selection', () => {
     const menu = page.locator('.context-menu-enter');
     await page.locator('mark.selection-highlight').first().click({ button: 'right' });
     await expect(menu).toBeVisible();
-    await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+    await expect(page.locator('[data-comment-form]')).toBeHidden();
 
     // Hidden, not unmounted: the component keeps its state while it renders
     // nothing, so the half-written comment is still there afterwards.
@@ -341,6 +341,124 @@ test.describe('Context menu on a text selection', () => {
     expect(
       await page.evaluate(() => (window as unknown as { __prevented: boolean | null }).__prevented),
     ).toBe(false);
+  });
+
+  test('ctrl+click, the macOS secondary click, keeps the selection', async ({ page }) => {
+    // Blink converts ctrl+click to contextmenu on macOS only, and
+    // isSecondaryClick counts the chord only there, so this asserts nothing on
+    // the Linux runner the e2e job uses. Same gate as advanced.spec.ts.
+    test.skip(process.platform !== 'darwin', 'ctrl+click is the secondary click on macOS only');
+    await openFixture(page);
+    await selectText(page, 'valid credentials');
+    const mark = page.locator('mark.selection-highlight').first();
+    await expect(mark).toBeVisible({ timeout: 5000 });
+    const box = await mark.boundingBox();
+
+    // macOS sends contextmenu with button 0 and ctrlKey set, so a guard that
+    // tests the button alone misses the platform's own secondary click.
+    await page.keyboard.down('Control');
+    await page.mouse.click(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.keyboard.up('Control');
+
+    await expect(page.locator('.context-menu-enter')).toBeVisible();
+    await expect(page.locator('mark.selection-highlight').first()).toBeVisible();
+  });
+
+  test('a multi-line draft keeps its size and caret through the menu', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await page.request.put('/api/preferences', { data: { settings: { quickComment: true } } });
+    await openFixture(page);
+    await selectText(page, 'valid credentials');
+    const draft = page.getByPlaceholder('Add your comment...');
+    await expect(draft).toBeVisible({ timeout: 5000 });
+    await draft.fill('one\ntwo\nthree\nfour\nfive');
+    const grown = (await draft.boundingBox())!.height;
+    expect(grown).toBeGreaterThan(60);
+
+    const menu = page.locator('.context-menu-enter');
+    await page.locator('mark.selection-highlight').first().click({ button: 'right' });
+    await expect(menu).toBeVisible();
+    await menu.getByText('Copy', { exact: true }).click();
+    await expect(menu).toHaveCount(0);
+
+    // The textarea auto-sizes on input and focuses on expand, and neither
+    // effect re-runs on a remount, so a discarded node comes back one line
+    // tall with the caret gone and lines two onward unreachable.
+    await expect(draft).toHaveValue('one\ntwo\nthree\nfour\nfive');
+    expect((await draft.boundingBox())!.height).toBe(grown);
+    expect(await draft.evaluate((el) => document.activeElement === el)).toBe(true);
+  });
+
+  test('switching tabs closes the menu', async ({ page }) => {
+    await openFixture(page);
+    await openSecondFile(page);
+    const menu = await openSelectionMenu(page, 'details section');
+    await expect(menu).toBeVisible();
+
+    await page.keyboard.press(withMod('Shift+['));
+    await expect(page.getByRole('heading', { name: 'Test Document' })).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Its items act on a SelectionInfo captured in the document that is no
+    // longer on screen; Comment would anchor into the wrong file.
+    await expect(menu).toHaveCount(0);
+  });
+
+  test('a live range that is not the committed selection gets no menu', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await openFixture(page);
+    await selectText(page, 'valid credentials');
+    await expect(page.locator('mark.selection-highlight').first()).toBeVisible({ timeout: 5000 });
+    await page.keyboard.press(withMod('Shift+m')); // lock it
+    await page.waitForTimeout(200);
+
+    // Drag out a real selection elsewhere. handleMouseUp bails while locked, so
+    // the native range is now different text from the committed selection.
+    const box = await page.evaluate(() => {
+      const walker = document.createTreeWalker(
+        document.querySelector('.prose') as Node,
+        NodeFilter.SHOW_TEXT,
+      );
+      let node: Text | null;
+      while ((node = walker.nextNode() as Text | null)) {
+        const idx = node.textContent?.indexOf('Rate limiting') ?? -1;
+        if (idx >= 0) {
+          const range = document.createRange();
+          range.setStart(node, idx);
+          range.setEnd(node, idx + 'Rate limiting'.length);
+          const r = range.getBoundingClientRect();
+          return { x: r.left, y: r.top + r.height / 2, w: r.width };
+        }
+      }
+      return null;
+    });
+    if (!box) throw new Error('target text not found');
+    await page.mouse.move(box.x + 1, box.y);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.w - 1, box.y, { steps: 10 });
+    await page.mouse.up();
+    await page.waitForTimeout(200);
+    expect(await page.evaluate(() => window.getSelection()?.toString())).toContain('Rate limiting');
+    // The precondition this test exists for: the drag was ignored, so the
+    // committed selection is still the first passage. Without asserting it, a
+    // lock that had not landed yet would make this test pass for no reason.
+    expect(await page.locator('mark.selection-highlight').first().textContent()).toContain(
+      'valid credentials',
+    );
+
+    await page.mouse.click(box.x + box.w / 2, box.y, { button: 'right' });
+    await page.waitForTimeout(300);
+
+    // Opening here would put a menu over one passage whose every item acts on
+    // another: Copy writes the old text, Comment anchors to it.
+    await expect(page.locator('.context-menu-enter')).toHaveCount(0);
   });
 
   test('Copy in the selection menu puts the selected text on the clipboard', async ({

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -379,7 +379,13 @@ test.describe('Context menu on a text selection', () => {
     expect(grown).toBeGreaterThan(60);
 
     const menu = page.locator('.context-menu-enter');
-    await page.locator('mark.selection-highlight').first().click({ button: 'right' });
+    // Dispatched rather than clicked: a draft this tall grows the composer over
+    // its own anchor, so a real click cannot reach the mark and the test would
+    // be measuring layout rather than the hide-and-restore it exists for.
+    await page
+      .locator('mark.selection-highlight')
+      .first()
+      .dispatchEvent('contextmenu', { bubbles: true, cancelable: true, button: 2 });
     await expect(menu).toBeVisible();
     await menu.getByText('Copy', { exact: true }).click();
     await expect(menu).toHaveCount(0);

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -61,6 +61,18 @@ async function selectText(page: Page, text: string) {
   }, text);
 }
 
+/**
+ * Select `text` and right-click the mark the viewer paints over it, which is
+ * what a reader's right-click actually lands on. Returns the open menu.
+ */
+async function openSelectionMenu(page: Page, text: string) {
+  await selectText(page, text);
+  const highlight = page.locator('mark.selection-highlight').first();
+  await expect(highlight).toBeVisible({ timeout: 5000 });
+  await highlight.click({ button: 'right' });
+  return page.locator('.context-menu-enter');
+}
+
 async function addComment(page: Page, anchorText: string, commentText: string) {
   await selectText(page, anchorText);
   const commentBtn = page.locator('[data-comment-form] button', { hasText: 'Comment' });
@@ -116,6 +128,91 @@ test.describe('Context menu on comment highlight', () => {
 
     // Comment should be removed
     await expect(page.getByText('Delete via ctx')).not.toBeVisible();
+  });
+});
+
+test.describe('Context menu on a text selection', () => {
+  test('right-clicking a selection shows the selection context menu', async ({ page }) => {
+    await openFixture(page);
+    const menu = await openSelectionMenu(page, 'valid credentials');
+
+    await expect(menu).toBeVisible();
+    await expect(menu.getByText('Copy', { exact: true })).toBeVisible();
+  });
+
+  test('the selection survives the right-click that opened the menu', async ({ page }) => {
+    await openFixture(page);
+    const menu = await openSelectionMenu(page, 'valid credentials');
+    await expect(menu).toBeVisible();
+
+    // The menu's items act on the selection. If the right-click's own mouseup
+    // clears it, the menu is left floating over text it can no longer touch.
+    await expect(page.locator('mark.selection-highlight').first()).toBeVisible();
+    await expect(page.locator('[data-comment-form]')).toBeVisible();
+  });
+
+  test('Comment in the selection menu opens the composer on that selection', async ({ page }) => {
+    await openFixture(page);
+    const menu = await openSelectionMenu(page, 'valid credentials');
+    await menu.getByText('Comment', { exact: true }).click();
+
+    await expect(page.getByPlaceholder('Add your comment...')).toBeVisible({ timeout: 5000 });
+  });
+
+  test('right-clicking a selection opens the menu with quick comment on', async ({ page }) => {
+    // Quick comment opens the composer the moment a selection is made, and the
+    // composer dismisses itself on an outside mousedown. A right-click on your
+    // own selection is such a mousedown, so this is a second way the menu was
+    // lost, independent of the one the tests above cover.
+    await page.request.put('/api/preferences', { data: { settings: { quickComment: true } } });
+    await openFixture(page);
+    await expect(page.getByRole('heading', { name: 'Test Document' })).toBeVisible({
+      timeout: 10_000,
+    });
+    const menu = await openSelectionMenu(page, 'valid credentials');
+
+    await expect(menu).toBeVisible();
+    await expect(menu.getByText('Copy', { exact: true })).toBeVisible();
+  });
+
+  test('a right-click the app cannot answer falls back to the browser menu', async ({ page }) => {
+    await openFixture(page);
+
+    // A painted mark the app holds no selection for. The consumer refuses to
+    // build a menu for it, so suppressing the native one would leave the reader
+    // with no menu at all: no Copy, no spellcheck, no Inspect.
+    await page.evaluate(() => {
+      const p = document.querySelector('.prose p');
+      const mark = document.createElement('mark');
+      mark.className = 'selection-highlight';
+      mark.textContent = 'orphaned highlight';
+      p?.appendChild(mark);
+      (window as unknown as { __prevented: boolean | null }).__prevented = null;
+      document.addEventListener('contextmenu', (e) => {
+        (window as unknown as { __prevented: boolean | null }).__prevented = e.defaultPrevented;
+      });
+    });
+
+    await page.locator('mark.selection-highlight').last().click({ button: 'right' });
+
+    await expect(page.locator('.context-menu-enter')).toHaveCount(0);
+    expect(
+      await page.evaluate(() => (window as unknown as { __prevented: boolean | null }).__prevented),
+    ).toBe(false);
+  });
+
+  test('Copy in the selection menu puts the selected text on the clipboard', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    await openFixture(page);
+    const menu = await openSelectionMenu(page, 'valid credentials');
+    await menu.getByText('Copy', { exact: true }).click();
+
+    await expect
+      .poll(() => page.evaluate(() => navigator.clipboard.readText()), { timeout: 5000 })
+      .toBe('valid credentials');
   });
 });
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -564,23 +564,6 @@ export default function App() {
   const tabCtxMenu = useContextMenu();
   const sidebarCtxMenu = useContextMenu();
 
-  // An overlay taking the screen closes any open context menu. Without this the
-  // palette, settings or the file opener render on top of a menu that is still
-  // live underneath, which is the same two-surfaces-for-one-gesture problem the
-  // pill has with this menu. Keyed on activeModal rather than patched into each
-  // shortcut, so a new overlay inherits it.
-  const closeViewerMenu = viewerCtxMenu.close;
-  const closeExplorerMenu = explorerCtxMenu.close;
-  const closeTabMenu = tabCtxMenu.close;
-  const closeSidebarMenu = sidebarCtxMenu.close;
-  useEffect(() => {
-    if (!activeModal) return;
-    closeViewerMenu();
-    closeExplorerMenu();
-    closeTabMenu();
-    closeSidebarMenu();
-  }, [activeModal, closeViewerMenu, closeExplorerMenu, closeTabMenu, closeSidebarMenu]);
-
   // Triggers for remotely entering edit/reply mode on a CommentCard
   const { requestedEditor, triggerEdit, triggerReply } = useCommentCardTriggers();
 
@@ -896,6 +879,26 @@ export default function App() {
   // it. Close it automatically once the rail becomes available again, so
   // the two surfaces never show at the same time.
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  // An overlay taking the screen closes any open context menu. Without this the
+  // palette, settings, the file opener or the comments drawer render on top of
+  // a menu that is still live underneath, which is the same
+  // two-surfaces-for-one-gesture problem the pill has with this menu. Keyed on
+  // the overlay state rather than patched into each shortcut, so a new overlay
+  // inherits it. The drawer is separate from activeModal but covers the
+  // viewport the same way, and Cmd+\\ opens it with no mousedown for the
+  // menu's own outside-close to catch.
+  const closeViewerMenu = viewerCtxMenu.close;
+  const closeExplorerMenu = explorerCtxMenu.close;
+  const closeTabMenu = tabCtxMenu.close;
+  const closeSidebarMenu = sidebarCtxMenu.close;
+  useEffect(() => {
+    if (!activeModal && !drawerOpen) return;
+    closeViewerMenu();
+    closeExplorerMenu();
+    closeTabMenu();
+    closeSidebarMenu();
+  }, [activeModal, drawerOpen, closeViewerMenu, closeExplorerMenu, closeTabMenu, closeSidebarMenu]);
   useEffect(() => {
     if (railShown) setDrawerOpen(false);
   }, [railShown]);
@@ -1457,8 +1460,11 @@ export default function App() {
       setDiffEnabled(false);
       setDiffPending(false);
       clearSelection();
+      // The viewer's menu holds a SelectionInfo captured in the document being
+      // left. Its items would anchor into the one arriving.
+      closeViewerMenu();
     }
-  }, [activeFilePath, setDiffEnabled, clearSelection, setActiveCommentId]);
+  }, [activeFilePath, setDiffEnabled, clearSelection, setActiveCommentId, closeViewerMenu]);
 
   // IDs of the replies present in newContent but not in oldContent. Kept
   // separate from the two things done with them (marking unread, stamping a
@@ -1976,11 +1982,9 @@ export default function App() {
   } = useContextMenuItems({
     comments,
     enableResolve: settings.enableResolve,
-    templates: settings.templates,
     handleResolve,
     handleUnresolve,
     handleDelete,
-    handleAddComment,
     setActiveCommentId,
     ensureCommentSurface,
     selectionRef: commentableSelectionRef,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -697,9 +697,8 @@ export default function App() {
     );
   }, []);
 
-  const { selection, commentSelection, isPending, clearSelection, lockSelection } = useSelection(
-    proseRef as RefObject<HTMLElement | null>,
-  );
+  const { selection, commentSelection, isPending, clearSelection, lockSelection, adoptSelection } =
+    useSelection(proseRef as RefObject<HTMLElement | null>);
   const requestCommentFocus = useCallback(
     (commentId: string, origin: CommentFocusOrigin = 'jump') =>
       setRequestedCommentFocus({ commentId, token: Date.now(), origin }),
@@ -1968,7 +1967,7 @@ export default function App() {
     setActiveCommentId,
     ensureCommentSurface,
     selectionRef: commentableSelectionRef,
-    lockSelection,
+    adoptSelection,
     setAutoExpandForm,
     triggerEdit,
     triggerReply,
@@ -3366,6 +3365,7 @@ export default function App() {
             items={ctxMenuItems}
             position={viewerCtxMenu.position}
             onClose={viewerCtxMenu.close}
+            preserveSelection
           />
         )}
         {explorerCtxMenu.isOpen && (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -564,6 +564,23 @@ export default function App() {
   const tabCtxMenu = useContextMenu();
   const sidebarCtxMenu = useContextMenu();
 
+  // An overlay taking the screen closes any open context menu. Without this the
+  // palette, settings or the file opener render on top of a menu that is still
+  // live underneath, which is the same two-surfaces-for-one-gesture problem the
+  // pill has with this menu. Keyed on activeModal rather than patched into each
+  // shortcut, so a new overlay inherits it.
+  const closeViewerMenu = viewerCtxMenu.close;
+  const closeExplorerMenu = explorerCtxMenu.close;
+  const closeTabMenu = tabCtxMenu.close;
+  const closeSidebarMenu = sidebarCtxMenu.close;
+  useEffect(() => {
+    if (!activeModal) return;
+    closeViewerMenu();
+    closeExplorerMenu();
+    closeTabMenu();
+    closeSidebarMenu();
+  }, [activeModal, closeViewerMenu, closeExplorerMenu, closeTabMenu, closeSidebarMenu]);
+
   // Triggers for remotely entering edit/reply mode on a CommentCard
   const { requestedEditor, triggerEdit, triggerReply } = useCommentCardTriggers();
 
@@ -3236,6 +3253,7 @@ export default function App() {
               selection={commentSelection}
               isPending={isPending}
               autoExpand={autoExpandForm}
+              hidden={viewerCtxMenu.isOpen}
               onSubmit={(anchor, text, ctxBefore, ctxAfter, hintOffset) => {
                 handleAddComment(anchor, text, ctxBefore, ctxAfter, hintOffset);
                 setAutoExpandForm(false);

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -14,6 +14,13 @@ interface Props {
    * step the pending flow exists for. */
   isPending?: boolean;
   autoExpand?: boolean;
+  /**
+   * Render nothing while the viewer's context menu is open. Both surfaces carry
+   * Comment and the same templates, and the menu's submenu opens straight over
+   * the pill's own template row. Hiding is not unmounting: state survives, so
+   * an expanded composer comes back with whatever was typed into it.
+   */
+  hidden?: boolean;
   onSubmit: (
     anchor: string,
     text: string,
@@ -29,6 +36,7 @@ export function CommentForm({
   selection,
   isPending,
   autoExpand,
+  hidden = false,
   onSubmit,
   onCancel,
   onLock,
@@ -296,6 +304,11 @@ export function CommentForm({
     // already bails, and the pill carries that attribute.
     setShowPillMenu((prev) => !prev);
   };
+
+  // After every hook, and before either branch: rendering nothing is not
+  // unmounting, so an expanded composer keeps its draft while it is out of
+  // sight and comes back with it when the menu closes.
+  if (hidden) return null;
 
   if (!isExpanded) {
     const pillTemplates = TEMPLATES.slice(0, 2);

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -97,6 +97,11 @@ export function CommentForm({
   useEffect(() => {
     if (!isExpanded) return;
     const handler = (e: MouseEvent) => {
+      // Secondary buttons are not dismissals: a right-click on the selection
+      // opens the viewer's context menu, and cancelling here would clear the
+      // selection that menu acts on. Scoped to button 2 rather than "not
+      // primary" so a middle-click still dismisses as it always has.
+      if (e.button === 2) return;
       if (formRef.current && !formRef.current.contains(e.target as Node) && !text.trim()) {
         onCancel();
       }

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -3,6 +3,7 @@ import type { SelectionInfo } from '../types';
 import { useAutoResize } from '../hooks/useAutoResize';
 import { useSettings } from '../contexts/SettingsContext';
 import { getPrimaryModifierLabel } from '../lib/platform';
+import { SELECTION_MARK_SELECTOR } from '../lib/selection-mark';
 
 interface Props {
   selection: SelectionInfo;
@@ -97,14 +98,21 @@ export function CommentForm({
   useEffect(() => {
     if (!isExpanded) return;
     const handler = (e: MouseEvent) => {
-      // Secondary buttons are not dismissals: a right-click on the selection
-      // opens the viewer's context menu, and cancelling here would clear the
-      // selection that menu acts on. Scoped to button 2 rather than "not
-      // primary" so a middle-click still dismisses as it always has.
-      if (e.button === 2) return;
-      if (formRef.current && !formRef.current.contains(e.target as Node) && !text.trim()) {
-        onCancel();
-      }
+      const target = e.target as HTMLElement | null;
+      if (!formRef.current || formRef.current.contains(target) || text.trim()) return;
+      // A press on the text you selected is engagement, not dismissal: it is
+      // how the viewer's context menu is opened, and cancelling here would
+      // clear the selection that menu acts on. Tested by target rather than by
+      // button, because a touch long-press opens the same menu and its
+      // compatibility mousedown reports button 0, indistinguishable from a
+      // left-click. Presses anywhere else still dismiss, whatever the button.
+      if (target?.closest?.(SELECTION_MARK_SELECTOR)) return;
+      // Nor is a press inside a surface that exists to keep the selection
+      // alive. The viewer's context menu carries this attribute and its items
+      // act on the selection, so cancelling here would clear the selection out
+      // from under the item the reader is in the middle of clicking.
+      if (target?.closest?.('[data-preserve-selection]')) return;
+      onCancel();
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -15,10 +15,11 @@ interface Props {
   isPending?: boolean;
   autoExpand?: boolean;
   /**
-   * Render nothing while the viewer's context menu is open. Both surfaces carry
-   * Comment and the same templates, and the menu's submenu opens straight over
-   * the pill's own template row. Hiding is not unmounting: state survives, so
-   * an expanded composer comes back with whatever was typed into it.
+   * Hide while the viewer's context menu is open. Both surfaces carry Comment
+   * and the same templates, and the menu's submenu opens straight over the
+   * pill's own template row. Hidden with visibility rather than by unmounting
+   * or returning null, so the textarea keeps its size, its caret and its node:
+   * a draft comes back exactly as it was left.
    */
   hidden?: boolean;
   onSubmit: (
@@ -277,6 +278,16 @@ export function CommentForm({
     }
   };
 
+  // A browser blurs the focused element when an ancestor becomes invisible, so
+  // an expanded composer comes back caretless after the menu closes. Put focus
+  // where the reader left it.
+  const wasHiddenRef = useRef(hidden);
+  useEffect(() => {
+    const cameBack = wasHiddenRef.current && !hidden;
+    wasHiddenRef.current = hidden;
+    if (cameBack && isExpanded) inputRef.current?.focus();
+  }, [hidden, isExpanded]);
+
   const handleExpand = () => {
     onLock(); // Lock the selection so mouseup events don't clear it
     setIsExpanded(true);
@@ -305,16 +316,23 @@ export function CommentForm({
     setShowPillMenu((prev) => !prev);
   };
 
-  // After every hook, and before either branch: rendering nothing is not
-  // unmounting, so an expanded composer keeps its draft while it is out of
-  // sight and comes back with it when the menu closes.
-  if (hidden) return null;
+  // Hidden with styles rather than by returning null. Returning null discards
+  // the DOM: the textarea comes back at its one-line default because
+  // useAutoResize only runs on input, the caret is gone because the focus
+  // effect only runs on expand, and formRef goes null so the click-outside
+  // dismissal silently stops working while the menu is up. `visibility` rather
+  // than `opacity`, so an invisible composer stays out of the tab order and out
+  // of the accessibility tree; the browser blurs what it hides, so the caret is
+  // put back by the effect above.
+  const surfaceStyle: React.CSSProperties = hidden
+    ? { ...style, visibility: 'hidden', pointerEvents: 'none' }
+    : style;
 
   if (!isExpanded) {
     const pillTemplates = TEMPLATES.slice(0, 2);
     const menuTemplates = TEMPLATES.slice(2);
     return (
-      <div ref={formRef} style={style} data-comment-form>
+      <div ref={formRef} style={surfaceStyle} aria-hidden={hidden || undefined} data-comment-form>
         {showPillMenu && menuTemplates.length > 0 && (
           <div
             data-pill-template-menu
@@ -416,7 +434,8 @@ export function CommentForm({
   return (
     <div
       ref={formRef}
-      style={style}
+      style={surfaceStyle}
+      aria-hidden={hidden || undefined}
       data-comment-form
       className="w-80 bg-surface-raised rounded-xl shadow-xl border border-border overflow-x-hidden overflow-y-auto"
     >

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -178,6 +178,7 @@ export function ContextMenu({ items, position, onClose, preserveSelection = fals
                 {openSubmenuIdx === idx && (
                   <div
                     ref={submenuRef}
+                    data-context-submenu
                     className="fixed z-[201] min-w-[160px] max-w-[240px] py-1 bg-surface-raised rounded-lg shadow-xl border border-border"
                     style={{ left: submenuPos.x, top: submenuPos.y }}
                     onMouseEnter={() => setOpenSubmenuIdx(idx)}

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -130,6 +130,11 @@ export function ContextMenu({ items, position, onClose }: Props) {
         className="fixed z-[200] min-w-[160px] max-w-[240px] py-1 bg-surface-raised rounded-lg shadow-xl border border-border context-menu-enter"
         style={{ left: adjustedPos.x, top: adjustedPos.y }}
         onContextMenu={(e) => e.preventDefault()}
+        /* Items opened on a selection act on it, and some read live state
+           rather than a captured copy. Without this the mouseup that picks an
+           item resolves a selection the viewer has already painted over, gets
+           null, and clears it before the item's click handler runs. */
+        data-preserve-selection
       >
         {items.map((entry, idx) => {
           if (isDivider(entry)) {

--- a/src/components/ContextMenu.tsx
+++ b/src/components/ContextMenu.tsx
@@ -32,9 +32,17 @@ interface Props {
   items: ContextMenuEntry[];
   position: { x: number; y: number };
   onClose: () => void;
+  /**
+   * Keep the document selection alive while this menu is used. Only the
+   * viewer's menu wants it: its items act on the selection, and the mouseup
+   * that picks one would otherwise resolve the collapsed range and clear it.
+   * The explorer, tab and sidebar menus have no such items, and sparing them
+   * would leave a stale selection alive through clicks that should end it.
+   */
+  preserveSelection?: boolean;
 }
 
-export function ContextMenu({ items, position, onClose }: Props) {
+export function ContextMenu({ items, position, onClose, preserveSelection = false }: Props) {
   const menuRef = useRef<HTMLDivElement>(null);
   const [adjustedPos, setAdjustedPos] = useState(position);
   const [openSubmenuIdx, setOpenSubmenuIdx] = useState<number | null>(null);
@@ -130,11 +138,7 @@ export function ContextMenu({ items, position, onClose }: Props) {
         className="fixed z-[200] min-w-[160px] max-w-[240px] py-1 bg-surface-raised rounded-lg shadow-xl border border-border context-menu-enter"
         style={{ left: adjustedPos.x, top: adjustedPos.y }}
         onContextMenu={(e) => e.preventDefault()}
-        /* Items opened on a selection act on it, and some read live state
-           rather than a captured copy. Without this the mouseup that picks an
-           item resolves a selection the viewer has already painted over, gets
-           null, and clears it before the item's click handler runs. */
-        data-preserve-selection
+        {...(preserveSelection ? { 'data-preserve-selection': '' } : {})}
       >
         {items.map((entry, idx) => {
           if (isDivider(entry)) {

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -21,12 +21,21 @@ import {
   scheduleMermaidLayoutStabilization,
 } from '../lib/mermaid-highlights';
 import { SELECTION_MARK_CLASS, SELECTION_MARK_SELECTOR } from '../lib/selection-mark';
+import { isSecondaryClick } from '../lib/platform';
 
 export interface ViewerContextMenuInfo {
   /** 'selection' when user right-clicks on selected text; 'highlight' when on a comment mark */
   type: 'selection' | 'highlight';
   /** Comment IDs (only for 'highlight' type) */
   commentIds?: string[];
+  /**
+   * The live native selection this was resolved from, when the menu came from
+   * a range rather than a painted mark. The consumer compares it with the
+   * committed selection: a drag made while the selection was locked leaves the
+   * two holding different text, and a menu built from the committed one would
+   * sit over one passage while acting on another.
+   */
+  liveText?: string;
   /** Screen coordinates for the menu */
   x: number;
   y: number;
@@ -618,12 +627,13 @@ export const MarkdownViewer = memo(
 
     const handleContextMenu = (e: React.MouseEvent) => {
       if (!onCtxMenu) return;
-      // Shift+right-click asks for the browser's own menu, which is what the
-      // chord already means in Chrome on Windows and Linux. Gated on a real
-      // secondary button, because Shift+F10 is the standard KEYBOARD chord for
-      // the context menu: it arrives with shiftKey set and button 0, so testing
-      // shiftKey alone would lock keyboard users out of this menu entirely.
-      if (e.shiftKey && e.button === 2) return;
+      // Shift plus the platform's secondary click asks for the browser's own
+      // menu, which is what the chord already means in Chrome on Windows and
+      // Linux. Gated on that click rather than on shiftKey alone, because
+      // Shift+F10 is the standard KEYBOARD chord for the context menu and
+      // arrives with shiftKey set and button 0: testing shiftKey by itself
+      // would lock keyboard users out of this menu entirely.
+      if (e.shiftKey && isSecondaryClick(e)) return;
 
       // Check if right-click is on a comment highlight
       const mark = markToAct(e.target as HTMLElement);
@@ -654,12 +664,9 @@ export const MarkdownViewer = memo(
       // A selection the viewer has not painted (nothing committed yet) still
       // has a live native range, so keep testing for one.
       const sel = window.getSelection();
-      if (
-        sel &&
-        sel.toString().trim().length > 0 &&
-        containerRef.current?.contains(sel.anchorNode)
-      ) {
-        if (onCtxMenu({ type: 'selection', x: e.clientX, y: e.clientY })) {
+      const liveText = sel?.toString().trim() ?? '';
+      if (sel && liveText.length > 0 && containerRef.current?.contains(sel.anchorNode)) {
+        if (onCtxMenu({ type: 'selection', liveText, x: e.clientX, y: e.clientY })) {
           e.preventDefault();
         }
         return;

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -40,7 +40,8 @@ interface Props {
   selectionOffset: number | null;
   onHighlightClick: (commentId: string) => void;
   onLocalLinkClick?: (path: string, fragment?: string) => void;
-  onContextMenu?: (info: ViewerContextMenuInfo) => void;
+  /** Returns whether it opened a menu; the native one is suppressed only then. */
+  onContextMenu?: (info: ViewerContextMenuInfo) => boolean;
   enableResolve?: boolean;
   sentCommentIds?: string[];
   searchQuery?: string;
@@ -71,6 +72,15 @@ export interface TocHeading {
  * useDragHandles checks status, so this omission is the only thing enforcing
  * that.
  */
+/**
+ * The class the viewer paints a committed selection with, and the selector for
+ * finding it again. Right-click resolution reads the painted mark rather than
+ * the native range, so the two have to agree; keeping one name is what makes
+ * that true by construction.
+ */
+const SELECTION_MARK_CLASS = 'selection-highlight';
+const SELECTION_MARK_SELECTOR = `mark.${SELECTION_MARK_CLASS}`;
+
 const COMMENT_MARK_SELECTOR =
   '.comment-highlight, .comment-highlight-sent, .comment-highlight-resolved, .mermaid-comment-highlight';
 
@@ -492,7 +502,7 @@ export const MarkdownViewer = memo(
           container,
           selectionText,
           (mark) => {
-            mark.className = 'selection-highlight';
+            mark.className = SELECTION_MARK_CLASS;
           },
           selectionOffset ?? undefined,
           undefined,
@@ -620,21 +630,40 @@ export const MarkdownViewer = memo(
       // Check if right-click is on a comment highlight
       const mark = markToAct(e.target as HTMLElement);
       if (mark?.dataset.commentIds) {
-        e.preventDefault();
         const ids = mark.dataset.commentIds.split(',');
-        onCtxMenu({ type: 'highlight', commentIds: ids, x: e.clientX, y: e.clientY });
+        // preventDefault only if a menu actually opened: the consumer refuses a
+        // mark whose comment is gone, and eating the native menu for a menu
+        // that never appears leaves the reader with no menu at all.
+        if (onCtxMenu({ type: 'highlight', commentIds: ids, x: e.clientX, y: e.clientY })) {
+          e.preventDefault();
+        }
         return;
       }
 
-      // Check if there is a text selection within the container
+      // The viewer paints the committed selection as mark.selection-highlight,
+      // which replaces the selected text nodes and so collapses the browser's
+      // own range. By the time a right-click arrives there is no native
+      // selection left for the check below to find, which is why right-clicking
+      // one's own selection fell through to the browser's menu. The painted
+      // mark IS the selection, so recognize it directly.
+      if ((e.target as HTMLElement).closest(SELECTION_MARK_SELECTOR)) {
+        if (onCtxMenu({ type: 'selection', x: e.clientX, y: e.clientY })) {
+          e.preventDefault();
+        }
+        return;
+      }
+
+      // A selection the viewer has not painted (nothing committed yet) still
+      // has a live native range, so keep testing for one.
       const sel = window.getSelection();
       if (
         sel &&
         sel.toString().trim().length > 0 &&
         containerRef.current?.contains(sel.anchorNode)
       ) {
-        e.preventDefault();
-        onCtxMenu({ type: 'selection', x: e.clientX, y: e.clientY });
+        if (onCtxMenu({ type: 'selection', x: e.clientX, y: e.clientY })) {
+          e.preventDefault();
+        }
         return;
       }
     };

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -20,6 +20,7 @@ import {
   getMermaidHighlightTheme,
   scheduleMermaidLayoutStabilization,
 } from '../lib/mermaid-highlights';
+import { SELECTION_MARK_CLASS, SELECTION_MARK_SELECTOR } from '../lib/selection-mark';
 
 export interface ViewerContextMenuInfo {
   /** 'selection' when user right-clicks on selected text; 'highlight' when on a comment mark */
@@ -72,15 +73,6 @@ export interface TocHeading {
  * useDragHandles checks status, so this omission is the only thing enforcing
  * that.
  */
-/**
- * The class the viewer paints a committed selection with, and the selector for
- * finding it again. Right-click resolution reads the painted mark rather than
- * the native range, so the two have to agree; keeping one name is what makes
- * that true by construction.
- */
-const SELECTION_MARK_CLASS = 'selection-highlight';
-const SELECTION_MARK_SELECTOR = `mark.${SELECTION_MARK_CLASS}`;
-
 const COMMENT_MARK_SELECTOR =
   '.comment-highlight, .comment-highlight-sent, .comment-highlight-resolved, .mermaid-comment-highlight';
 
@@ -626,6 +618,12 @@ export const MarkdownViewer = memo(
 
     const handleContextMenu = (e: React.MouseEvent) => {
       if (!onCtxMenu) return;
+      // Shift+right-click asks for the browser's own menu, which is what the
+      // chord already means in Chrome on Windows and Linux. Gated on a real
+      // secondary button, because Shift+F10 is the standard KEYBOARD chord for
+      // the context menu: it arrives with shiftKey set and button 0, so testing
+      // shiftKey alone would lock keyboard users out of this menu entirely.
+      if (e.shiftKey && e.button === 2) return;
 
       // Check if right-click is on a comment highlight
       const mark = markToAct(e.target as HTMLElement);

--- a/src/hooks/useContextMenuItems.ts
+++ b/src/hooks/useContextMenuItems.ts
@@ -128,8 +128,14 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
   const [tabCtxMenuItems, setTabCtxMenuItems] = useState<ContextMenuEntry[]>([]);
   const [sidebarCtxMenuItems, setSidebarCtxMenuItems] = useState<ContextMenuEntry[]>([]);
 
+  /**
+   * Returns whether a menu was opened. The viewer suppresses the browser's own
+   * menu only when this says yes: a right-click that opens nothing and also
+   * eats the native menu is a dead gesture, with no Copy, no spellcheck and no
+   * Inspect, and nothing on screen to explain it.
+   */
   const handleViewerContextMenu = useCallback(
-    (info: ViewerContextMenuInfo) => {
+    (info: ViewerContextMenuInfo): boolean => {
       explorerCtxMenu.close();
       tabCtxMenu.close();
       sidebarCtxMenu.close();
@@ -137,7 +143,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
       if (info.type === 'highlight' && info.commentIds?.length) {
         const commentId = info.commentIds[0];
         const comment = comments.find((c) => c.id === commentId);
-        if (!comment) return;
+        if (!comment) return false;
 
         const isResolved = enableResolve && getEffectiveStatus(comment) === 'resolved';
 
@@ -208,9 +214,10 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
 
         setCtxMenuItems(items);
         viewerCtxMenu.open(info.x, info.y);
+        return true;
       } else if (info.type === 'selection') {
         const sel = selectionRef.current;
-        if (!sel) return;
+        if (!sel) return false;
 
         const templateItems: ContextMenuItem[] = templates.map((t) => ({
           label: t.label,
@@ -242,7 +249,9 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
 
         setCtxMenuItems(items);
         viewerCtxMenu.open(info.x, info.y);
+        return true;
       }
+      return false;
     },
     [
       comments,

--- a/src/hooks/useContextMenuItems.ts
+++ b/src/hooks/useContextMenuItems.ts
@@ -43,7 +43,8 @@ export interface UseContextMenuItemsParams {
    */
   ensureCommentSurface: (commentId?: string) => void;
   selectionRef: RefObject<SelectionInfo | null>;
-  lockSelection: () => void;
+  /** Commit and lock a selection the menu captured when it opened. */
+  adoptSelection: (info: SelectionInfo) => void;
   setAutoExpandForm: Dispatch<SetStateAction<boolean>>;
   triggerEdit: (id: string) => void;
   triggerReply: (id: string) => void;
@@ -101,7 +102,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
     setActiveCommentId,
     ensureCommentSurface,
     selectionRef,
-    lockSelection,
+    adoptSelection,
     setAutoExpandForm,
     triggerEdit,
     triggerReply,
@@ -230,7 +231,11 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
           {
             label: 'Comment',
             onClick: () => {
-              lockSelection();
+              // The captured selection, not live state: the other items in this
+              // menu already act on `sel`, and locking whatever happens to be
+              // selected at click time is how a cleared selection wedged the
+              // lock and made the document unselectable.
+              adoptSelection(sel);
               setAutoExpandForm(true);
             },
           },
@@ -261,7 +266,7 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
       handleUnresolve,
       handleDelete,
       handleAddComment,
-      lockSelection,
+      adoptSelection,
       ensureCommentSurface,
       triggerEdit,
       triggerReply,

--- a/src/hooks/useContextMenuItems.ts
+++ b/src/hooks/useContextMenuItems.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, type RefObject, type Dispatch, type SetStateAction } from 'react';
-import type { ContextMenuEntry, ContextMenuItem } from '../components/ContextMenu';
+import type { ContextMenuEntry } from '../components/ContextMenu';
 import type { ViewerContextMenuInfo, MarkdownViewerHandle } from '../components/MarkdownViewer';
 import type { ExplorerContextMenuInfo } from '../components/FileExplorer';
 import type { TabContextMenuInfo } from '../components/TabBar';
@@ -13,25 +13,12 @@ type ContextMenuInstance = {
   close: () => void;
 };
 
-interface CommentTemplate {
-  label: string;
-  text: string;
-}
-
 export interface UseContextMenuItemsParams {
   comments: MdComment[];
   enableResolve: boolean;
-  templates: CommentTemplate[];
   handleResolve: (id: string) => void;
   handleUnresolve: (id: string) => void;
   handleDelete: (id: string) => void;
-  handleAddComment: (
-    anchor: string,
-    text: string,
-    contextBefore?: string,
-    contextAfter?: string,
-    hintOffset?: number,
-  ) => void;
   setActiveCommentId: Dispatch<SetStateAction<string | null>>;
   /**
    * Opens whichever comment surface can currently show one (the rail when it
@@ -94,11 +81,9 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
   const {
     comments,
     enableResolve,
-    templates,
     handleResolve,
     handleUnresolve,
     handleDelete,
-    handleAddComment,
     setActiveCommentId,
     ensureCommentSurface,
     selectionRef,
@@ -219,13 +204,11 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
       } else if (info.type === 'selection') {
         const sel = selectionRef.current;
         if (!sel) return false;
-
-        const templateItems: ContextMenuItem[] = templates.map((t) => ({
-          label: t.label,
-          onClick: () => {
-            handleAddComment(sel.text, t.text, sel.contextBefore, sel.contextAfter, sel.offset);
-          },
-        }));
+        // When the viewer resolved this from a live range rather than the
+        // painted mark, that range has to BE the committed selection. While a
+        // selection is locked a fresh drag never reaches the app, so the two
+        // hold different text and every item here would act on the wrong one.
+        if (info.liveText && info.liveText !== sel.text) return false;
 
         const items: ContextMenuEntry[] = [
           {
@@ -238,10 +221,6 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
               adoptSelection(sel);
               setAutoExpandForm(true);
             },
-          },
-          {
-            label: 'Templates',
-            items: templateItems,
           },
           { type: 'divider' as const },
           {
@@ -261,11 +240,9 @@ export function useContextMenuItems(params: UseContextMenuItemsParams) {
     [
       comments,
       enableResolve,
-      templates,
       handleResolve,
       handleUnresolve,
       handleDelete,
-      handleAddComment,
       adoptSelection,
       ensureCommentSurface,
       triggerEdit,

--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -37,9 +37,9 @@ function pointerDown(pointerType: string) {
  * primary button commits or clears a selection. Dispatching a bare Event here
  * left `button` undefined, which is not a state the browser can produce.
  */
-function mouseUp(button = 0) {
+function mouseUp(button = 0, target: EventTarget = document) {
   act(() => {
-    document.dispatchEvent(new MouseEvent('mouseup', { button }));
+    target.dispatchEvent(new MouseEvent('mouseup', { button, bubbles: true }));
   });
 }
 
@@ -73,7 +73,7 @@ describe('useSelection modality routing', () => {
     expect(hook().pendingSelection).toBeNull();
   });
 
-  it('leaves a committed selection alone on a secondary-button mouseup', () => {
+  it('leaves a committed selection alone when the secondary press lands on it', () => {
     pointerDown('mouse');
     mouseUp();
     expect(hook().selection).toEqual(INFO);
@@ -82,9 +82,27 @@ describe('useSelection modality routing', () => {
     // act on it. Resolving again here would find the collapsed native range,
     // return null, and clear the selection out from under the menu.
     mockResolve.mockReturnValue(null);
+    const painted = document.createElement('mark');
+    painted.className = 'selection-highlight';
+    document.body.appendChild(painted);
+    pointerDown('mouse');
+    mouseUp(2, painted);
+    expect(hook().selection).toEqual(INFO);
+    painted.remove();
+  });
+
+  it('clears a committed selection when a secondary press lands elsewhere', () => {
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection).toEqual(INFO);
+
+    // Sparing every secondary press would leave this selection committed while
+    // its pill floats over unrelated text, and the next context menu would
+    // build on it rather than on what the reader pointed at.
+    mockResolve.mockReturnValue(null);
     pointerDown('mouse');
     mouseUp(2);
-    expect(hook().selection).toEqual(INFO);
+    expect(hook().selection).toBeNull();
   });
 
   it('does not open on mouseup when the gesture was touch', () => {

--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -91,6 +91,23 @@ describe('useSelection modality routing', () => {
     painted.remove();
   });
 
+  it('clears a committed selection on a middle-click, which opens no menu', () => {
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection).toEqual(INFO);
+
+    // Only the secondary click is spared. The middle button opens no context
+    // menu, so it should end a selection the way any other press does.
+    mockResolve.mockReturnValue(null);
+    const painted = document.createElement('mark');
+    painted.className = 'selection-highlight';
+    document.body.appendChild(painted);
+    pointerDown('mouse');
+    mouseUp(1, painted);
+    expect(hook().selection).toBeNull();
+    painted.remove();
+  });
+
   it('clears a committed selection when a secondary press lands elsewhere', () => {
     pointerDown('mouse');
     mouseUp();

--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -32,9 +32,14 @@ function pointerDown(pointerType: string) {
   });
 }
 
-function mouseUp() {
+/**
+ * A real mouseup always carries a button, and the hook now reads it: only the
+ * primary button commits or clears a selection. Dispatching a bare Event here
+ * left `button` undefined, which is not a state the browser can produce.
+ */
+function mouseUp(button = 0) {
   act(() => {
-    document.dispatchEvent(new Event('mouseup'));
+    document.dispatchEvent(new MouseEvent('mouseup', { button }));
   });
 }
 
@@ -66,6 +71,20 @@ describe('useSelection modality routing', () => {
     mouseUp();
     expect(hook().selection).toEqual(INFO);
     expect(hook().pendingSelection).toBeNull();
+  });
+
+  it('leaves a committed selection alone on a secondary-button mouseup', () => {
+    pointerDown('mouse');
+    mouseUp();
+    expect(hook().selection).toEqual(INFO);
+
+    // Right-clicking the selection opens the viewer's context menu, whose items
+    // act on it. Resolving again here would find the collapsed native range,
+    // return null, and clear the selection out from under the menu.
+    mockResolve.mockReturnValue(null);
+    pointerDown('mouse');
+    mouseUp(2);
+    expect(hook().selection).toEqual(INFO);
   });
 
   it('does not open on mouseup when the gesture was touch', () => {

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -100,6 +100,14 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
 
     const handleMouseUp = (e: MouseEvent) => {
       if (lastPointerType !== 'mouse') return;
+      // A secondary button never commits or clears a selection. Right-clicking
+      // your own selection opens the viewer's context menu, whose items act on
+      // that selection, and resolveSelection below would return null for it:
+      // the viewer has painted the selection as a mark, which collapses the
+      // native range. So this handler would destroy the selection the menu was
+      // opened on. It also decouples the fix from event ordering, since Windows
+      // fires contextmenu after mouseup rather than before it.
+      if (e.button !== 0) return;
       if (lockedRef.current) return;
       if ((e.target as Element)?.closest?.('[data-comment-form]')) return;
       if ((e.target as Element)?.closest?.('[data-drag-handle]')) return;

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { resolveSelection } from '../lib/selection-resolver';
+import { SELECTION_MARK_SELECTOR } from '../lib/selection-mark';
 import type { SelectionInfo } from '../types';
 
 export function useSelection(containerRef: React.RefObject<HTMLElement | null>) {
@@ -52,6 +53,22 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
     setSelection(info);
   }, []);
 
+  /**
+   * Commit an already-resolved selection and lock it, because every caller is
+   * about to act on it. The context menu builds its items from a snapshot taken
+   * when the menu opened; locking live state instead means that if anything has
+   * cleared the selection in between, `lockedRef` is set with nothing committed
+   * and stays set, which silently ignores every later selection in the
+   * document. Delegates to commitSelection, so the two-writer rule above holds.
+   */
+  const adoptSelection = useCallback(
+    (info: SelectionInfo) => {
+      commitSelection(info);
+      lockedRef.current = true;
+    },
+    [commitSelection],
+  );
+
   const clearSelection = useCallback(() => {
     lockedRef.current = false;
     commitSelection(null);
@@ -100,14 +117,19 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
 
     const handleMouseUp = (e: MouseEvent) => {
       if (lastPointerType !== 'mouse') return;
-      // A secondary button never commits or clears a selection. Right-clicking
-      // your own selection opens the viewer's context menu, whose items act on
-      // that selection, and resolveSelection below would return null for it:
-      // the viewer has painted the selection as a mark, which collapses the
-      // native range. So this handler would destroy the selection the menu was
-      // opened on. It also decouples the fix from event ordering, since Windows
-      // fires contextmenu after mouseup rather than before it.
-      if (e.button !== 0) return;
+      // A secondary press ON the selection is spared, and only there. That
+      // gesture opens the viewer's context menu, whose items act on the
+      // selection, and resolveSelection below would return null for it: the
+      // viewer has painted the selection as a mark, which collapses the native
+      // range. So this handler would destroy the selection the menu was opened
+      // on. It also decouples that from event ordering, since Windows fires
+      // contextmenu after mouseup rather than before it.
+      //
+      // Anywhere else a secondary press clears like any other click. Sparing
+      // it everywhere leaves a stale selection committed with its pill floating
+      // over unrelated text, and the next menu builds on that stale selection
+      // rather than on what the reader pointed at.
+      if (e.button !== 0 && (e.target as HTMLElement)?.closest?.(SELECTION_MARK_SELECTOR)) return;
       if (lockedRef.current) return;
       if ((e.target as Element)?.closest?.('[data-comment-form]')) return;
       if ((e.target as Element)?.closest?.('[data-drag-handle]')) return;
@@ -199,6 +221,7 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
     isPending: !selection && pendingSelection !== null,
     clearSelection,
     lockSelection,
+    adoptSelection,
     commitPendingSelection,
   };
 }

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { resolveSelection } from '../lib/selection-resolver';
 import { SELECTION_MARK_SELECTOR } from '../lib/selection-mark';
+import { isSecondaryClick } from '../lib/platform';
 import type { SelectionInfo } from '../types';
 
 export function useSelection(containerRef: React.RefObject<HTMLElement | null>) {
@@ -129,7 +130,9 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
       // it everywhere leaves a stale selection committed with its pill floating
       // over unrelated text, and the next menu builds on that stale selection
       // rather than on what the reader pointed at.
-      if (e.button !== 0 && (e.target as HTMLElement)?.closest?.(SELECTION_MARK_SELECTOR)) return;
+      if (isSecondaryClick(e) && (e.target as HTMLElement)?.closest?.(SELECTION_MARK_SELECTOR)) {
+        return;
+      }
       if (lockedRef.current) return;
       if ((e.target as Element)?.closest?.('[data-comment-form]')) return;
       if ((e.target as Element)?.closest?.('[data-drag-handle]')) return;

--- a/src/lib/platform.ts
+++ b/src/lib/platform.ts
@@ -12,3 +12,19 @@ export function isApplePlatform(): boolean {
 export function getPrimaryModifierLabel(): 'Cmd' | 'Ctrl' {
   return isApplePlatform() ? 'Cmd' : 'Ctrl';
 }
+
+/**
+ * Whether a pointer event is the platform's secondary click.
+ *
+ * macOS sends ctrl+click as the secondary click, and it arrives with
+ * `button: 0` and `ctrlKey: true`, so testing the button alone misses the
+ * gesture most Mac users make to open a context menu. Elsewhere ctrl+click is
+ * an ordinary primary click (multi-select, open-in-new-tab) and must stay one.
+ *
+ * Only buttons 2 and the macOS chord count. `button !== 0` would sweep in the
+ * middle button and the side buttons, which open no menu and should go on
+ * clearing a selection the way any other press does.
+ */
+export function isSecondaryClick(e: { button: number; ctrlKey: boolean }): boolean {
+  return e.button === 2 || (e.button === 0 && e.ctrlKey && isApplePlatform());
+}

--- a/src/lib/selection-mark.ts
+++ b/src/lib/selection-mark.ts
@@ -1,0 +1,11 @@
+/**
+ * The class the viewer paints a committed selection with, and the selector for
+ * finding it again.
+ *
+ * Three modules have to agree on this string: `MarkdownViewer` paints it and
+ * resolves right-clicks from it, `useSelection` spares a secondary press that
+ * lands on it, and `CommentForm` refuses to read such a press as a dismissal.
+ * A second copy of the literal is how one of them silently stops matching.
+ */
+export const SELECTION_MARK_CLASS = 'selection-highlight';
+export const SELECTION_MARK_SELECTOR = `mark.${SELECTION_MARK_CLASS}`;


### PR DESCRIPTION
Right-clicking a text selection in the rendered view gave you Chrome's menu, not the viewer's. Comment, Templates and Copy were all unreachable there, and had been since March: the highlight painting is in the initial commit and the menu's selection branch landed six days later.

Closes #85.

## Why it never worked

`handleContextMenu` opened the menu only while `window.getSelection()` still held a range inside the container, and it never does by then. Committing a selection re-runs the render layout effect, whose deps include `selectionText`, and that effect's first act is `container.innerHTML = sanitizeRenderedMarkdown(html)`. The subtree is replaced and the range dies there, before any mark is painted.

So the menu opens from the painted mark now, with the range check kept beneath it for a selection the viewer has not painted yet.

## What it took to make the menu usable

Opening it was half the work. Each of these was a defect found after the previous fix, most of them by driving the app rather than reading it:

- **The gesture that opens the menu was destroying the selection it acts on.** `useSelection` now spares a secondary press that lands on the selection's own mark, and only there: sparing every non-primary press everywhere let a stale selection outlive a right-click elsewhere, so the next menu built on the wrong text.
- **Picking an item cleared it the same way**, through the mouseup that closes the menu. The menu carries `data-preserve-selection`, and two listeners respect it: `useSelection`'s mouseup and `CommentForm`'s dismissal.
- **Comment read live state**, so with the selection already cleared it set `lockedRef` with nothing committed and never released it, silently ignoring every later selection in the document. It adopts the captured `SelectionInfo` now.
- **ctrl+click is the macOS secondary click** and arrives with `button: 0`, so both guards missed the gesture most Mac users make. `isSecondaryClick` covers button 2 plus that chord on Apple platforms, and deliberately not the middle button.
- **The pill and the menu stacked**, offering Comment twice with the submenu opening over the pill's own template row. The pill hides while the menu is up, with `visibility` rather than by unmounting, so a draft keeps its size and caret.
- **`preventDefault` ran before the consumer had a say**, so a right-click it refuses ate the browser's menu and opened nothing.

Templates are gone from the menu. They made one label mean two things, since the pill's prefill the composer while the menu's posted immediately. Comment opens the composer, and the templates live there.

## Tests

23 in `context-menu.spec.ts`, which previously covered the comment-highlight, tab and rail-card menus but never a plain selection. The suite ran at the shipped default of quick comment off, where the composer is a collapsed pill and half these paths are unreachable, so three tests now pin the setting on. The ctrl+click test is platform-gated, since CI runs e2e on ubuntu and Blink only converts that chord on macOS.

## Deliberately not fixed here

- #86, the root cause: selection paint is coupled to the document rebuild. Decoupling it would let most of the machinery above be deleted rather than maintained, and it touches the renderer everything else reads from, so it wants its own branch.
- #87, three ways the menu's captured selection goes stale.
- #88, a selection overlapping a comment opens the comment menu, so Copy is unreachable on commented text. Pre-existing precedence, and a product call.
