### PR TITLE
Fix four defects found reviewing main ahead of 0.9.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -727,7 +727,7 @@ after typing) closes the form as usual.
 
 ### Right-clicking a selection
 
-The viewer's own menu (Comment, Templates, Copy) opens from the painted mark,
+The viewer's own menu (Comment, Copy, Copy as Markdown) opens from the painted mark,
 not from the native range. `handleContextMenu` in `MarkdownViewer` checks
 `SELECTION_MARK_SELECTOR` before it falls back to `window.getSelection()`,
 because the range is gone by then.
@@ -810,9 +810,10 @@ would sit over one passage while every item acted on another.
 **Shift+right-click** returns before every branch, so the browser's own menu is
 never suppressed. That matches what the chord already means in Chrome on
 Windows and Linux, and it is the escape hatch to Inspect on a painted highlight.
-It is gated on `button === 2`: Shift+F10 is the standard keyboard chord for the
-context menu and arrives with `shiftKey` set and button 0, so testing `shiftKey`
-alone would lock keyboard users out of this menu entirely.
+It is gated on `isSecondaryClick` (button 2, or ctrl+click on macOS): Shift+F10
+is the standard keyboard chord for the context menu and arrives with `shiftKey`
+set and button 0, so testing `shiftKey` alone would lock keyboard users out of
+this menu entirely.
 
 `onContextMenu` returns whether it opened a menu, and the viewer calls
 `preventDefault` only when it did. The consumer refuses a mark whose comment is

