### PR TITLE
Let a triple-click widen a quick-comment selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -717,7 +717,11 @@ or any template opens the full form with the template grid hidden; the footer's
 selection while the document scrolls (live DOM selection when available, a
 scroll-delta fallback for locked selections) and hides while the selected text is
 off-screen. The **Quick comment** setting skips the pill entirely and opens the
-full form immediately on selection, as before. The pill's width is capped to
+full form immediately on selection, as before. That form locks its selection on
+mount, which lands between a triple-click's second and third presses, so
+`useSelection` lets the next press of the multi-click that committed a locked
+selection replace it (the lock carries over): a triple-click anchors the whole
+line, not the word its double-click opened the form on. The pill's width is capped to
 `calc(100vw - 24px)` so it never overflows on narrow windows, and its buttons
 show a crimson focus-visible ring on keyboard focus.
 

--- a/e2e/selection-pill.spec.ts
+++ b/e2e/selection-pill.spec.ts
@@ -3,7 +3,7 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { TEST_DOC_BASELINE } from './helpers/fixture-baselines';
-import { resetTestAppState } from './helpers/test-state';
+import { clearPersistedPreferences, resetTestAppState } from './helpers/test-state';
 import { addComment } from './helpers/comments';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -179,5 +179,47 @@ test.describe('Selection pill', () => {
     await selectOutsideProse(page, 'Is this per tenant?');
 
     await expect(page.locator('[data-comment-form]')).toHaveCount(0);
+  });
+});
+
+test.describe('triple-click with quick comment on', () => {
+  // Quick comment persists to the prefs file that every later spec boots into.
+  test.afterAll(() => clearPersistedPreferences());
+
+  test('anchors the composer to the line a triple-click selects', async ({ page }) => {
+    // The second press selects a word, and quick comment opens and locks the
+    // composer on it. The third press then widened only the browser's
+    // highlight, so the composer kept offering the word.
+    await page.request.put('/api/preferences', { data: { settings: { quickComment: true } } });
+    await openFixture(page);
+    await expect(page.getByRole('heading', { name: 'Section One' })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const point = await page.evaluate(() => {
+      const heading = [...document.querySelectorAll('.prose h2')].find((h) =>
+        h.textContent?.includes('Section One'),
+      );
+      if (!heading) throw new Error('"Section One" heading not found');
+      const walker = document.createTreeWalker(heading, NodeFilter.SHOW_TEXT);
+      let node: Text | null;
+      while ((node = walker.nextNode() as Text | null)) {
+        const idx = node.textContent?.indexOf('Section') ?? -1;
+        if (idx < 0) continue;
+        const range = document.createRange();
+        range.setStart(node, idx);
+        range.setEnd(node, idx + 'Section'.length);
+        const rect = range.getBoundingClientRect();
+        return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+      }
+      throw new Error('"Section" not found in the heading');
+    });
+    // Real presses rather than a synthetic mouseup: the bug is in how the three
+    // presses of one gesture arrive.
+    await page.mouse.click(point.x, point.y, { clickCount: 3 });
+
+    await expect(page.locator('[data-comment-form]')).toContainText('“Section One”', {
+      timeout: 5000,
+    });
   });
 });

--- a/src/hooks/useSelection.test.ts
+++ b/src/hooks/useSelection.test.ts
@@ -405,3 +405,80 @@ describe('useSelection modality routing', () => {
     expect(mockResolve).toHaveBeenCalledTimes(1);
   });
 });
+
+// A triple-click reaches the page as three presses. The second selects a word,
+// which is committed and, with Quick comment on, locked by the composer on
+// mount, all before the third press widens the native selection to the line.
+describe('useSelection multi-click', () => {
+  const WORD: SelectionInfo = { ...INFO, text: 'gets' };
+  const LINE: SelectionInfo = { ...INFO, text: 'F4. A member asks and gets a cited answer' };
+
+  /**
+   * One press of a multi-click. The browser fires a pointerdown for each press
+   * and numbers them in the mouseup's `detail`: 1, then 2, then 3.
+   */
+  function click(detail: number, target: EventTarget = document) {
+    pointerDown('mouse');
+    act(() => {
+      target.dispatchEvent(new MouseEvent('mouseup', { button: 0, detail, bubbles: true }));
+    });
+  }
+
+  function doubleClickAndLock() {
+    mockResolve.mockReturnValue(null);
+    click(1);
+    mockResolve.mockReturnValue(WORD);
+    click(2);
+    act(() => hook().lockSelection());
+  }
+
+  it('the third press of a triple-click replaces the word its double-click locked', () => {
+    doubleClickAndLock();
+    mockResolve.mockReturnValue(LINE);
+    click(3);
+    expect(hook().selection).toEqual(LINE);
+  });
+
+  it('the line a triple-click selects stays locked', () => {
+    doubleClickAndLock();
+    mockResolve.mockReturnValue(LINE);
+    click(3);
+
+    // Unlocking here would let the next stray click clear the composer and
+    // whatever the reader had typed into it.
+    mockResolve.mockReturnValue(null);
+    click(1);
+    expect(hook().selection).toEqual(LINE);
+  });
+
+  it('a triple-click made after the lock does not replace the locked selection', () => {
+    // The composer is open on a drag selection, possibly with a comment typed,
+    // and the reader triple-clicks somewhere else. None of those presses
+    // committed what is locked, so none of them may replace it.
+    click(1);
+    act(() => hook().lockSelection());
+    mockResolve.mockReturnValue(LINE);
+    click(1);
+    click(2);
+    click(3);
+    expect(hook().selection).toEqual(INFO);
+  });
+
+  it('a third press that resolves to nothing keeps the locked word', () => {
+    doubleClickAndLock();
+    mockResolve.mockReturnValue(null);
+    click(3);
+    expect(hook().selection).toEqual(WORD);
+  });
+
+  it('a third press inside the composer does not replace the locked word', () => {
+    doubleClickAndLock();
+    const form = document.createElement('div');
+    form.setAttribute('data-comment-form', '');
+    document.body.appendChild(form);
+    mockResolve.mockReturnValue(LINE);
+    click(3, form);
+    expect(hook().selection).toEqual(WORD);
+    form.remove();
+  });
+});

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -106,6 +106,10 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
     // Whether the gesture in progress started inside something that must not
     // lose the selection: the pill, the comment form, a drag handle.
     let pointerInPreserved = false;
