### PR TITLE
Add a setting to keep single line breaks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -844,7 +844,9 @@ highlighted:
   passage has to find it in the file, and rebuilt markdown may not match.
 - Anything finer: markdown rebuilt from the rendered fragment through
   `rehype-remark`, which keeps the words as selected and normalises only the
-  syntax (`_x_` may come back as `*x*`).
+  syntax (`_x_` may come back as `*x*`). A soft break comes back as a space
+  with Keep line breaks off, and as a backslash hard break (`\` then newline)
+  with it on, since the rendered `<br>` is what gets rebuilt.
 
 Widening a ragged selection out to its enclosing block was considered and
 rejected. It hands back more text than was highlighted, and people paste into a
@@ -1585,6 +1587,7 @@ with no focus chip present to explain why or restore them. Toggle the explorer
 - **Prose typeface**: `'serif'` or `'sans'`, default `'serif'`. Controls the rendered document body font (`[data-prose-font]` attribute plus `.prose` font-family in `src/index.css`). Set from the General tab.
 - **Document width**: `'narrow' | 'default' | 'wide'` (520/672/860px column caps, `DOC_WIDTH_COLS` in `src/lib/page-geometry.ts`), default `'default'`. Feeds the page geometry's `colMax`; also settable from the command palette ("Document width: ..."). The rail threshold (888px) is width-setting independent since `COL_MIN` governs it.
 - **Prose size**: `'small' | 'default' | 'large'` (14px/16px/18px), default `'default'`. Controls the rendered document body font size (`[data-prose-size]` attribute plus `.prose` font-size rules in `src/index.css`); the typography plugin's em-based spacing scales proportionally with it. Set from the General tab; also settable from the command palette ("Prose size: ...").
+- **Keep line breaks**: boolean, default `false`. When on, `remark-breaks` (in `src/markdown/pipeline.ts`, via the `keepLineBreaks` render option) turns each single newline inside a paragraph into a `<br>`, the way Obsidian and GitHub comments render. Off follows CommonMark, where a soft break renders as a space, which is also what GitHub's file view does. The DOM text does not change (remark-rehype emits a `<br>` followed by a `"\n"` text node), so comment anchoring behaves the same either way. Applies to the rendered view and the rendered diff; fenced code is untouched. Set from the General tab; also togglable from the command palette ("Keep line breaks: On/Off").
 
 The Prose typeface, Document width, and Prose size controls are each an accessible
 segmented control (`role="group"` with a label) whose segments show a crimson

--- a/e2e/settings-features.spec.ts
+++ b/e2e/settings-features.spec.ts
@@ -306,6 +306,33 @@ test.describe('Quick comment mode', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Keep line breaks
+// ---------------------------------------------------------------------------
+
+test.describe('Keep line breaks', () => {
+  const SOFT_BREAKS =
+    '# Test Document\n\n**Actor:** the creator.\n**Trigger:** what do I do now?\n';
+
+  test('joins lines by default, then keeps each source line when enabled', async ({ page }) => {
+    writeFileSync(FIXTURE, SOFT_BREAKS);
+    await openFixture(page);
+    const paragraph = page.locator('.prose p', { hasText: 'Actor:' });
+    await expect(paragraph.locator('br')).toHaveCount(0);
+
+    await toggleSetting(page, 'Keep line breaks');
+    await expect(paragraph.locator('br')).toHaveCount(1);
+  });
+
+  test('comments still anchor with line breaks kept', async ({ page }) => {
+    writeFileSync(FIXTURE, SOFT_BREAKS);
+    await openFixture(page);
+    await toggleSetting(page, 'Keep line breaks');
+    await addComment(page, 'what do I do now', 'Anchors with kept breaks');
+    await expect(page.locator('.prose mark', { hasText: 'what do I do now' })).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Middle-click tab close
 // ---------------------------------------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "rehype-remark": "^10.0.1",
         "rehype-sanitize": "^6.0.0",
         "rehype-stringify": "^10.0.1",
+        "remark-breaks": "^4.0.0",
         "remark-frontmatter": "^5.0.0",
         "remark-gfm": "^4.0.1",
         "remark-parse": "^11.0.0",
@@ -6392,6 +6393,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-newline-to-break": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-newline-to-break/-/mdast-util-newline-to-break-2.0.0.tgz",
+      "integrity": "sha512-MbgeFca0hLYIEx/2zGsszCSEJJ1JSCdiY5xQxRcLDDGa8EPvlLPupJ4DSajbMPAnC0je8jfb9TiUATnxxrHUog==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-find-and-replace": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
@@ -7807,6 +7822,21 @@
       "dependencies": {
         "@types/hast": "^3.0.0",
         "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-breaks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-breaks/-/remark-breaks-4.0.0.tgz",
+      "integrity": "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-newline-to-break": "^2.0.0",
         "unified": "^11.0.0"
       },
       "funding": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "rehype-remark": "^10.0.1",
     "rehype-sanitize": "^6.0.0",
     "rehype-stringify": "^10.0.1",
+    "remark-breaks": "^4.0.0",
     "remark-frontmatter": "^5.0.0",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/server/preferences.test.ts
+++ b/server/preferences.test.ts
@@ -837,7 +837,12 @@ describe('cross-process file lock', () => {
     // DEFAULT_SETTINGS always carries every AppSettings key, so a field added
     // on the client that the server whitelist drops fails this test even if
     // the compile-time exhaustiveness check in SETTING_SANITIZERS is bypassed.
-    const full: ClientAppSettings = { ...DEFAULT_SETTINGS, proseFont: 'sans', docWidth: 'wide' };
+    const full: ClientAppSettings = {
+      ...DEFAULT_SETTINGS,
+      proseFont: 'sans',
+      docWidth: 'wide',
+      keepLineBreaks: true,
+    };
     const result = await writePreferences(testDir, { settings: full });
     expect(result.settings).toEqual(full);
     expect(await readPreferences(testDir)).toEqual({ settings: full });

--- a/server/preferences.ts
+++ b/server/preferences.ts
@@ -96,6 +96,7 @@ const SETTING_SANITIZERS: {
   proseFont: (v) => sanitizeEnum(PROSE_FONTS, v),
   docWidth: (v) => sanitizeEnum(DOC_WIDTHS, v),
   proseSize: (v) => sanitizeEnum(PROSE_SIZES, v),
+  keepLineBreaks: sanitizeBoolean,
 };
 
 function sanitizeSettings(value: unknown): AppSettings | undefined {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -323,7 +323,7 @@ export default function App() {
   const [homeDir, setHomeDir] = useState<string>('');
   const { recentFiles, addRecentFile, clearRecentFiles } = useRecentFiles();
   const { author, setAuthor } = useAuthor();
-  const { settings, updateDocWidth, updateProseSize } = useSettings();
+  const { settings, updateDocWidth, updateProseSize, updateKeepLineBreaks } = useSettings();
   const setTheme = useSetPersistedTheme();
   const { explorerWidth, mermaidPanelWidth, onResizeStart, isDragging } = useResizablePanel();
   const pageVisible = usePageVisible();
@@ -763,6 +763,7 @@ export default function App() {
     saveFile,
     author,
     enableResolve: settings.enableResolve,
+    keepLineBreaks: settings.keepLineBreaks,
     tabs,
     activeFilePath,
     viewerRef,
@@ -2390,6 +2391,12 @@ export default function App() {
         onExecute: () => updateProseSize('large'),
       },
       {
+        id: 'toggle-keep-line-breaks',
+        label: settings.keepLineBreaks ? 'Keep line breaks: Off' : 'Keep line breaks: On',
+        section: 'View',
+        onExecute: () => updateKeepLineBreaks(!settings.keepLineBreaks),
+      },
+      {
         id: 'view-raw',
         label: 'Switch to raw markdown',
         section: 'View',
@@ -2456,6 +2463,8 @@ export default function App() {
     setViewMode,
     updateDocWidth,
     updateProseSize,
+    updateKeepLineBreaks,
+    settings.keepLineBreaks,
     setExplorerVisibleGuarded,
     setLeftPanelView,
     explorerVisible,
@@ -3158,6 +3167,7 @@ export default function App() {
                                 rawMarkdown={rawMarkdown}
                                 diffSnapshot={currentSnapshot}
                                 diffLines={diffLines}
+                                keepLineBreaks={settings.keepLineBreaks}
                               />
                             ) : (
                               <>

--- a/src/components/RenderedDiffView.tsx
+++ b/src/components/RenderedDiffView.tsx
@@ -283,6 +283,8 @@ interface Props {
    * component renders the same change set the raw view sees.
    */
   diffLines: DiffLine[];
+  /** Render single source newlines as line breaks, matching the main view. */
+  keepLineBreaks: boolean;
 }
 
 function escapeHtmlAttr(s: string): string {
@@ -290,7 +292,7 @@ function escapeHtmlAttr(s: string): string {
 }
 
 export const RenderedDiffView = forwardRef<RenderedDiffViewHandle, Props>(function RenderedDiffView(
-  { rawMarkdown, diffSnapshot, diffLines },
+  { rawMarkdown, diffSnapshot, diffLines, keepLineBreaks },
   ref,
 ) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -317,6 +319,7 @@ export const RenderedDiffView = forwardRef<RenderedDiffViewHandle, Props>(functi
     for (const [segIndex, seg] of segments.entries()) {
       const inner = renderMarkdown(seg.text, undefined, {
         allowFrontmatter: segmentIsDocumentStart(segments, segIndex),
+        keepLineBreaks,
       });
       if (seg.type === 'same') {
         parts.push(inner);
@@ -329,7 +332,7 @@ export const RenderedDiffView = forwardRef<RenderedDiffViewHandle, Props>(functi
       }
     }
     return parts.join('');
-  }, [segments]);
+  }, [segments, keepLineBreaks]);
 
   // Reset active chunk when the diff itself changes.
   useEffect(() => {

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -26,6 +26,7 @@ export function SettingsPanel({ open, onClose, author, onAuthorChange }: Props) 
     updateProseFont,
     updateDocWidth,
     updateProseSize,
+    updateKeepLineBreaks,
     resetTemplates,
   } = useSettings();
   const { theme, setTheme } = useThemePersistence();
@@ -718,6 +719,33 @@ export function SettingsPanel({ open, onClose, author, onAuthorChange }: Props) 
                       ))}
                     </div>
                   </div>
+                </div>
+
+                {/* Keep Line Breaks */}
+                <div>
+                  <label className="flex items-center justify-between gap-4">
+                    <div>
+                      <h3 className="text-sm font-semibold text-content">Keep line breaks</h3>
+                      <p className="text-xs text-content-muted mt-0.5">
+                        Show a single line break in the file as a new line. Off follows standard
+                        Markdown, which joins those lines into one paragraph.
+                      </p>
+                    </div>
+                    <button
+                      role="switch"
+                      aria-checked={settings.keepLineBreaks}
+                      onClick={() => updateKeepLineBreaks(!settings.keepLineBreaks)}
+                      className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+                        settings.keepLineBreaks ? 'bg-primary' : 'bg-border'
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow-sm transition-transform ${
+                          settings.keepLineBreaks ? 'translate-x-[18px]' : 'translate-x-[3px]'
+                        }`}
+                      />
+                    </button>
+                  </label>
                 </div>
 
                 {/* Comment Max Length */}

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -30,6 +30,7 @@ interface SettingsContextValue {
   updateProseFont: (font: 'serif' | 'sans') => void;
   updateDocWidth: (width: DocWidth) => void;
   updateProseSize: (size: ProseSize) => void;
+  updateKeepLineBreaks: (keep: boolean) => void;
   resetTemplates: () => void;
   resetAll: () => void;
 }
