### PR TITLE
Clamp a selection to the prose instead of rejecting it

### DIFF
--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -467,6 +467,47 @@ test.describe('Context menu on a text selection', () => {
     await expect(page.locator('.context-menu-enter')).toHaveCount(0);
   });
 
+  test('a drag released in the empty area below the text still commits', async ({ page }) => {
+    await openFixture(page);
+    // Measure after the document has settled: openFixture waits for .prose to
+    // exist, and geometry read before layout finishes sends the drag somewhere
+    // else entirely.
+    await expect(page.getByRole('heading', { name: 'Test Document' })).toBeVisible({
+      timeout: 10_000,
+    });
+    await page.waitForTimeout(300);
+    const from = await page.evaluate(() => {
+      const p = document.querySelector('.prose p') as HTMLElement;
+      const r = document.createRange();
+      r.selectNodeContents(p);
+      const rect = r.getBoundingClientRect();
+      return { x: rect.left + 5, y: rect.top + rect.height / 2 };
+    });
+    // Below the last line, but inside the viewport: a drag past the bottom edge
+    // is a different gesture (autoscroll) and would not test this.
+    const releaseY = await page.evaluate(() => {
+      const bottom = (document.querySelector('.prose') as HTMLElement).getBoundingClientRect()
+        .bottom;
+      return Math.min(bottom + 60, window.innerHeight - 10);
+    });
+
+    // Letting go past the last line carries the range's end into a layout
+    // wrapper above the prose, which used to throw the whole selection away:
+    // native highlight painted, nothing committed, and the right-click that
+    // followed reached the browser's menu.
+    await page.mouse.move(from.x, from.y);
+    await page.mouse.down();
+    await page.mouse.move(from.x + 200, releaseY, { steps: 12 });
+    await page.mouse.up();
+
+    await expect(page.locator('mark.selection-highlight').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('[data-comment-form]')).toBeVisible();
+
+    const menu = page.locator('.context-menu-enter');
+    await page.locator('mark.selection-highlight').first().click({ button: 'right' });
+    await expect(menu).toBeVisible();
+  });
+
   test('Copy in the selection menu puts the selected text on the clipboard', async ({
     page,
     context,

--- a/src/lib/selection-resolver.test.ts
+++ b/src/lib/selection-resolver.test.ts
@@ -67,6 +67,43 @@ describe('resolveSelection', () => {
     expect(resolveSelection(container)).toBeNull();
   });
 
+  it('resolves a drag that ends outside the container, clamped to it', () => {
+    // Releasing the mouse in the sheet's empty area leaves the range ending
+    // outside the prose, so its common ancestor is a layout wrapper ABOVE the
+    // container. Rejecting on containment threw the whole selection away: no
+    // pill, no painted mark, and a right-click that fell through to the
+    // browser's menu.
+    document.body.innerHTML =
+      '<div id="page"><div id="root">The quick brown fox jumps over the lazy dog</div><div id="after">trailing</div></div>';
+    const container = document.getElementById('root')!;
+    const textNode = container.firstChild!;
+    const outside = document.getElementById('after')!.firstChild!;
+
+    const range = document.createRange();
+    range.setStart(textNode, 4);
+    range.setEnd(outside, 8);
+
+    mockSelection({ text: 'quick brown fox jumps over the lazy dogtrailing', range });
+
+    const result = resolveSelection(container);
+    expect(result).not.toBeNull();
+    expect(result!.text).toBe('quick brown fox jumps over the lazy dog');
+  });
+
+  it('returns null when the selection does not touch the container at all', () => {
+    document.body.innerHTML =
+      '<div id="page"><div id="root">inside text</div><div id="after">outside text</div></div>';
+    const container = document.getElementById('root')!;
+    const outside = document.getElementById('after')!.firstChild!;
+
+    const range = document.createRange();
+    range.setStart(outside, 0);
+    range.setEnd(outside, 7);
+
+    mockSelection({ text: 'outside', range });
+    expect(resolveSelection(container)).toBeNull();
+  });
+
   it('returns correct contextBefore and contextAfter for a mid-document selection', () => {
     const content = 'The quick brown fox jumps over the lazy dog and then some more text follows';
     document.body.innerHTML = `<div id="root">${content}</div>`;

--- a/src/lib/selection-resolver.ts
+++ b/src/lib/selection-resolver.ts
@@ -2,16 +2,45 @@ import type { SelectionInfo } from '../types';
 import { buildRangeHtml } from './copy-selection-html';
 import { getVisibleTextContent, getVisibleTextOffset } from './visible-text';
 
+/**
+ * The part of `range` that lies inside `containerEl`, or null if none of it
+ * does.
+ *
+ * A drag that ends in the sheet's empty area below the text does not stop at
+ * the last character: the browser carries the range's end into whatever layout
+ * element the pointer was over, so its `commonAncestorContainer` is a wrapper
+ * ABOVE the prose. Testing containment on that ancestor threw the entire
+ * selection away, leaving the native highlight painted with no pill, no mark,
+ * and a right-click that reached the browser's menu instead of the viewer's.
+ * Clamping keeps what the reader actually selected inside the document and
+ * drops the overshoot.
+ */
+function clampToContainer(range: Range, containerEl: HTMLElement): Range | null {
+  const bounds = containerEl.ownerDocument.createRange();
+  bounds.selectNodeContents(containerEl);
+
+  const clamped = range.cloneRange();
+  if (clamped.compareBoundaryPoints(Range.START_TO_START, bounds) < 0) {
+    clamped.setStart(bounds.startContainer, bounds.startOffset);
+  }
+  if (clamped.compareBoundaryPoints(Range.END_TO_END, bounds) > 0) {
+    clamped.setEnd(bounds.endContainer, bounds.endOffset);
+  }
+  // A selection entirely outside the container clamps to nothing, which is the
+  // case the old containment check was right about.
+  return clamped.collapsed ? null : clamped;
+}
+
 export function resolveSelection(containerEl: HTMLElement): SelectionInfo | null {
   const sel = window.getSelection();
-  if (!sel || sel.isCollapsed) return null;
+  if (!sel || sel.isCollapsed || sel.rangeCount === 0) return null;
 
-  const rawText = sel.toString();
+  const range = clampToContainer(sel.getRangeAt(0), containerEl);
+  if (!range) return null;
+
+  const rawText = range.toString();
   const text = rawText.trim();
   if (!text || text.length < 2) return null;
-
-  const range = sel.getRangeAt(0);
-  if (!containerEl.contains(range.commonAncestorContainer)) return null;
 
   // Get surrounding context from the rendered text
   const fullText = getVisibleTextContent(containerEl);


### PR DESCRIPTION
Drag across text and let go in the empty area below the last line: the browser's own blue highlight stays, and nothing else happens. No pill, no painted mark, and a right-click gives Chrome's menu. Let go while still over text and it all behaves.

Closes #90.

## Why

`resolveSelection` tested containment on the range's `commonAncestorContainer`. A drag does not stop at the last character: releasing past the end of the text carries the range's end into whatever layout element the pointer was over, so that ancestor climbs above `.prose` and the whole selection was thrown away over an overshoot at its end.

Measured in the running app:

```
release in whitespace:  native selection 406 chars
                        commonAncestor  DIV.flex-1, a wrapper above .prose
                        painted marks 0, pill 0
release on text:        painted marks 2, pill 1
```

The right-click falling through to the browser is a consequence rather than a second bug: nothing was committed, so there is no `mark.selection-highlight` for the viewer's handler to recognise. Same shape as #85 from a different direction, and pre-existing.

## The change

Clamp the range to the container instead of testing containment on it. Keep the part inside the document, drop the overshoot, and return null only when the selection does not touch the container at all, which is the case the old check was right about.

## Tests

Two unit tests, one for the clamped drag and one for a selection entirely outside the container, plus an e2e test that performs the real gesture and asserts the mark, the pill and the menu that follows.

That e2e test flaked at first because it read geometry before the document had settled, which sent the drag somewhere else entirely. It waits for the heading now and passes six for six.