+    // The press that committed the current selection: its multi-click count
+    // and the epoch right after the commit. handleMouseUp reads it to tell the
+    // next press of the same double- or triple-click from a new gesture.
+    let lastCommit: { epoch: number; detail: number } | null = null;
     const handlePointerDown = (e: PointerEvent) => {
       // A new gesture invalidates any timer armed by the previous one.
       epochRef.current += 1;
@@ -133,7 +137,19 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
       if (isSecondaryClick(e) && (e.target as HTMLElement)?.closest?.(SELECTION_MARK_SELECTOR)) {
         return;
       }
-      if (lockedRef.current) return;
+      // A locked selection ignores mouseups, except the next press of the
+      // multi-click that committed it. A triple-click arrives as three presses:
+      // the second commits a word, which quick comment locks as its composer
+      // mounts, and the third widens the browser's highlight to the whole line.
+      // Ignoring that press left the composer anchored to the word. `detail`
+      // numbers the presses, and an epoch moved by exactly this press's
+      // pointerdown means nothing else wrote a selection in between.
+      const continuesCommit =
+        lastCommit !== null &&
+        e.detail >= 2 &&
+        e.detail === lastCommit.detail + 1 &&
+        epochRef.current === lastCommit.epoch + 1;
+      if (lockedRef.current && !continuesCommit) return;
       if ((e.target as Element)?.closest?.('[data-comment-form]')) return;
       if ((e.target as Element)?.closest?.('[data-drag-handle]')) return;
       if ((e.target as Element)?.closest?.('[data-preserve-selection]')) return;
@@ -141,9 +157,14 @@ export function useSelection(containerRef: React.RefObject<HTMLElement | null>) 
       if (!containerRef.current) return;
 
       const info = resolveSelection(containerRef.current);
+      // That press may replace a locked selection but never clear it, and the
+      // lock carries over to the replacement: the composer does not remount,
+      // so nothing would lock it again.
+      if (lockedRef.current && !info) return;
       // Also clears any pending touch selection: the mouse gesture supersedes
       // it, whether it resolved to something or collapsed to nothing.
       commitSelection(info);
+      lastCommit = info ? { epoch: epochRef.current, detail: e.detail } : null;
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {


### PR DESCRIPTION
## The bug

With Quick comment on, triple-clicking a line highlighted all of it, but the composer said "Commenting on: gets", the word under the pointer. With Quick comment off, the same gesture anchored the line.

A triple-click reaches the page as three presses, and the second one is a complete double-click: it selects a word, `useSelection` commits it, and the Quick comment composer locks that selection the moment it mounts. The third press widens the browser's highlight to the whole line, but `handleMouseUp` ignores every press while a selection is locked, so the anchor stayed on the word.

Measured in the running app: mouseups with click counts 1, 2 and 3; after the third, a native selection of the full heading; the painted mark and the composer still on the word.

Not a regression. The lock-on-mount has been there since Quick comment shipped.

## The change

A locked selection now yields to one press only: the next press of the multi-click that committed it. `handleMouseUp` records the committing press's click count (`detail`) and the epoch right after the commit. A press counts as a continuation when its `detail` is one higher and the epoch moved only by its own pointerdown, so nothing else wrote a selection in between.

That press may replace the locked selection but never clear it, and the lock carries over. The composer does not remount on a new selection, so nothing else would lock it again, and an unlocked composer can be closed by the next stray click along with whatever was typed into it.

## What stays the same

- A triple-click started after the lock (the composer open, maybe with a draft) cannot replace the selection, because none of its presses committed what is locked.
- Presses inside the composer, on drag handles or on preserved surfaces are still ignored.
- A third press that resolves to nothing keeps the locked word.
- Quick comment off is unchanged. Nothing is locked there, so the third press already re-resolved.

## Verification

- **Unit:** 5 new tests in `useSelection.test.ts`. The two core cases failed first with the selection stuck on `gets`; the other three pin the cases above. Full suite: 2078 passed. `tsc -b` and eslint clean.
- **E2E:** a real triple-click in `selection-pill.spec.ts` with Quick comment on. It failed before the fix with the composer reading "Section" instead of "Section One", and passes after. Across `selection-pill`, `context-menu`, `touch-selection` and `copy-selection`, 45 passed. The one failure, `ctrl+click, the macOS secondary click, keeps the selection`, fails the same way on `main` and only runs on macOS.
- **Not verified** in the desktop shell's WKWebView. The change reads only the click count, which WebKit reports the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G95hw5r82PcpbL2UsEHuSJ
