### PR TITLE
Fix the demo drag that never showed a selection, and re-cut the pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ With the built-in MCP server, review runs in both directions. Your agent can req
 
 ![md-redline screenshot](https://raw.githubusercontent.com/dejuknow/md-redline/main/public/screenshot.png)
 
-**See the full review workflow in 30 seconds:**
+**See the full review workflow in about 30 seconds:**
 
-https://github.com/user-attachments/assets/3a2bf20a-d4a0-403c-b023-e877130fd959
+https://github.com/user-attachments/assets/830de5ff-a170-43e5-8a83-a4d8ba69cdd5
 
 Works with [Claude Code](https://claude.com/claude-code), Claude Desktop, [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and any other MCP client that supports stdio servers. As Sean Grove argues in [specs are the new code](https://www.youtube.com/watch?v=8rABwKRsec4), specs are becoming the primary unit of work in agentic development. `mdr` gives that workflow review tooling closer to code review.
 
@@ -126,7 +126,7 @@ The reverse direction, for docs the agent did not just write: your own draft, a 
 
 The agent calls `mdr_comment`. Its findings land as inline comments anchored to the exact text, and the browser opens so you can read them as they arrive. The agent then waits (via `mdr_wait`) while you work through the feedback: reply on any card, edit the doc, delete comments you disagree with. When you are done, click **End review** in the banner. That click is the signal for the agent to re-read the file and pick up your replies and edits, so the session stays open until you press it. The agent is not stuck; it is listening.
 
-https://github.com/user-attachments/assets/41339401-6096-40de-abbf-e93ef7ffd2c2
+https://github.com/user-attachments/assets/885f2bd2-dc3c-4cba-a9e2-2334f343f9d2
 
 ### Either direction: the agent can ask you questions
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ With the built-in MCP server, review runs in both directions. Your agent can req
 
 **See the full review workflow in about 30 seconds:**
 
-https://github.com/user-attachments/assets/830de5ff-a170-43e5-8a83-a4d8ba69cdd5
+https://github.com/user-attachments/assets/8b9b3546-a895-42e1-b3cc-5ee5b2c00398
 
 Works with [Claude Code](https://claude.com/claude-code), Claude Desktop, [Codex CLI](https://github.com/openai/codex), [Gemini CLI](https://github.com/google-gemini/gemini-cli), and any other MCP client that supports stdio servers. As Sean Grove argues in [specs are the new code](https://www.youtube.com/watch?v=8rABwKRsec4), specs are becoming the primary unit of work in agentic development. `mdr` gives that workflow review tooling closer to code review.
 
@@ -126,7 +126,7 @@ The reverse direction, for docs the agent did not just write: your own draft, a 
 
 The agent calls `mdr_comment`. Its findings land as inline comments anchored to the exact text, and the browser opens so you can read them as they arrive. The agent then waits (via `mdr_wait`) while you work through the feedback: reply on any card, edit the doc, delete comments you disagree with. When you are done, click **End review** in the banner. That click is the signal for the agent to re-read the file and pick up your replies and edits, so the session stays open until you press it. The agent is not stuck; it is listening.
 
-https://github.com/user-attachments/assets/885f2bd2-dc3c-4cba-a9e2-2334f343f9d2
+https://github.com/user-attachments/assets/a695017d-ed59-4fe8-8a29-e5306dab788c
 
 ### Either direction: the agent can ask you questions
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -23,6 +23,31 @@ npx playwright install chromium   # Playwright drives the browser clips
 
 `vhs` requires `ttyd` on PATH (Homebrew installs it as a dependency).
 
+## Pacing rule
+
+A clip that cuts from the terminal to the browser (or back) holds on its final
+frame for **about 4 seconds** before the cut. Measure the hold, not the tape's
+`Sleep` value: VHS trims some trailing time, so `Sleep 5s` produced a 2.97s
+hold. To check one:
+
+```bash
+ffmpeg -i demo/clips/03-terminal-agent.mp4 -vf freezedetect=n=0.003:d=0.5 -f null - 2>&1 \
+  | grep freeze_start | tail -1
+```
+
+Subtract that from the clip duration. A viewer has to read what the
+agent just did before the scene changes, and 2 to 3 seconds is not enough: the
+state goes by before it can be parsed. The trailing `Sleep` in each
+`demo-terminal-*.tape` is where that dwell lives, and each tape carries a
+comment saying so.
+
+Do not name the fixture file in the TYPED prompts. The agent's tool output
+should name it, as a real one would, and that name has to match the fixture on
+disk (`demo/fixtures/myapp/`). Naming it in the human prompt too just adds a
+second place to drift: `mock-claude.sh` said `sample.md` for a while after the
+fixture became `auth-spec.md`, and the video showed one name being typed and a
+different one opening in mdr.
+
 ## Making a video
 
 ### 1. Regular update (UI hasn't changed meaningfully)

--- a/demo/README.md
+++ b/demo/README.md
@@ -26,7 +26,7 @@ npx playwright install chromium   # Playwright drives the browser clips
 ## Pacing rule
 
 A clip that cuts from the terminal to the browser (or back) holds on its final
-frame for **about 4 seconds** before the cut. Measure the hold, not the tape's
+frame for **about 3 seconds** before the cut. Measure the hold, not the tape's
 `Sleep` value: VHS trims some trailing time, so `Sleep 5s` produced a 2.97s
 hold. To check one:
 
@@ -35,11 +35,11 @@ ffmpeg -i demo/clips/03-terminal-agent.mp4 -vf freezedetect=n=0.003:d=0.5 -f nul
   | grep freeze_start | tail -1
 ```
 
-Subtract that from the clip duration. A viewer has to read what the
-agent just did before the scene changes, and 2 to 3 seconds is not enough: the
-state goes by before it can be parsed. The trailing `Sleep` in each
-`demo-terminal-*.tape` is where that dwell lives, and each tape carries a
-comment saying so.
+Subtract that from the clip duration. A viewer has to read what the agent just
+did before the scene changes, and under 2 seconds is not enough: the state goes
+by before it can be parsed. Four seconds turned out to drag, so 3 is the target.
+The trailing `Sleep` in each `demo-terminal-*.tape` is where that dwell lives,
+and each tape carries a comment saying so.
 
 Do not name the fixture file in the TYPED prompts. The agent's tool output
 should name it, as a real one would, and that name has to match the fixture on

--- a/demo/demo-terminal-1.tape
+++ b/demo/demo-terminal-1.tape
@@ -39,6 +39,6 @@ Enter
 # Beat showing "I'll open that in mdr for your review." + the waiting state.
 # Trailing dwell: this clip cuts to a browser clip, so it holds on its
 # final frame long enough to read before the switch. Standing rule for
-# these recordings: >= 4s. Anything shorter and the state a viewer is
-# meant to absorb is gone before they have parsed it.
-Sleep 4s
+# these recordings: ~3s measured. Anything shorter and the state a viewer
+# is meant to absorb is gone before they have parsed it.
+Sleep 3s

--- a/demo/demo-terminal-1.tape
+++ b/demo/demo-terminal-1.tape
@@ -24,7 +24,7 @@ Sleep 400ms
 # Scene 1: User types the spec generation prompt. Kept short enough that it
 # fits on one line at Width 1440 / FontSize 28 so continuation doesn't need
 # a hanging indent (terminals don't do that automatically).
-Type "Write a spec for user auth (email, OAuth, magic links) to sample.md."
+Type "Write a spec for user auth (email, OAuth, magic links)."
 Sleep 750ms
 Enter
 
@@ -32,9 +32,13 @@ Enter
 Sleep 1.2s
 
 # Scene 3: User requests review in mdr
-Type "Let me review sample.md in mdr before you continue."
+Type "Let me review the spec in mdr before you continue."
 Sleep 750ms
 Enter
 
 # Beat showing "I'll open that in mdr for your review." + the waiting state.
-Sleep 1.5s
+# Trailing dwell: this clip cuts to a browser clip, so it holds on its
+# final frame long enough to read before the switch. Standing rule for
+# these recordings: >= 4s. Anything shorter and the state a viewer is
+# meant to absorb is gone before they have parsed it.
+Sleep 4s

--- a/demo/demo-terminal-2.tape
+++ b/demo/demo-terminal-2.tape
@@ -22,4 +22,8 @@ Show
 # "Review received", streams the agent's edits, then prints "Both comments
 # addressed..." + the ❯ prompt. Hold long enough after the final message
 # that viewers can read it before the cut back to mdr.
-Sleep 3.3s
+# Trailing dwell: this clip cuts to a browser clip, so it holds on its
+# final frame long enough to read before the switch. Standing rule for
+# these recordings: >= 4s. Anything shorter and the state a viewer is
+# meant to absorb is gone before they have parsed it.
+Sleep 6s

--- a/demo/demo-terminal-2.tape
+++ b/demo/demo-terminal-2.tape
@@ -24,6 +24,6 @@ Show
 # that viewers can read it before the cut back to mdr.
 # Trailing dwell: this clip cuts to a browser clip, so it holds on its
 # final frame long enough to read before the switch. Standing rule for
-# these recordings: >= 4s. Anything shorter and the state a viewer is
-# meant to absorb is gone before they have parsed it.
-Sleep 6s
+# these recordings: ~3s measured. Anything shorter and the state a viewer
+# is meant to absorb is gone before they have parsed it.
+Sleep 5s

--- a/demo/demo-terminal-3.tape
+++ b/demo/demo-terminal-3.tape
@@ -31,6 +31,6 @@ Enter
 # on the final waiting line.
 # Trailing dwell: this clip cuts to a browser clip, so it holds on its
 # final frame long enough to read before the switch. Standing rule for
-# these recordings: >= 4s. Anything shorter and the state a viewer is
-# meant to absorb is gone before they have parsed it.
-Sleep 5s
+# these recordings: ~3s measured. Anything shorter and the state a viewer
+# is meant to absorb is gone before they have parsed it.
+Sleep 4s

--- a/demo/demo-terminal-3.tape
+++ b/demo/demo-terminal-3.tape
@@ -29,4 +29,8 @@ Enter
 # Agent prints the mdr_comment + mdr_wait tool calls, ending on the waiting
 # state. Tail hold matches the clip-01 rule: the CLI->MDR cut needs >=1.5s
 # on the final waiting line.
-Sleep 2.6s
+# Trailing dwell: this clip cuts to a browser clip, so it holds on its
+# final frame long enough to read before the switch. Standing rule for
+# these recordings: >= 4s. Anything shorter and the state a viewer is
+# meant to absorb is gone before they have parsed it.
+Sleep 5s

--- a/demo/demo.spec.ts
+++ b/demo/demo.spec.ts
@@ -434,6 +434,11 @@ async function setupDemoPage(page: Page) {
       document.addEventListener(
         'mousedown',
         (e) => {
+          // A drag-to-select spawns its ripple exactly where the highlight
+          // starts, and the ring's glow washes the tint off the first few
+          // characters. The ripple is there to make a click read as a click,
+          // so the drag turns it off for its own duration.
+          if ((window as unknown as { __demoNoRipple?: boolean }).__demoNoRipple) return;
           const ripple = document.createElement('div');
           ripple.className = 'demo-ripple';
           ripple.style.left = e.clientX + TIP_OFFSET_X + 'px';
@@ -566,6 +571,24 @@ async function getTextBounds(page: Page, text: string) {
   }, text);
 }
 
+/** Read the anchor's bounds only once the layout has stopped moving under it.
+ *  The margin rail measures its cards after they mount and nudges the prose,
+ *  which moved the second anchor 13px between reading its bounds and pressing
+ *  the mouse. The whole drag then ran through the gap below the line: the
+ *  comment still landed (the Range pin below guarantees that) but the
+ *  highlight painted offset from the glyphs, so the video showed a drag over
+ *  text that never lit up. Poll until two consecutive reads agree. */
+async function getSettledTextBounds(page: Page, text: string, attempts = 20) {
+  let prev = await getTextBounds(page, text);
+  for (let i = 0; i < attempts; i++) {
+    await page.waitForTimeout(50);
+    const next = await getTextBounds(page, text);
+    if (Math.abs(next.x - prev.x) < 0.5 && Math.abs(next.y - prev.y) < 0.5) return next;
+    prev = next;
+  }
+  return prev;
+}
+
 async function addCommentAnimated(page: Page, anchorText: string, commentText: string) {
   // Double-rAF + brief settle before reading the text bounds. Right after a
   // smooth-scroll and a previous form close, the document layout can still
@@ -577,29 +600,47 @@ async function addCommentAnimated(page: Page, anchorText: string, commentText: s
   );
   await page.waitForTimeout(80);
 
-  const bounds = await getTextBounds(page, anchorText);
-
   // The fake cursor's visible tip sits 2px right / 1px below its DOM origin
   // (SVG tip at (5,3), with transform: translate(-3px, -2px)). To land the
   // tip ON the text rather than to the right and below, shift the Playwright
   // mouse coordinate back by that offset.
   const TIP_DX = 2;
   const TIP_DY = 1;
-  const startX = bounds.x + 2 - TIP_DX;
-  const centerY = bounds.y + bounds.height / 2 - TIP_DY;
-  const endX = bounds.x + bounds.width - 2 - TIP_DX;
+  const track = (b: { x: number; y: number; width: number; height: number }) => ({
+    startX: b.x + 2 - TIP_DX,
+    centerY: b.y + b.height / 2 - TIP_DY,
+    endX: b.x + b.width - 2 - TIP_DX,
+  });
 
   // Glide the cursor over to the anchor text first so the motion reads for viewers.
-  await slowMove(page, startX, centerY, T.CURSOR_TO_ANCHOR);
+  const approach = track(await getSettledTextBounds(page, anchorText));
+  await slowMove(page, approach.startX, approach.centerY, T.CURSOR_TO_ANCHOR);
   await page.waitForTimeout(T.PRE_DRAG_PAUSE);
+
+  // Re-read after the glide and correct. Cheap insurance: if nothing moved
+  // this is a no-op (slowMove short-circuits under 3px), and if something did,
+  // the press still lands on the glyphs instead of in the gap beneath them.
+  const { startX, centerY, endX } = track(await getSettledTextBounds(page, anchorText));
+  if (Math.abs(startX - approach.startX) > 1 || Math.abs(centerY - approach.centerY) > 1) {
+    await slowMove(page, startX, centerY, 120);
+  }
 
   // Drag across the anchor — visibly slow so the highlight tracks the motion.
   // The browser's native selection can extend a bit past the intended range
   // during a slow drag; we pin the final selection to exactly `anchorText`
   // via Range API before mouse.up so the form reads the correct text.
+  await page.evaluate(() => {
+    (window as unknown as { __demoNoRipple?: boolean }).__demoNoRipple = true;
+  });
   await page.mouse.move(startX, centerY);
   await page.mouse.down();
   await slowMove(page, endX, centerY, T.DRAG_DURATION);
+
+  // The drag has to produce a real native selection, because that highlight IS
+  // the shot. The Range pin below would hide a failure here: the comment would
+  // still be correct while the video showed a cursor sliding over dead text.
+  const draggedText = await page.evaluate(() => window.getSelection()?.toString() ?? '');
+  expect(draggedText.length, `drag over "${anchorText}" selected nothing`).toBeGreaterThan(0);
 
   // Re-pin the selection to exactly cover the anchor, independent of what
   // the browser captured during the drag. This is what the comment form
@@ -625,6 +666,9 @@ async function addCommentAnimated(page: Page, anchorText: string, commentText: s
   }, anchorText);
 
   await page.mouse.up();
+  await page.evaluate(() => {
+    (window as unknown as { __demoNoRipple?: boolean }).__demoNoRipple = false;
+  });
   await page.waitForTimeout(T.POST_DRAG);
 
   const input = page.getByPlaceholder('Add your comment...');

--- a/demo/mock-claude.sh
+++ b/demo/mock-claude.sh
@@ -58,7 +58,7 @@ prompt_mode() {
   echo ""
 
   # Tool call: Write file
-  echo -e "  ${YELLOW}⏺${RESET} ${BOLD}Write${RESET}${DIM}(sample.md)${RESET}"
+  echo -e "  ${YELLOW}⏺${RESET} ${BOLD}Write${RESET}${DIM}(auth-spec.md)${RESET}"
   echo ""
   echo -e "    ${DIM}# User Authentication Spec${RESET}" | stream
   echo -e "    ${DIM}${RESET}" | stream
@@ -75,7 +75,7 @@ prompt_mode() {
   echo -e "    ${DIM}Password reset via email with expiring tokens (valid 1 hour).${RESET}" | stream
   echo -e "    ${DIM}...${RESET}" | stream
   echo ""
-  echo -e "  ${GREEN}✓${RESET} ${DIM}Wrote sample.md (67 lines)${RESET}"
+  echo -e "  ${GREEN}✓${RESET} ${DIM}Wrote auth-spec.md (67 lines)${RESET}"
   echo ""
   hr 76
   echo ""
@@ -91,7 +91,7 @@ prompt_mode() {
   echo ""
 
   # Tool call: mdr_request_review
-  echo -e "  ${MAGENTA}⏺${RESET} ${BOLD}mdr_request_review${RESET}${DIM}({\"filePaths\": [\"sample.md\"]})${RESET}"
+  echo -e "  ${MAGENTA}⏺${RESET} ${BOLD}mdr_request_review${RESET}${DIM}({\"filePaths\": [\"auth-spec.md\"]})${RESET}"
   echo -e "    ${DIM}⎿ Waiting for review in md-redline...${RESET}"
   echo ""
 
@@ -105,7 +105,7 @@ review_mode() {
   echo ""
   echo -e "  ${BOLD}⏺${RESET} I'll open that in mdr for your review."
   echo ""
-  echo -e "  ${MAGENTA}⏺${RESET} ${BOLD}mdr_request_review${RESET}${DIM}({\"filePaths\": [\"sample.md\"]})${RESET}"
+  echo -e "  ${MAGENTA}⏺${RESET} ${BOLD}mdr_request_review${RESET}${DIM}({\"filePaths\": [\"auth-spec.md\"]})${RESET}"
   echo -e "    ${DIM}⎿ Waiting for review in md-redline...${RESET}"
   # Longer pause at the clip start — the CLI has just come back on screen
   # after the transition, so give viewers a beat to register the state
@@ -129,11 +129,11 @@ review_mode() {
   sleep 0.08
 
   echo ""
-  echo -e "  ${YELLOW}⏺${RESET} ${BOLD}Edit${RESET}${DIM}(sample.md)${RESET}"
+  echo -e "  ${YELLOW}⏺${RESET} ${BOLD}Edit${RESET}${DIM}(auth-spec.md)${RESET}"
   echo -e "    ${DIM}  ${RED}- Minimum 8 characters${RESET}"
   echo -e "    ${DIM}  ${GREEN}+ Minimum 12 characters${RESET}"
   echo ""
-  echo -e "  ${GREEN}✓${RESET} ${DIM}Updated sample.md${RESET}"
+  echo -e "  ${GREEN}✓${RESET} ${DIM}Updated auth-spec.md${RESET}"
   sleep 0.1
 
   echo ""
@@ -143,13 +143,13 @@ review_mode() {
   sleep 0.08
 
   echo ""
-  echo -e "  ${YELLOW}⏺${RESET} ${BOLD}Edit${RESET}${DIM}(sample.md)${RESET}"
+  echo -e "  ${YELLOW}⏺${RESET} ${BOLD}Edit${RESET}${DIM}(auth-spec.md)${RESET}"
   echo -e "    ${DIM}  ${RED}- Password reset via email with expiring tokens (valid 1 hour).${RESET}"
   echo -e "    ${DIM}  ${GREEN}+ Password reset via email with expiring tokens (valid 24 hours).${RESET}"
   echo -e "    ${DIM}  ${GREEN}+${RESET}"
   echo -e "    ${DIM}  ${GREEN}+ Industry standard for password reset tokens is 24 hours...${RESET}"
   echo ""
-  echo -e "  ${GREEN}✓${RESET} ${DIM}Updated sample.md${RESET}"
+  echo -e "  ${GREEN}✓${RESET} ${DIM}Updated auth-spec.md${RESET}"
   echo ""
   hr 76
   echo ""

--- a/demo/mock-claude.sh
+++ b/demo/mock-claude.sh
@@ -40,7 +40,7 @@ prompt_mode() {
   # Claude Code startup banner (matches real CLI format)
   echo ""
   echo -e "  ${BOLD}Claude Code${RESET} ${DIM}v2.1.108${RESET}"
-  echo -e "  ${DIM}Opus 4.6 (1M context) with high effort · Claude Max${RESET}"
+  echo -e "  ${DIM}Opus 5 (1M context) with high effort · Claude Max${RESET}"
   echo -e "  ${DIM}~/dev/myapp${RESET}"
   echo ""
   hr 76
@@ -169,7 +169,7 @@ agent_review_mode() {
   # Claude Code startup banner (matches real CLI format)
   echo ""
   echo -e "  ${BOLD}Claude Code${RESET} ${DIM}v2.1.108${RESET}"
-  echo -e "  ${DIM}Opus 4.6 (1M context) with high effort · Claude Max${RESET}"
+  echo -e "  ${DIM}Opus 5 (1M context) with high effort · Claude Max${RESET}"
   echo -e "  ${DIM}~/dev/myapp${RESET}"
   echo ""
   hr 76


### PR DESCRIPTION
Three rounds of watching the recordings, all of them problems the code could not have told me about.

## The drag was not selecting anything on screen

The cursor slid across the anchor text and no highlight followed it. Instrumenting the real recording gave the answer:

```
[valid 1 hour] read={"y":503.98}  afterGlide={"y":490.98}
```

The margin rail measures its cards after they mount and nudges the prose under them. Between reading the anchor's bounds and pressing the mouse, the line moved 13px, so the entire drag ran through the gap beneath it.

What kept this hidden: `addCommentAnimated` re-pins the selection with the Range API before `mouseup`, so the comment always landed on the right text. The app was right and only the video was wrong, which is the failure mode that survives every check that looks at state instead of pixels.

Fixes in `demo/demo.spec.ts`:

- `getSettledTextBounds` polls until two consecutive reads agree, so a moving layout is never used for coordinates.
- The bounds are re-read after the approach glide and corrected if they drifted, so the press lands on the glyphs.
- The drag now asserts it produced a native selection. That highlight is the shot, and the Range pin would otherwise keep hiding its absence.
- The click ripple sits out the drag. It spawns exactly where the highlight begins and its glow was washing the tint off the first few characters, so even correctly painted frames read as unselected.

## Pacing, trimmed

The previous pass took every scene hold to ~4s, which dragged. Measured with `freezedetect`, the holds are now 2.88s, 2.97s and 3.15s. `demo/README.md` and the tape comments carry the ~3s target and the measurement command, since the tape's `Sleep` value is not the hold: VHS trims trailing time.

## Also

The mock CLI reported "Opus 4.6". It now says Opus 5.

## Videos

Hero, 33.0s:

https://github.com/user-attachments/assets/8b9b3546-a895-42e1-b3cc-5ee5b2c00398

Agent-review flow, 21.6s:

https://github.com/user-attachments/assets/a695017d-ed59-4fe8-8a29-e5306dab788c

The drag is visible at ~12.3s and ~18.4s in the hero. README links point at these two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQDZxycbpQxCT6VGNbSxRZ