@@ -130,6 +131,11 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const updateProseSize = useCallback((proseSize: ProseSize) => update({ proseSize }), [update]);
 
+  const updateKeepLineBreaks = useCallback(
+    (keepLineBreaks: boolean) => update({ keepLineBreaks }),
+    [update],
+  );
+
   const resetTemplates = useCallback(() => update({ templates: DEFAULT_TEMPLATES }), [update]);
 
   const resetAll = useCallback(() => {
@@ -156,6 +162,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         updateProseFont,
         updateDocWidth,
         updateProseSize,
+        updateKeepLineBreaks,
         resetTemplates,
         resetAll,
       }}

--- a/src/hooks/useComments.test.ts
+++ b/src/hooks/useComments.test.ts
@@ -38,6 +38,7 @@ function defaultParams(overrides: Partial<UseCommentsParams> = {}): UseCommentsP
     saveFile: vi.fn(),
     author: 'Tester',
     enableResolve: false,
+    keepLineBreaks: false,
     tabs: [],
     activeFilePath: null,
     viewerRef: {

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -60,6 +60,8 @@ export interface UseCommentsParams {
   saveFile: (content: string) => void;
   author: string;
   enableResolve: boolean;
+  /** Render single source newlines as line breaks (the Keep line breaks setting). */
+  keepLineBreaks: boolean;
   tabs: TabInfo[];
   activeFilePath: string | null;
   viewerRef: RefObject<MarkdownViewerHandle | null>;
@@ -78,6 +80,7 @@ export function useComments(params: UseCommentsParams) {
     saveFile,
     author,
     enableResolve,
+    keepLineBreaks,
     tabs,
     activeFilePath,
     viewerRef,
@@ -98,8 +101,11 @@ export function useComments(params: UseCommentsParams) {
 
   // Render markdown to HTML
   const html = useMemo(
-    () => (cleanMarkdown ? renderMarkdown(cleanMarkdown, activeFilePath ?? undefined) : ''),
-    [cleanMarkdown, activeFilePath],
+    () =>
+      cleanMarkdown
+        ? renderMarkdown(cleanMarkdown, activeFilePath ?? undefined, { keepLineBreaks })
+        : '',
+    [cleanMarkdown, activeFilePath, keepLineBreaks],
   );
 
   // Detect missing anchors

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -104,6 +104,7 @@ describe('parseSettings', () => {
       proseFont: 'serif',
       docWidth: 'wide',
       proseSize: 'large',
+      keepLineBreaks: true,
     };
     expect(parseSettings(full)).toEqual(full);
   });
@@ -118,6 +119,18 @@ describe('parseSettings docWidth', () => {
   it('accepts narrow, default, and wide', () => {
     expect(parseSettings({ docWidth: 'narrow' }).docWidth).toBe('narrow');
     expect(parseSettings({ docWidth: 'wide' }).docWidth).toBe('wide');
+  });
+});
+
+describe('parseSettings keepLineBreaks', () => {
+  it('defaults to off, which is CommonMark', () => {
+    expect(DEFAULT_SETTINGS.keepLineBreaks).toBe(false);
+    expect(parseSettings({}).keepLineBreaks).toBe(false);
+  });
+
+  it('keeps a stored boolean and ignores anything else', () => {
+    expect(parseSettings({ keepLineBreaks: true }).keepLineBreaks).toBe(true);
+    expect(parseSettings({ keepLineBreaks: 'yes' }).keepLineBreaks).toBe(false);
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -32,6 +32,8 @@ export interface AppSettings {
   docWidth: DocWidth;
   /** Font size for rendered document prose (small 14px, default 16px, large 18px). */
   proseSize: ProseSize;
+  /** Render a single newline in the source as a line break instead of a space. Off follows CommonMark. */
+  keepLineBreaks: boolean;
 }
 
 /**
@@ -115,6 +117,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   proseFont: 'serif',
   docWidth: 'default',
   proseSize: 'default',
+  keepLineBreaks: false,
 };
 
 /**
@@ -174,5 +177,9 @@ export function parseSettings(input: unknown): AppSettings {
     proseSize: PROSE_SIZES.includes(parsed.proseSize as ProseSize)
       ? (parsed.proseSize as ProseSize)
       : DEFAULT_SETTINGS.proseSize,
+    keepLineBreaks:
+      typeof parsed.keepLineBreaks === 'boolean'
+        ? parsed.keepLineBreaks
+        : DEFAULT_SETTINGS.keepLineBreaks,
   };
 }

--- a/src/markdown/pipeline.test.ts
+++ b/src/markdown/pipeline.test.ts
@@ -72,6 +72,39 @@ describe('renderMarkdown source positions', () => {
   });
 });
 
+describe('renderMarkdown keepLineBreaks', () => {
+  const md = '**Actor:** the creator.\n**Trigger:** what now?';
+  const textOf = (html: string) => html.replace(/<[^>]+>/g, '');
+
+  it('joins soft-broken lines by default, as CommonMark does', () => {
+    expect(renderMarkdown(md)).not.toContain('<br>');
+  });
+
+  it('turns each single newline into a line break when on', () => {
+    const html = renderMarkdown(md, undefined, { keepLineBreaks: true });
+    expect(html).toContain('the creator.<br>\n<strong>Trigger:</strong>');
+  });
+
+  it('leaves the text that comment anchoring searches unchanged', () => {
+    expect(textOf(renderMarkdown(md, undefined, { keepLineBreaks: true }))).toBe(
+      textOf(renderMarkdown(md)),
+    );
+  });
+
+  it('does not touch fenced code', () => {
+    const fenced = '```\nline one\nline two\n```';
+    expect(renderMarkdown(fenced, undefined, { keepLineBreaks: true })).toBe(
+      renderMarkdown(fenced),
+    );
+  });
+
+  it('keeps the source span a whole-paragraph copy slices by', () => {
+    expect(renderMarkdown(md, undefined, { keepLineBreaks: true })).toContain(
+      `data-src-start="0" data-src-end="${md.length}"`,
+    );
+  });
+});
+
 describe('renderMarkdown', () => {
   it('renders basic markdown (headings, paragraphs, bold, italic)', () => {
     const md = '# Hello\n\nThis is **bold** and *italic*.';

--- a/src/markdown/pipeline.ts
+++ b/src/markdown/pipeline.ts
@@ -2,6 +2,7 @@ import { unified } from 'unified';
 import remarkParse from 'remark-parse';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkGfm from 'remark-gfm';
+import remarkBreaks from 'remark-breaks';
 import remarkRehype from 'remark-rehype';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
@@ -256,7 +257,7 @@ function frontmatterHandler(_state: unknown, node: { value: string }): Element |
   };
 }
 
-function buildProcessor(filePath?: string, allowFrontmatter = true) {
+function buildProcessor(filePath?: string, allowFrontmatter = true, keepLineBreaks = false) {
   const processor = unified().use(remarkParse);
   // Frontmatter is defined as being at offset 0 of the DOCUMENT. A caller
   // rendering a fragment (the diff overlay renders one segment at a time) has
@@ -264,8 +265,14 @@ function buildProcessor(filePath?: string, allowFrontmatter = true) {
   // this on invents a frontmatter block out of any `---` that happens to start
   // a segment.
   if (allowFrontmatter) processor.use(remarkFrontmatter, ['yaml', 'toml']);
+  processor.use(remarkGfm);
+  // A single newline is a soft break in CommonMark and renders as a space.
+  // remark-breaks turns each one into a hard break instead. The visible text
+  // does not change: remark-rehype emits every break as a <br> followed by a
+  // "\n" text node, so the DOM text that comment anchoring searches reads the
+  // same with the setting on or off.
+  if (keepLineBreaks) processor.use(remarkBreaks);
   return processor
-    .use(remarkGfm)
     .use(remarkRehype, {
       allowDangerousHtml: true,
       handlers: { yaml: frontmatterHandler, toml: frontmatterHandler },
@@ -285,6 +292,11 @@ export interface RenderOptions {
    * fragment's offset 0 is not the document's.
    */
   allowFrontmatter?: boolean;
+  /**
+   * Render a single newline in the source as a line break rather than a
+   * space. Off by default, which is CommonMark and what GitHub's file view does.
+   */
+  keepLineBreaks?: boolean;
 }
 
 export function renderMarkdown(
@@ -292,7 +304,7 @@ export function renderMarkdown(
   filePath?: string,
   options: RenderOptions = {},
 ): string {
-  const { allowFrontmatter = true } = options;
-  const file = buildProcessor(filePath, allowFrontmatter).processSync(markdown);
+  const { allowFrontmatter = true, keepLineBreaks = false } = options;
+  const file = buildProcessor(filePath, allowFrontmatter, keepLineBreaks).processSync(markdown);
   return String(file);
 }


### PR DESCRIPTION
A single newline inside a paragraph is a soft break in CommonMark and renders as a space. Agent-written specs often put one labeled field per line (`**Actor:**`, `**Trigger:**`, `**Outcome:**`) with no blank line between them, and those read as one run-on paragraph even though the source clearly means separate lines.

## Keep line breaks

A new switch in Settings > General, below Prose size, plus a "Keep line breaks: On/Off" command in the palette. When on, the pipeline adds `remark-breaks`, so each single newline in a paragraph renders as a line break, the way Obsidian and GitHub comments do. It is off by default, which is CommonMark and what GitHub's file view shows for the same file.

It applies to the rendered view and the rendered diff. Fenced code is untouched.

Off (default), the fields in each flow run together:

![pr-linebreaks-off.png](https://github.com/user-attachments/assets/b10e6956-51d6-407b-b3f4-83b03966d182)

On, each field starts its own line; the blank-line paragraph and the code block are unchanged:

![pr-linebreaks-on.png](https://github.com/user-attachments/assets/2568010c-a809-4691-9a66-7d61bc4067ab)

The switch, in the General tab:

![pr-linebreaks-settings.png](https://github.com/user-attachments/assets/02dba332-77ea-49ee-9ced-ec413cc114af)

## Why comment anchoring is unaffected

remark-rehype emits every break as a `<br>` followed by a `"\n"` text node, and remark-breaks removes the newline it replaces, so the concatenated DOM text is identical with the setting on or off. The text that anchoring searches does not change, and block source spans (what Copy as Markdown slices by) still cover whole paragraphs.

One visible difference: a ragged selection copied as Markdown across a kept break comes back with a backslash hard break (`\` then a newline) instead of a space, because the rebuild path converts the rendered `<br>`. Neither form is byte-identical to the source, and whole-block copies still slice the file exactly. This is documented in AGENTS.md.

## Verification

- `tsc -b`, eslint and prettier clean on the changed files.
- `vitest run`: 2075 passing, including new tests for the pipeline option, settings parsing, and the server whitelist round-trip.
- `e2e/settings-features.spec.ts`: 13 passing, two new (the toggle adds `<br>`s; a comment still anchors with the setting on).
- Driven in the running app on a real spec: turning the setting on re-renders live, and every existing comment highlight stays anchored.

Adds `remark-breaks` ^4.0.0 as a runtime dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S5VeYrrP5E423qSArgxiMf
