### PR TITLE
Paint a double-clicked word where it was clicked

### DIFF
--- a/src/components/MarkdownViewer.test.tsx
+++ b/src/components/MarkdownViewer.test.tsx
@@ -10,6 +10,7 @@ import {
 } from './MarkdownViewer';
 import { renderMarkdown } from '../markdown/pipeline';
 import { insertComment, parseComments } from '../lib/comment-parser';
+import { getVisibleTextOffset } from '../lib/visible-text';
 
 describe('matchTableScroll', () => {
   it('restores offsets to the same tables when nothing changed', () => {
@@ -475,6 +476,53 @@ describe('MarkdownViewer selection highlights', () => {
 
     const leadingCode = paragraph?.querySelector('mark.selection-highlight > code');
     expect(leadingCode?.textContent).toBe('md-redline');
+  });
+
+  it('paints the occurrence at the selection offset, not a copy just before it', async () => {
+    // Table cells run together in the rendered text, so a row ending in
+    // "knowledge source" puts a second "source" a few characters before the
+    // bold one that starts the next row.
+    const markdown =
+      '| Say this | Engineering calls it |\n| --- | --- |\n| **library** | knowledge source |\n| **source** (one connected channel) | connector |\n';
+    const props = {
+      html: renderMarkdown(markdown),
+      cleanMarkdown: markdown,
+      comments: [],
+      activeCommentId: null,
+      onHighlightClick: vi.fn(),
+    };
+
+    // jsdom has no ResizeObserver, and the viewer observes every table for
+    // its scroll cues.
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    try {
+      const { container, rerender } = render(
+        <MarkdownViewer {...props} selectionText={null} selectionOffset={null} />,
+      );
+      const prose = container.querySelector('.prose') as HTMLElement;
+      const target = Array.from(prose.querySelectorAll('td strong')).find(
+        (el) => el.textContent === 'source',
+      );
+      // The offset the selection resolver reports for a double-click on it.
+      const offset = getVisibleTextOffset(prose, target!.firstChild!, 0);
+
+      rerender(<MarkdownViewer {...props} selectionText="source" selectionOffset={offset} />);
+
+      await waitFor(() => {
+        expect(container.querySelector('mark.selection-highlight')).not.toBeNull();
+      });
+      const row = container.querySelector('mark.selection-highlight')?.closest('tr');
+      expect(row?.querySelector('td')?.textContent).toBe('source (one connected channel)');
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });
 

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -514,6 +514,9 @@ export const MarkdownViewer = memo(
             if (!textEl.closest('.mermaid-block')) return;
             applyMermaidSvgTextHighlight(textEl, mermaidTheme, true, matchStart, matchEnd);
           },
+          // The selection resolver measured this offset over the same text
+          // nodes, so it is exact.
+          true,
         );
       }
 
@@ -695,6 +698,8 @@ export const MarkdownViewer = memo(
  *  When `hintOffset` is provided (in rendered/plain-text space), uses it to disambiguate
  *  duplicate anchor text. When `contextBefore`/`contextAfter` are provided, uses them as
  *  primary disambiguation (more reliable than offset across coordinate spaces).
+ *  `exactHint` marks a hint measured over these same text nodes, so a match
+ *  starting exactly there is taken before any other disambiguation.
  *  Handles text that spans multiple DOM elements. */
 function wrapText(
   container: HTMLElement,
@@ -704,6 +709,7 @@ function wrapText(
   contextBefore?: string,
   contextAfter?: string,
   onSvgText?: (textEl: SVGElement, matchStart: number, matchEnd: number) => void,
+  exactHint = false,
 ) {
   // Collect ALL text nodes — include those inside marks to support overlapping highlights
   const allTextNodes = collectVisibleTextNodes(container);
@@ -722,7 +728,17 @@ function wrapText(
   // Find the match. The fallback tiers (literal → stripped → Mermaid label →
   // flexibleSearch) are shared between the hint-offset and no-offset paths;
   // see findMatchRange for the consolidated implementation.
-  const matchRange = findMatchRange(fullText, text, hintOffset, contextBefore, contextAfter);
+  //
+  // An exact hint that lands on the text is taken as is. Without context,
+  // findMatchRange takes the first match starting up to 20 characters before
+  // the hint, and table cells run together in this text: a double-click on a
+  // bold "source" opening a row painted the "knowledge source" ending the row
+  // above. Comment hints come from the markdown, where table pipes push them
+  // off the rendered text, so they keep the window.
+  const matchRange =
+    exactHint && hintOffset !== undefined && fullText.startsWith(text, hintOffset)
+      ? { start: hintOffset, end: hintOffset + text.length }
+      : findMatchRange(fullText, text, hintOffset, contextBefore, contextAfter);
   if (!matchRange) return;
   const matchStart = matchRange.start;
   const matchEnd = matchRange.end;


### PR DESCRIPTION
## The bug

Double-clicking a word in a table could highlight a copy of it in the row above. In a vocabulary table, a double-click on the bold "source" opening a row painted the "source" at the end of "knowledge source" in the previous row's last cell, while the composer read "Commenting on: source".

Table cells run together in the rendered text ("…knowledge source" + "source (one connected…"), so the two copies sat six characters apart. The pending selection is painted by `wrapText` with the resolver's offset and no context, and without context `pickLiteralOccurrence` takes the first match starting up to 20 characters before the hint. Measured in the running app: hint 15227, matches at 15221 and 15227, and the window chose 15221.

Submitting was never affected. `insertComment` scores the stored context and anchors the right copy, and saved highlights render from that. Only the highlight shown while composing was wrong.

## The change

The selection's offset is exact: `resolveSelection` measures it over the same text nodes `wrapText` searches. `wrapText` now takes an `exactHint` flag, set only by the selection call, and uses a match that starts exactly at the hint as is. If the selected text does not sit exactly there (a multi-cell selection whose `toString()` adds tabs, for example), it falls through to `findMatchRange` as before.

## What stays the same

- Comment highlights keep the 20-character window. Their hint comes from the markdown, where table pipes and `| --- |` rows push it off the rendered text, so an exact hit there can be a coincidence. An earlier version put the exact-hit rule inside `pickLiteralOccurrence`, which would have applied it to context-free comments (recovered anchors, agent comments sent without context) too. Review caught that, and `pickLiteralOccurrence` is unchanged from `main`.
- The backward-expansion case the window exists for (a drag handle pulling an anchor's start left of its marker) is untouched.

## Verification

- **Unit:** a new test in `MarkdownViewer.test.tsx` renders the two-row table and measures the hint with the resolver's own `getVisibleTextOffset`. It failed first with the mark in the "library" row, and fails again with the flag switched off. Full suite: 2074 passed. `tsc -b` and eslint clean.
- **E2E:** `drag-regression` and `selection-pill`, 10 passed, including the four backward-expansion drag cases.
- **In the app:** checked on the reporting document with the first version of the fix, where the mark landed in the right row. The final version is covered by the unit test, which reproduces the same layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PHyut2xM5V1K8sRYvQ8p1o
