### PR TITLE
Give a collapsed comment gutter to the prose, not the canvas

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -850,13 +850,16 @@ export default function App() {
     [marginComments],
   );
   // The anchored rail earns its gutter width only once it has a card to
-  // place. List density always reserves — its panel is intentional even when
+  // place. List density always reserves: its panel is intentional even when
   // empty. Anchored + zero non-resolved comments collapses the empty margin
   // instead of parking a wide dead gutter next to the prose. The rail itself
   // stays mounted (railShown is unaffected, so chrome and routing are
-  // unchanged); only the sheet width drops and re-centers, and colWidth is
-  // held constant so the first comment slides the gutter open without
-  // reflowing the text.
+  // unchanged); the sheet re-centers on the prose and the freed width goes to
+  // the column, so a comment-free document reads at its full Document width.
+  // Note this boundary is the open-comment count crossing 0 and 1, not a
+  // one-way door: resolving, deleting or unresolving the last comment swaps
+  // the column back the other way, and between 888 and 1080 of content width
+  // that rewraps the prose.
   const railHasContent = railDensity === 'list' || marginComments.length > 0;
   const geometry = usePageGeometry(
     containerRef as RefObject<HTMLElement | null>,

--- a/src/hooks/useMarginLayout.ts
+++ b/src/hooks/useMarginLayout.ts
@@ -46,6 +46,7 @@ export function useMarginLayout(
   const heightObserver = useRef<ResizeObserver | null>(null);
   const [remeasureTick, setRemeasureTick] = useState(0);
   const lastProseHeightRef = useRef<number | null>(null);
+  const lastProseWidthRef = useRef<number | null>(null);
 
   // Anchor measurement: one pass over painted marks per trigger (paint tick,
   // comment set change, or a late-reflow remeasure tick). Measured against
@@ -73,16 +74,26 @@ export function useMarginLayout(
 
   // Mermaid stabilization and image loads can shift prose height after the
   // paint signal already fired. Watch the prose column itself and bump a
-  // tick when its height actually changes, so the anchor-measurement effect
+  // tick when its box actually changes, so the anchor-measurement effect
   // above re-runs and catches the late reflow.
+  //
+  // Width counts as well as height: the first comment on a document collapses
+  // the empty gutter back into a reserved rail, which animates the column
+  // narrower over 150ms while the measurement effect has already run against
+  // the pre-transition layout. A rewrap that happens to land at the same
+  // total height would otherwise leave the new card on a stale top.
   useEffect(() => {
     if (!active) return;
     const prose = pageRef.current?.firstElementChild;
     if (!prose) return;
     const ro = new ResizeObserver((entries) => {
-      const height = entries[0]?.contentRect.height;
-      if (height === undefined || height === lastProseHeightRef.current) return;
-      lastProseHeightRef.current = height;
+      const box = entries[0]?.contentRect;
+      if (!box) return;
+      if (box.height === lastProseHeightRef.current && box.width === lastProseWidthRef.current) {
+        return;
+      }
+      lastProseHeightRef.current = box.height;
+      lastProseWidthRef.current = box.width;
       setRemeasureTick((t) => t + 1);
     });
     ro.observe(prose);

--- a/src/lib/page-geometry.test.ts
+++ b/src/lib/page-geometry.test.ts
@@ -55,25 +55,41 @@ describe('pageGeometry', () => {
     expect(g.colWidth).toBe(320);
   });
 
-  it('collapses the empty gutter but keeps the rail shown and column stable', () => {
+  it('collapses the empty gutter and keeps the rail shown', () => {
     // Same width as the full-rail case, but the anchored rail has no cards.
     const reserved = pageGeometry(1400, true);
     const collapsed = pageGeometry(1400, true, COL_MAX, false);
-    // Rail stays logically shown and the prose column is byte-for-byte the
-    // same, so the first comment slides the gutter open without reflowing text.
+    // The rail stays logically shown, so its chrome and focus routing are
+    // unchanged; only the sheet loses the footprint it has nothing to put in.
     expect(collapsed.railShown).toBe(true);
-    expect(collapsed.colWidth).toBe(reserved.colWidth);
-    // Only the sheet shrinks: rail footprint drops to a symmetric PAD_L.
     expect(collapsed.pageWidth).toBe(PAD_L + collapsed.colWidth + PAD_L);
     expect(collapsed.pageWidth).toBeLessThan(reserved.pageWidth);
   });
 
-  it('holds the column on the rail-shown track when collapsed mid-width', () => {
-    // 1000px: rail-shown column is 592 (below COL_MAX). Collapsing must keep
-    // that same 592 so the text does not rewrap when the first comment lands.
+  it('gives the collapsed gutter to the column, not to the canvas', () => {
+    // 1000px: the rail-shown column is 592, but with no card to place the
+    // 360px footprint belongs to the prose. Anything less leaves a
+    // comment-free document narrow between two dead margins.
     const collapsed = pageGeometry(1000, true, COL_MAX, false);
-    expect(collapsed.colWidth).toBe(592);
-    expect(collapsed.pageWidth).toBe(PAD_L + 592 + PAD_L);
+    expect(collapsed.colWidth).toBe(Math.min(1000 - 2 * PAD_L, COL_MAX));
+    expect(collapsed.colWidth).toBeGreaterThan(pageGeometry(1000, true).colWidth);
+    expect(collapsed.pageWidth).toBe(PAD_L + collapsed.colWidth + PAD_L);
+  });
+
+  it('lays a collapsed gutter out exactly like the no-rail case', () => {
+    // The two states differ only in whether the rail chrome is mounted, so
+    // their geometry must not drift apart.
+    for (const w of [900, 1000, 1200, 1400, 2000]) {
+      const collapsed = pageGeometry(w, true, COL_MAX, false);
+      const noRail = pageGeometry(w, false);
+      expect(collapsed.colWidth).toBe(noRail.colWidth);
+      expect(collapsed.pageWidth).toBe(noRail.pageWidth);
+    }
+  });
+
+  it('respects the docWidth cap when the gutter collapses', () => {
+    expect(pageGeometry(2000, true, DOC_WIDTH_COLS.narrow, false).colWidth).toBe(520);
+    expect(pageGeometry(2000, true, DOC_WIDTH_COLS.wide, false).colWidth).toBe(860);
   });
 
   it('ignores reserveRail when the rail cannot fit by width', () => {

--- a/src/lib/page-geometry.ts
+++ b/src/lib/page-geometry.ts
@@ -29,10 +29,17 @@ export interface PageGeometry {
  * `reserveRail` collapses the empty right gutter while keeping the rail
  * logically shown. When the anchored rail has no cards to place, the sheet
  * drops the rail footprint and re-centers on the prose (symmetric PAD_L),
- * but colWidth stays on the rail-shown track so the prose column never
- * reflows across the transition — only the sheet slides as the gutter opens
- * with the first comment. railShown is unaffected, so the rail's chrome
- * (density toggle, open count) stays visible.
+ * and the freed width goes to the column rather than to the canvas: a
+ * comment-free document reads at its full Document width instead of sitting
+ * narrow between two dead margins.
+ *
+ * The cost is a reflow whenever the open-comment count crosses 0 and 1 in
+ * either direction, since the column swaps tracks: adding the first comment,
+ * and equally resolving, deleting or unresolving the last one. It only
+ * rewraps text between 888 and 1080 of content width; above that both tracks
+ * clamp to colMax and only the sheet moves. That is the deliberate trade for
+ * every comment-free document reading at full measure. railShown is
+ * unaffected, so the rail chrome (density toggle, open count) stays visible.
  */
 export function pageGeometry(
   contentWidth: number,
@@ -40,13 +47,29 @@ export function pageGeometry(
   colMax: number = COL_MAX,
   reserveRail: boolean = true,
 ): PageGeometry {
+  // The column with nothing reserved to its right: the whole sheet minus
+  // symmetric padding, capped by the Document width setting. Both the
+  // collapsed-gutter case and the no-rail case land here, so an empty margin
+  // is never wider than the text it sits next to.
+  const fullCol = Math.max(Math.min(contentWidth - 2 * PAD_L, colMax), 320);
   const railCol = contentWidth - PAD_L - RAIL_FOOTPRINT;
   const railFits = railCol >= COL_MIN;
   if (railAllowed && railFits) {
+    if (!reserveRail) {
+      return {
+        railFits,
+        railShown: true,
+        colWidth: fullCol,
+        pageWidth: PAD_L + fullCol + PAD_L,
+      };
+    }
     const colWidth = Math.min(railCol, colMax);
-    const pageWidth = reserveRail ? PAD_L + colWidth + RAIL_FOOTPRINT : PAD_L + colWidth + PAD_L;
-    return { railFits, railShown: true, colWidth, pageWidth };
+    return {
+      railFits,
+      railShown: true,
+      colWidth,
+      pageWidth: PAD_L + colWidth + RAIL_FOOTPRINT,
+    };
   }
-  const colWidth = Math.max(Math.min(contentWidth - 2 * PAD_L, colMax), 320);
-  return { railFits, railShown: false, colWidth, pageWidth: PAD_L + colWidth + PAD_L };
+  return { railFits, railShown: false, colWidth: fullCol, pageWidth: PAD_L + fullCol + PAD_L };
 }


### PR DESCRIPTION
## The bug

An anchored rail with no card to place already dropped its 360px footprint from the sheet, but `colWidth` stayed on the rail-shown track. The freed width went to the canvas instead of the text, so a comment-free document sat narrow between two dead margins, and the wider the window, the more obvious it got.

Worse, it produced a discontinuity you could feel: shrinking the window past the 888px rail threshold made the column jump *wider*, because below the threshold the no-rail branch handed the column all the space the rail branch had been withholding.

**Before**, on a 1065px canvas: column 622px in a 718px sheet, roughly 350px of empty margin.

![before.png](https://github.com/user-attachments/assets/a4f3f80a-3130-4708-b3cb-62045be768d0)

**After**, same window and same Document width setting: column 860px in a 956px sheet.

![after.png](https://github.com/user-attachments/assets/533a4479-4161-4012-91f1-8ad772e95350)

## The change

`pageGeometry` now hands the collapsed gutter to the column. Both the collapsed-gutter case and the no-rail case share one `fullCol` expression, so the two layouts cannot drift apart.

`railShown` is unaffected, so the rail chrome, focus routing and density toggle behave exactly as before, and the reserved path (any document with an open comment) is byte-identical.

`useMarginLayout`'s late-reflow watcher now bumps its remeasure tick on width as well as height. A height-only guard was sufficient while the collapsed and reserved states shared a `colWidth`, because a landing comment never resized the column. It does now, over a 150ms transition, and a rewrap that lands at the same total height would otherwise leave the new card on a stale `top`.

## What this trades away

The no-reflow property the old code was protecting. The column swaps tracks whenever the open-comment count crosses 0 and 1 **in either direction**: adding the first comment, and equally resolving, deleting or unresolving the last one.

Text only rewraps between 888 and 1080 of content width. Above 1080 both tracks clamp to `colMax`, so only the sheet moves.

That is deliberate: the old behavior optimized a transition that happens a handful of times per document, and charged for it on every comment-free document, permanently.

## Verification

Dev pair on 3111/5199 against a comment-free fixture, at the `wide` Document width:

| | Before | After |
|---|---|---|
| Column, 0 comments | 622 | 860 |
| Sheet | 718, dead margins | 956, centred, 48/48 padding |

Then appended a comment marker and let the file watcher pick it up: sheet 956 to 1030, column 860 to 622, card lands beside its anchor. The 0 to 1 transition works live.

- `tsc -b` clean
- `vitest run`: 2068 passed, 1 file skipped
- `page-geometry.test.ts`: replaced the two tests that asserted the old hold-the-column behavior. New ones assert the collapsed gutter goes to the column, that a collapsed gutter lays out identically to the no-rail case across five widths, and that the docWidth cap still applies when collapsed.

E2E not run. The margin-notes specs all add a comment before measuring, so they exercise the unchanged reserved path.

## Follow-ups, not in this PR

1. **Scroll-anchor the track swap.** In the 888 to 1080 band, resolving the last comment rewraps and shortens the document under a fixed `scrollTop`, so the trace the user just clicked can move out from under the cursor.
2. **The 888px cliff itself.** Resizing across it still jumps the column, because the rail genuinely appears and disappears there. Softening that means letting the rail compress (280 to 210, gap 56 to 32) so it survives to narrower windows and the drop is smaller when it comes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5VeYrrP5E423qSArgxiMf