--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
   },
   "files": [
     "bin/",
+    "!bin/*.test.ts",
+    "!bin/cli-browser-stub.ts",
+    "!bin/test-windows.ps1",
     "dist/",
     "README.md",
     "LICENSE"

--- a/scripts/eval-freshness.mjs
+++ b/scripts/eval-freshness.mjs
@@ -31,8 +31,12 @@ export function parseRunDirName(name) {
   const parts = String(name).split('_');
   if (parts.length !== 3) return null;
   const [stamp, agent, format] = parts;
-  // 2026-08-27T07-03-32 -> 2026-08-27T07:03:32
-  const iso = stamp.replace(/T(\d{2})-(\d{2})-(\d{2})$/, 'T$1:$2:$3');
+  // 2026-08-27T07-03-32 -> 2026-08-27T07:03:32Z. The runner stamps the
+  // directory from toISOString(), which is UTC, and the Z has to say so:
+  // Date.parse reads a date-time with no offset as LOCAL time, which shifted
+  // every run by the machine's offset and let a run from before a prompt
+  // change pass as fresh on a UTC-7 machine.
+  const iso = stamp.replace(/T(\d{2})-(\d{2})-(\d{2})$/, 'T$1:$2:$3Z');
   if (iso === stamp) return null;
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return null;

--- a/scripts/eval-freshness.test.ts
+++ b/scripts/eval-freshness.test.ts
@@ -19,8 +19,27 @@ describe('parseRunDirName', () => {
     expect(parseRunDirName('2026-08-27T07-03-32_claude-cli-remove_current')).toMatchObject({
       agent: 'claude-cli-remove',
       format: 'current',
-      ranAt: T('2026-08-27T07:03:32'),
+      ranAt: T('2026-08-27T07:03:32Z'),
     });
+  });
+
+  it('reads the stamp as UTC whatever the machine timezone, because the runner writes UTC', () => {
+    // eval/runner.ts names the directory from toISOString(), which is UTC. A
+    // parse that read it as local time shifted every run by the machine's
+    // offset: on a UTC-7 machine a run 13 minutes BEFORE a prompt change
+    // looked 7 hours after it, and the gate passed.
+    const saved = process.env.TZ;
+    try {
+      for (const tz of ['America/Los_Angeles', 'Pacific/Kiritimati', 'UTC']) {
+        process.env.TZ = tz;
+        expect(parseRunDirName('2026-08-27T07-21-34_claude-cli-remove_current')?.ranAt).toBe(
+          Math.floor(Date.UTC(2026, 7, 27, 7, 21, 34) / 1000),
+        );
+      }
+    } finally {
+      if (saved === undefined) delete process.env.TZ;
+      else process.env.TZ = saved;
+    }
   });
 
   it('keeps hyphenated agent names intact', () => {

--- a/server/mcp-stdio/validate.test.ts
+++ b/server/mcp-stdio/validate.test.ts
@@ -100,6 +100,19 @@ describe('validateReviewInput', () => {
     if (!res.ok) expect(res.error).toMatch(/enableResolve/);
   });
 
+  it('preserves an explicit enableResolve: false in the filePaths form', () => {
+    // The server falls back to the reader's saved mode when the field is
+    // absent, so collapsing false into "absent" hands an agent that asked for
+    // remove mode a resolve-mode session.
+    const res = validateReviewInput({
+      filePaths: ['/tmp/a.md'],
+      enableResolve: false,
+      comments: [{ filePath: '/tmp/a.md', anchor: 'hi', text: 't' }],
+    });
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.value.enableResolve).toBe(false);
+  });
+
   it('names both forms when neither filePaths nor sessionId is given', () => {
     const res = validateReviewInput({
       comments: [{ filePath: '/tmp/a.md', anchor: 'hi', text: 't' }],

--- a/server/mcp-stdio/validate.ts
+++ b/server/mcp-stdio/validate.ts
@@ -235,7 +235,11 @@ export function validateReviewInput(raw: unknown): ValidationResult<ReviewInput>
     value: {
       ...payload,
       filePaths: obj.filePaths as string[],
-      enableResolve: obj.enableResolve === true ? true : undefined,
+      // Preserve absence, as validateRequestReviewInput does. The server falls
+      // back to the reader's saved mode when the field is missing, so
+      // collapsing false into "missing" handed an agent that asked for remove
+      // mode a resolve-mode session.
+      enableResolve: typeof obj.enableResolve === 'boolean' ? obj.enableResolve : undefined,
     },
   };
 }

--- a/src/lib/copy-as-markdown.test.ts
+++ b/src/lib/copy-as-markdown.test.ts
@@ -91,6 +91,53 @@ describe('resolveSelectionMarkdown', () => {
     expect(result!.markdown).toContain('Para B with ref');
   });
 
+  it('refuses to slice when unselected source sits between the selected blocks', () => {
+    // Two GFM footnote definitions render together at the end of the document
+    // whatever their position in the file. Between them in the SOURCE sits a
+    // paragraph that renders above them, so a slice from the first to the
+    // second would hand back that paragraph too. A monotonic run is not enough
+    // to see this: the two footnotes are in order relative to each other.
+    const source = 'Para A.[^1]\n\n[^1]: Note one.\n\nPara B.[^2]\n\n[^2]: Note two.\n';
+    const container = mount(
+      '<p data-src-start="0" data-src-end="11">Para A.<sup><a>1</a></sup></p>' +
+        '<p data-src-start="30" data-src-end="41">Para B.<sup><a>2</a></sup></p>' +
+        '<section><ol>' +
+        '<li data-src-start="13" data-src-end="28"><p>Note one. <a>↩</a></p></li>' +
+        '<li data-src-start="43" data-src-end="58"><p>Note two. <a>↩</a></p></li>' +
+        '</ol></section>',
+    );
+    const [first, second] = Array.from(container.querySelectorAll('li'));
+    const range = document.createRange();
+    range.setStart(first.querySelector('p')!.firstChild!, 0);
+    const back = second.querySelector('a')!.firstChild!;
+    range.setEnd(back, back.textContent!.length);
+
+    const result = resolveSelectionMarkdown(range, container, source);
+    expect(result).not.toBeNull();
+    expect(result!.exact).toBe(false);
+    expect(result!.markdown).not.toContain('Para B');
+  });
+
+  it('still slices a run of list items whose list is annotated around them', () => {
+    // A list and its items both carry spans. The list overlaps any slice of
+    // its items, and must not be mistaken for unselected source.
+    const source = '- item one\n\n- item two\n\n- item three\n';
+    const container = mount(
+      '<ul data-src-start="0" data-src-end="36">' +
+        '<li data-src-start="0" data-src-end="10"><p>item one</p></li>' +
+        '<li data-src-start="12" data-src-end="22"><p>item two</p></li>' +
+        '<li data-src-start="24" data-src-end="36"><p>item three</p></li>' +
+        '</ul>',
+    );
+    const [first, second] = Array.from(container.querySelectorAll('li'));
+    const range = document.createRange();
+    range.setStart(first.firstChild!.firstChild!, 0);
+    range.setEnd(second.firstChild!.firstChild!, 'item two'.length);
+
+    const result = resolveSelectionMarkdown(range, container, source);
+    expect(result).toEqual({ markdown: '- item one\n\n- item two', exact: true });
+  });
+
   it('returns null for a collapsed selection', () => {
     const container = mount('<p data-src-start="0" data-src-end="52">Text</p>');
     const range = document.createRange();

--- a/src/lib/copy-as-markdown.ts
+++ b/src/lib/copy-as-markdown.ts
@@ -61,17 +61,23 @@ function coversWholeElement(range: Range, el: HTMLElement): boolean {
 }
 
 /**
- * Whether every annotated block from `startBlock` to `endBlock` runs forward in
- * the source, so that slicing between their spans returns those blocks and
- * nothing else.
+ * Whether slicing the source from `startBlock`'s span to `endBlock`'s returns
+ * those blocks and nothing else.
  *
- * The reason this is not obvious: a GFM footnote definition renders at the end
- * of the document whatever its position in the file, so DOM order and source
- * order come apart. Selecting from the first paragraph through such a footnote
- * would slice from the paragraph's start to the footnote's end and hand back a
- * stretch of file the reader never highlighted, while dropping one they did.
- * Whenever the run is not monotonic, the rebuild path answers instead, which
- * cannot invent text because it is built from what is on screen.
+ * Two things have to hold, and neither implies the other. First, the annotated
+ * blocks from `startBlock` to `endBlock` in DOM order must run forward in the
+ * source, or a selected block falls outside the slice: a GFM footnote
+ * definition renders at the end of the document whatever its position in the
+ * file, so selecting from the first paragraph through such a footnote would
+ * hand back a stretch of file the reader never highlighted while dropping one
+ * they did. Second, no annotated block OUTSIDE that run may overlap the slice,
+ * or an unselected block falls inside it: two footnote definitions are in
+ * order relative to each other, and the paragraph between them in the file
+ * renders above both. A block that contains a run block, or sits inside one,
+ * is exempt from the second check; its overlap is the run's own content.
+ *
+ * Whenever either fails, the rebuild path answers instead, which cannot invent
+ * text because it is built from what is on screen.
  */
 function spansRunInSourceOrder(
   startBlock: HTMLElement,
@@ -83,15 +89,26 @@ function spansRunInSourceOrder(
   const to = blocks.indexOf(endBlock);
   if (from < 0 || to < 0 || to < from) return false;
 
+  const run = blocks.slice(from, to + 1);
   let previousEnd = -1;
-  for (const block of blocks.slice(from, to + 1)) {
+  for (const block of run) {
     const start = Number(block.getAttribute(START));
     const end = Number(block.getAttribute(END));
     if (!Number.isFinite(start) || !Number.isFinite(end)) return false;
-    // Nested blocks are excluded from annotation, so spans never legitimately
-    // contain one another: each must begin at or after the last one ended.
+    // A list and its items are both annotated, so a run that crosses into a
+    // list holds a span inside another and is refused here. Between top-level
+    // blocks, each must begin at or after the last one ended.
     if (start < previousEnd) return false;
     previousEnd = end;
+  }
+
+  const sliceStart = Number(startBlock.getAttribute(START));
+  const sliceEnd = Number(endBlock.getAttribute(END));
+  for (const block of blocks) {
+    if (run.some((r) => r === block || r.contains(block) || block.contains(r))) continue;
+    const start = Number(block.getAttribute(START));
+    const end = Number(block.getAttribute(END));
+    if (start < sliceEnd && end > sliceStart) return false;
   }
   return true;
 }

--- a/src/markdown/pipeline.test.ts
+++ b/src/markdown/pipeline.test.ts
@@ -57,6 +57,19 @@ describe('renderMarkdown source positions', () => {
     const html = renderMarkdown(md);
     expect(html).not.toContain('data-src-end="99999"');
   });
+
+  it('counts a leading byte-order mark, so spans index the string it was handed', () => {
+    // micromark skips a BOM before it starts counting. Without correcting for
+    // it every span is one short: a copy sliced by it drops the block's last
+    // character and picks up the delimiter before its first.
+    const source = '\uFEFFFirst para.\n\nSecond para.\n';
+    const html = renderMarkdown(source);
+    const spans = [...html.matchAll(/data-src-start="(\d+)" data-src-end="(\d+)"/g)];
+    expect(spans.map((m) => source.slice(Number(m[1]), Number(m[2])))).toEqual([
+      'First para.',
+      'Second para.',
+    ]);
+  });
 });
 
 describe('renderMarkdown', () => {

--- a/src/markdown/pipeline.ts
+++ b/src/markdown/pipeline.ts
@@ -120,7 +120,11 @@ const MARKER_CARRYING_ANCESTORS = new Set(['blockquote', 'li']);
  * that belongs on a clipboard.
  */
 function rehypeAnnotateSource() {
-  return (tree: Root) => {
+  return (tree: Root, file: { value: unknown }) => {
+    // micromark skips a leading byte-order mark before it starts counting, so
+    // every position in a BOM-prefixed document is one short of the string's
+    // own index. The spans index the string, since that is what a copy slices.
+    const bom = String(file.value).charCodeAt(0) === 0xfeff ? 1 : 0;
     visitParents(tree, 'element', (node: Element, ancestors) => {
       if (!SOURCE_SPAN_TAGS.has(node.tagName)) return;
       if (
@@ -137,8 +141,8 @@ function rehypeAnnotateSource() {
       if (start == null || end == null) return;
       node.properties = {
         ...node.properties,
-        dataSrcStart: String(start),
-        dataSrcEnd: String(end),
+        dataSrcStart: String(start + bom),
+        dataSrcEnd: String(end + bom),
       };
     });
   };


### PR DESCRIPTION
Four fixes from a review of everything on main since v0.8.3, each with a test that failed before the change. Nothing here alters the surface that shipped in that range; each is a narrow correction to code the range introduced or exposed.

## Copy as Markdown could hand back text that was never selected

The exact-slice path checked that the selected blocks run forward in the source, but only looked at the blocks between the first and last in DOM order. Source that sits between two selected blocks and renders somewhere else was invisible to it. Two GFM footnote definitions render together at the end of the document; the paragraph between them in the file renders above both, and selecting the two footnotes copied that paragraph too, flagged `exact: true`. The guard now also refuses when any annotated block outside the run overlaps the slice, with a run block's own container or content exempt so a run of list items inside an annotated list still slices exactly.

## Source spans were one short on a BOM-prefixed file

micromark skips a UTF-8 BOM before it starts counting and nothing strips one, so every `data-src-start` / `data-src-end` on a file saved by Windows tooling was off by one: a paragraph copied with a leading newline and a missing last character, and a fenced block came back with a broken closing fence. The annotator now adds the BOM's length to every span.

## `mdr_comment` ignored an explicit `enableResolve: false`

The validator collapsed `false` into `undefined`. Harmless while the server treated a missing field as `false`, but the server now falls back to the reader's saved mode (default resolve), so an agent asking for remove mode silently got a resolve-mode session. `validateRequestReviewInput` was already fixed for this in the same range; the `filePaths` form of `mdr_comment` now matches it.

## The release eval gate parsed UTC stamps as local time

The eval runner names a results directory from `toISOString()`, but `parseRunDirName` handed the stamp to `Date.parse` with no offset, which parses as local time. Every run shifted by the machine's timezone offset: on a UTC-7 machine a run from 13 minutes before a prompt change looked 7 hours after it and the gate passed. The stamp now parses with an explicit `Z`, and the test pins the result across three timezones. The gate still passes on the current tree; the newest runs genuinely postdate both watched files.

## Verification

- `npm run build`, `npm run test:unit` (2071 passing, five new), `npm run lint`, `npm run format:check` all clean.
- The footnote and BOM cases were also driven through the real pipeline in jsdom before and after: the footnote selection now takes the rebuild path with no `Para B` in the output, and the BOM paragraph and fenced block slice to the file's own bytes.


## Two follow-ups from the same review

- **AGENTS.md**: the "Right-clicking a selection" opener still listed Templates on the viewer menu and did not mention Copy as Markdown, and the Shift+right-click paragraph said the guard tests `button === 2` when it tests `isSecondaryClick` (button 2, or ctrl+click on macOS).
- **npm package**: `files` allowed `bin/` wholesale, so every install shipped the bin unit tests, the browser stub they import, and the Windows test runner script. Three negations drop the tarball from 140 files to 129; `npm pack --dry-run` now lists only the nine runtime `.js` files under `bin/`.

The rest of the review is filed as #99 to #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQDZxycbpQxCT6VGNbSxRZ