### PR TITLE
Keep the blank line between blocks in a resolved selection

### DIFF
--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -469,42 +469,39 @@ test.describe('Context menu on a text selection', () => {
 
   test('a drag released in the empty area below the text still commits', async ({ page }) => {
     await openFixture(page);
-    // Measure after the document has settled: openFixture waits for .prose to
-    // exist, and geometry read before layout finishes sends the drag somewhere
-    // else entirely.
     await expect(page.getByRole('heading', { name: 'Test Document' })).toBeVisible({
       timeout: 10_000,
     });
-    await page.waitForTimeout(300);
-    const from = await page.evaluate(() => {
-      const p = document.querySelector('.prose p') as HTMLElement;
-      const r = document.createRange();
-      r.selectNodeContents(p);
-      const rect = r.getBoundingClientRect();
-      return { x: rect.left + 5, y: rect.top + rect.height / 2 };
-    });
-    // Below the last line, but inside the viewport: a drag past the bottom edge
-    // is a different gesture (autoscroll) and would not test this.
-    const releaseY = await page.evaluate(() => {
-      const bottom = (document.querySelector('.prose') as HTMLElement).getBoundingClientRect()
-        .bottom;
-      return Math.min(bottom + 60, window.innerHeight - 10);
-    });
 
-    // Letting go past the last line carries the range's end into a layout
-    // wrapper above the prose, which used to throw the whole selection away:
-    // native highlight painted, nothing committed, and the right-click that
-    // followed reached the browser's menu.
-    // If the fixture ever grows past the viewport this release point lands ON
-    // text, and the test would keep passing while exercising an ordinary drag.
-    const proseBottom = await page.evaluate(
-      () => (document.querySelector('.prose') as HTMLElement).getBoundingClientRect().bottom,
-    );
-    expect(releaseY).toBeGreaterThan(proseBottom);
+    // Scroll to the end first. The empty area below the text only exists at the
+    // bottom of the document, and on a taller viewport-to-content ratio than
+    // this machine happens to have, "below the prose" is off screen entirely:
+    // the release would land back on text and this would pass while testing an
+    // ordinary drag.
+    await page.evaluate(() => {
+      const scroller = document.scrollingElement ?? document.documentElement;
+      scroller.scrollTop = scroller.scrollHeight;
+      const pane = document.querySelector('.doc-sheet')?.parentElement;
+      if (pane) pane.scrollTop = pane.scrollHeight;
+    });
+    await page.waitForTimeout(400);
 
-    await page.mouse.move(from.x, from.y);
+    const geom = await page.evaluate(() => {
+      const ps = [...document.querySelectorAll('.prose p')];
+      const last = ps[ps.length - 1].getBoundingClientRect();
+      return {
+        x: last.left + 5,
+        y: last.top + last.height / 2,
+        bottom: last.bottom,
+        viewport: window.innerHeight,
+      };
+    });
+    const releaseY = Math.min(geom.bottom + 60, geom.viewport - 10);
+    expect(releaseY).toBeGreaterThan(geom.bottom);
+
+    await page.mouse.move(geom.x, geom.y);
     await page.mouse.down();
-    await page.mouse.move(from.x + 200, releaseY, { steps: 12 });
+    await page.mouse.move(geom.x + 150, releaseY, { steps: 12 });
     await page.mouse.up();
 
     await expect(page.locator('mark.selection-highlight').first()).toBeVisible({ timeout: 5000 });

--- a/e2e/context-menu.spec.ts
+++ b/e2e/context-menu.spec.ts
@@ -495,6 +495,13 @@ test.describe('Context menu on a text selection', () => {
     // wrapper above the prose, which used to throw the whole selection away:
     // native highlight painted, nothing committed, and the right-click that
     // followed reached the browser's menu.
+    // If the fixture ever grows past the viewport this release point lands ON
+    // text, and the test would keep passing while exercising an ordinary drag.
+    const proseBottom = await page.evaluate(
+      () => (document.querySelector('.prose') as HTMLElement).getBoundingClientRect().bottom,
+    );
+    expect(releaseY).toBeGreaterThan(proseBottom);
+
     await page.mouse.move(from.x, from.y);
     await page.mouse.down();
     await page.mouse.move(from.x + 200, releaseY, { steps: 12 });

--- a/e2e/copy-selection.spec.ts
+++ b/e2e/copy-selection.spec.ts
@@ -121,6 +121,33 @@ test.describe('Copy selection', () => {
     expect(copied.html).toContain('<strong>');
   });
 
+  test('a selection spanning two paragraphs keeps the blank line between them', async ({
+    page,
+  }) => {
+    await openFixture(page);
+    await armCopyListener(page);
+    await page.evaluate(() => {
+      const ps = [...document.querySelectorAll('.prose p')];
+      const first = ps.find((p) => p.textContent?.includes('First paragraph ends here'))!;
+      const second = ps.find((p) => p.textContent?.includes('Second paragraph starts here'))!;
+      const range = document.createRange();
+      range.setStart(first.firstChild!, 0);
+      range.setEnd(second.firstChild!, 20);
+      const sel = window.getSelection()!;
+      sel.removeAllRanges();
+      sel.addRange(range);
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+
+    await page.keyboard.press('ControlOrMeta+c');
+
+    await expect.poll(() => readCopied(page)).not.toBeNull();
+    // In markdown a single newline is a soft break, so losing the blank line
+    // pastes two paragraphs back as one. A Range reports no blank line at a
+    // paragraph boundary; the Selection does.
+    expect((await readCopied(page))!.plain).toContain('ends here.\n\nSecond paragraph');
+  });
+
   test('Quick comment focusing the composer with a collapsed caret still copies the document selection', async ({
     page,
   }) => {

--- a/src/lib/selection-resolver.test.ts
+++ b/src/lib/selection-resolver.test.ts
@@ -67,6 +67,29 @@ describe('resolveSelection', () => {
     expect(resolveSelection(container)).toBeNull();
   });
 
+  it('clamps the start to real text when the first block has none', () => {
+    // getVisibleTextOffset walks text nodes and returns the container's total
+    // length when it never meets the node it was given, so clamping to
+    // (container, 0) in front of a childless first block reported the END of
+    // the document as the selection's offset.
+    document.body.innerHTML =
+      '<div id="page"><div id="root"><hr><p>Alpha beta gamma.</p></div><div id="after">tail</div></div>';
+    const container = document.getElementById('root')!;
+    const para = container.querySelector('p')!.firstChild!;
+    const outside = document.getElementById('after')!.firstChild!;
+
+    const range = document.createRange();
+    range.setStartBefore(container.firstChild!);
+    range.setEnd(outside, 4);
+
+    mockSelection({ text: 'Alpha beta gamma.tail', range });
+
+    const result = resolveSelection(container);
+    expect(result).not.toBeNull();
+    expect(result!.offset).toBe(0);
+    expect(para.textContent).toContain('Alpha');
+  });
+
   it('keeps the blank line between blocks that Selection.toString reports', () => {
     // Range.toString() collapses a block boundary to a single newline while
     // Selection.toString() reports the blank line. That string is the comment's

--- a/src/lib/selection-resolver.test.ts
+++ b/src/lib/selection-resolver.test.ts
@@ -67,6 +67,26 @@ describe('resolveSelection', () => {
     expect(resolveSelection(container)).toBeNull();
   });
 
+  it('keeps the blank line between blocks that Selection.toString reports', () => {
+    // Range.toString() collapses a block boundary to a single newline while
+    // Selection.toString() reports the blank line. That string is the comment's
+    // stored anchor and the text/plain clipboard flavour, and in markdown one
+    // newline is a soft break: two paragraphs would paste back as one.
+    document.body.innerHTML = '<div id="root"><p>Para one text.</p><p>Para two text.</p></div>';
+    const container = document.getElementById('root')!;
+    const first = container.firstChild!.firstChild!;
+    const second = container.lastChild!.firstChild!;
+
+    const range = document.createRange();
+    range.setStart(first, 0);
+    range.setEnd(second, second.textContent!.length);
+
+    mockSelection({ text: 'Para one text.\n\nPara two text.', range });
+
+    const result = resolveSelection(container);
+    expect(result!.text).toBe('Para one text.\n\nPara two text.');
+  });
+
   it('resolves a drag that ends outside the container, clamped to it', () => {
     // Releasing the mouse in the sheet's empty area leaves the range ending
     // outside the prose, so its common ancestor is a layout wrapper ABOVE the

--- a/src/lib/selection-resolver.ts
+++ b/src/lib/selection-resolver.ts
@@ -1,6 +1,10 @@
 import type { SelectionInfo } from '../types';
 import { buildRangeHtml } from './copy-selection-html';
-import { getVisibleTextContent, getVisibleTextOffset } from './visible-text';
+import {
+  collectVisibleTextNodes,
+  getVisibleTextContent,
+  getVisibleTextOffset,
+} from './visible-text';
 
 /**
  * The part of `range` that lies inside `containerEl`, or null if none of it
@@ -20,11 +24,24 @@ function clampToContainer(range: Range, containerEl: HTMLElement): Range | null 
   bounds.selectNodeContents(containerEl);
 
   const clamped = range.cloneRange();
-  if (clamped.compareBoundaryPoints(Range.START_TO_START, bounds) < 0) {
-    clamped.setStart(bounds.startContainer, bounds.startOffset);
+  const startsBefore = clamped.compareBoundaryPoints(Range.START_TO_START, bounds) < 0;
+  const endsAfter = clamped.compareBoundaryPoints(Range.END_TO_END, bounds) > 0;
+  // Clamp onto real text rather than onto the container's own boundary points.
+  // getVisibleTextOffset walks text nodes and returns the container's total
+  // length when it never meets the node it was handed, so a boundary resolving
+  // to a childless first block (a leading rule or image) reported the END of
+  // the document as this selection's offset, and anchor disambiguation then had
+  // the wrong hint entirely.
+  const texts = startsBefore || endsAfter ? collectVisibleTextNodes(containerEl) : [];
+  if (startsBefore) {
+    const first = texts[0];
+    if (first) clamped.setStart(first, 0);
+    else clamped.setStart(bounds.startContainer, bounds.startOffset);
   }
-  if (clamped.compareBoundaryPoints(Range.END_TO_END, bounds) > 0) {
-    clamped.setEnd(bounds.endContainer, bounds.endOffset);
+  if (endsAfter) {
+    const last = texts[texts.length - 1];
+    if (last) clamped.setEnd(last, last.textContent?.length ?? 0);
+    else clamped.setEnd(bounds.endContainer, bounds.endOffset);
   }
   // A selection entirely outside the container clamps to nothing, which is the
   // case the old containment check was right about.

--- a/src/lib/selection-resolver.ts
+++ b/src/lib/selection-resolver.ts
@@ -38,7 +38,22 @@ export function resolveSelection(containerEl: HTMLElement): SelectionInfo | null
   const range = clampToContainer(sel.getRangeAt(0), containerEl);
   if (!range) return null;
 
-  const rawText = range.toString();
+  // `Selection.toString()` reports block boundaries, so two paragraphs come
+  // back separated by a blank line; `Range.toString()` runs them together.
+  // That string is the comment's stored anchor and the text/plain clipboard
+  // flavour, and in markdown a single newline is a soft break, so the blank
+  // line is the difference between pasting two paragraphs and pasting one.
+  //
+  // Prefer the selection's own string whenever the clamp only dropped empty
+  // layout space, which is the whitespace-release case it exists for. When the
+  // clamp removed actual content, the drag ran into another surface and the
+  // clamped text is the honest answer.
+  // Compared without whitespace, since the whole difference between the two is
+  // whitespace: same characters means the clamp dropped nothing that matters.
+  const squash = (t: string) => t.replace(/\s+/g, '');
+  const selectionText = sel.toString();
+  const clampedText = range.toString();
+  const rawText = squash(selectionText) === squash(clampedText) ? selectionText : clampedText;
   const text = rawText.trim();
   if (!text || text.length < 2) return null;
 

--- a/src/lib/visible-text.test.ts
+++ b/src/lib/visible-text.test.ts
@@ -84,3 +84,20 @@ describe('visible-text helpers', () => {
     expect(getVisibleTextOffset(root, parent, parent.childNodes.length)).toBe('Hello World'.length);
   });
 });
+
+describe('getVisibleTextOffset with a textless target', () => {
+  it('reports the position of the next text, not the end of the container', () => {
+    // A rule or an image holds no text, so the walker never yields it. Falling
+    // through returned the container's total length, which put a selection that
+    // starts at the top of the document at its very end.
+    document.body.innerHTML = '<div id="root"><hr><p>Alpha beta gamma.</p></div>';
+    const root = document.getElementById('root')!;
+    expect(getVisibleTextOffset(root, root, 0)).toBe(0);
+  });
+
+  it('still reports the end when the target follows all of the text', () => {
+    document.body.innerHTML = '<div id="root"><p>Alpha beta gamma.</p><hr></div>';
+    const root = document.getElementById('root')!;
+    expect(getVisibleTextOffset(root, root, 1)).toBe('Alpha beta gamma.'.length);
+  });
+});

--- a/src/lib/visible-text.ts
+++ b/src/lib/visible-text.ts
@@ -71,6 +71,17 @@ export function getVisibleTextOffset(root: Node, targetNode: Node, offset: numbe
     if (node === resolvedNode) {
       return total + resolvedOffset;
     }
+    // A target that holds no text of its own (a horizontal rule, an image, an
+    // empty element) is never yielded by this walker, and falling out of the
+    // loop would report the whole container's length: the END of the document
+    // for a selection that starts at its beginning. The first text node after
+    // it in document order marks the same position.
+    if (
+      resolvedNode.nodeType !== Node.TEXT_NODE &&
+      resolvedNode.compareDocumentPosition(node) & Node.DOCUMENT_POSITION_FOLLOWING
+    ) {
+      return total;
+    }
     total += node.textContent?.length || 0;
   }
   return total;


### PR DESCRIPTION
A regression from #91, found by a review of the branch that followed it.

Clamping the selection to the prose container also switched where its text comes from, and `Range.toString()` and `Selection.toString()` disagree at a block boundary. Measured in Chromium:

```
Selection: "Para one text.\n\nPara two text."
Range:     "Para one text.\nPara two text."
```

jsdom's `Range` drops the separator entirely.

That string is both the comment's stored anchor and the `text/plain` clipboard flavour. In markdown a single newline is a soft break, so copying two paragraphs pasted them back as one.

## Not comment loss

The review reported this as comments silently vanishing. It isn't: `insertComment`'s flexible whitespace matching splits on `\s+`, so a single newline still matches the source. I checked by creating a cross-paragraph comment in the running app before and after the change, and it was written to the file both times. Real regression, smaller blast radius than reported.

## The fix

Prefer the selection's own string whenever the clamp dropped nothing that matters, compared with whitespace removed, since whitespace is the entire difference between the two. When the clamp really did remove content the drag ran into another surface, and the clamped text is the honest answer there.

Verified in the app: clipboard and stored anchor both carry the blank line again.

## Test note

The first e2e attempt crossed a heading boundary, where both APIs report a single newline, so it passed with and without the fix. It targets a paragraph boundary now and was watched failing before the change went in. The spec's existing helper crosses that same heading boundary, which is why nothing caught this the first time.
