### PR TITLE
Keep the comment form on screen when pasted text grows it

### DIFF
--- a/e2e/commenting.spec.ts
+++ b/e2e/commenting.spec.ts
@@ -531,6 +531,27 @@ test.describe('Comment form click-outside dismiss', () => {
   });
 });
 
+test.describe('Comment form placement', () => {
+  test('a long paste keeps the form and its buttons on screen', async ({ page }) => {
+    await openFixture(page);
+    await selectText(page, 'This is a test document');
+    await page.locator('[data-comment-form] button', { hasText: 'Comment' }).click();
+    const form = page.locator('[data-comment-form]');
+    const textarea = page.getByPlaceholder('Add your comment...');
+    await expect(textarea).toBeFocused();
+
+    // One input event, the way a paste or a dictation tool delivers text. Typed
+    // text re-measured the form on the next key, so it hid the bug.
+    await page.keyboard.insertText(
+      Array.from({ length: 20 }, (_, i) => `Line ${i + 1} of a long comment`).join('\n'),
+    );
+
+    await expect(form).toBeInViewport({ ratio: 1 });
+    await expect(form.getByRole('button', { name: 'Comment' })).toBeInViewport({ ratio: 1 });
+    await expect(form.getByRole('button', { name: 'Cancel' })).toBeInViewport({ ratio: 1 });
+  });
+});
+
 test.describe('Sidebar toggle', () => {
   test.use({ viewport: { width: 1600, height: 900 } });
 

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -197,6 +197,10 @@ export function CommentForm({
     };
   }, [isExpanded, selection.rect]);
 
+  // Measures after useAutoResize above has sized the textarea for this text:
+  // both are layout effects and run in declaration order. Measured before the
+  // resize, a paste or a dictated sentence leaves the form placed for its old
+  // height, pushing the buttons off the bottom of the viewport.
   useLayoutEffect(() => {
     const node = formRef.current;
     if (!node) return;

--- a/src/hooks/useAutoResize.ts
+++ b/src/hooks/useAutoResize.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, type RefObject } from 'react';
+import { useCallback, useLayoutEffect, type RefObject } from 'react';
 
 /**
  * Auto-resizes a textarea to fit its content.
@@ -12,7 +12,9 @@ export function useAutoResize(ref: RefObject<HTMLTextAreaElement | null>, value:
     el.style.height = `${el.scrollHeight}px`;
   }, [ref]);
 
-  useEffect(() => {
+  // A layout effect, so the new height lands before paint and before any
+  // layout effect declared after this hook measures the surrounding surface.
+  useLayoutEffect(() => {
     resize();
   }, [value, resize]);
 


### PR DESCRIPTION
## The bug

The comment form picks where to sit from its own measured height, but it measured before the textarea grew to fit the new text. `useAutoResize` resized in a passive `useEffect`, which runs after `CommentForm`'s `useLayoutEffect` measurement, and nothing measured again afterwards.

Typing mostly hid it: each key re-measured the previous key's resize, so the form ran at most one line past the safe edge until the next keystroke. A paste or a dictated sentence arrives as one input event, so the form stayed placed for its empty height. When it had opened below the selection, the Cancel and Comment buttons hung off the bottom of the viewport. Scrolling the document does not rescue them: the expanded form is `position: fixed`, and it never reaches its own `max-height`, so it has nothing to scroll internally either.

**Before**, 800px viewport, a comment pasted in one input event: the form stays below the selection with its bottom at 819, and the Comment button (806) is off screen.

![Before: the form stays below the selection and its buttons run off the bottom of the viewport](https://github.com/user-attachments/assets/fee99168-c809-4152-af58-22e566d98994)

**After**, same steps: the form measures its real height, sees it no longer fits below the selection, and opens above it with both buttons in view.

![After: the form opens above the selection with Cancel and Comment in view](https://github.com/user-attachments/assets/64c57f2e-b5ef-4b0a-bbe9-7483db61fa53)

## The change

`useAutoResize` now resizes in a `useLayoutEffect`. `CommentForm` calls it before its measuring layout effect, and React runs layout effects in declaration order, so the textarea has its final height by the time the form measures, and the corrected position lands before paint. A comment on the measuring effect records that ordering dependency.

The hook's other caller, `CommentCard` (edit, reply and reply-edit textareas), only gains the same thing: the new height lands before paint instead of a frame late. Its `checkClamped` layout effect measures a different element, so it is unaffected.

## What this does not change

- While typing, the form still flips above the selection once it no longer fits below, and back below (clamped) once it fits neither way. It now stays fully visible through each move, but the move itself is existing behavior.
- A paste taller than the viewport still caps the form at the viewport height. The form scrolls internally, so the buttons stay reachable by scrolling inside it.

## Verification

New e2e test `Comment form placement › a long paste keeps the form and its buttons on screen` in `e2e/commenting.spec.ts` pastes 20 lines in one input event and asserts the form and both buttons are fully in the viewport. It failed on the unfixed hook (viewport ratio 0.84) and passes with the fix.

Dev pair on 3111/5199 against a neutral fixture, 1280x800 viewport (bottom safe edge 788):

| | Before | After |
|---|---|---|
| Paste, form placement | below the selection, bottom at 819 | above the selection, 32 to 405 |
| Paste, Comment button bottom | 806, off screen | 392 |
| Typed key by key, worst form bottom | 808 | 788 |

- `tsc -b` and eslint: clean
- Unit, `CommentForm.test.tsx` and `CommentCard.test.tsx`: 47 passed
- E2E, `commenting`, `selection-pill` and `touch-selection`: 40 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012cXgiZC8gdzku6zu6hADA8
