### PR TITLE
Stop the release notes rewrite from stalling on hidden prompts

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -341,7 +341,16 @@ function generateNotes(currentVersion, nextVersion) {
  * we leave the default notes in place and let the user edit at the prompt.
  *
  * Set RELEASE_SKIP_CLAUDE=1 to skip this step (e.g. offline / CI).
+ *
+ * The session runs in dontAsk mode so a tool call outside the allowlist is
+ * refused on the spot. Under a terminal that injects a PermissionRequest
+ * hook (cmux does), any other mode parks each unlisted call on a prompt
+ * nobody can see until the hook times out, which stalls the release for
+ * minutes with no output. The timeout is the backstop for anything else
+ * that hangs.
  */
+const CLAUDE_REWRITE_TIMEOUT_MS = 5 * 60 * 1000;
+
 function rewriteNotesWithClaude(notesPath, currentVersion, nextVersion) {
   if (process.env.RELEASE_SKIP_CLAUDE === '1') {
     console.log(`\n→ Skipping Claude rewrite (RELEASE_SKIP_CLAUDE=1)`);
@@ -355,6 +364,9 @@ function rewriteNotesWithClaude(notesPath, currentVersion, nextVersion) {
     `2. Run: git log v${currentVersion}..HEAD --format='%h %s%n%n%b%n---'`,
     `3. Overwrite ${notesPath} with the polished release notes.`,
     ``,
+    `The only shell commands available are git log, git describe, and`,
+    `gh release list/view. Anything else is refused, so don't retry it.`,
+    ``,
     `Do not output anything else. Do not add commentary outside the file.`,
   ].join('\n');
   const result = spawnSync(
@@ -363,20 +375,23 @@ function rewriteNotesWithClaude(notesPath, currentVersion, nextVersion) {
       '-p',
       prompt,
       '--allowed-tools',
-      'Read Write Bash(git log:*)',
+      'Read Write Bash(git log:*) Bash(git describe:*) Bash(gh release list:*) Bash(gh release view:*)',
       '--permission-mode',
-      'acceptEdits',
+      'dontAsk',
     ],
     {
       cwd: PROJECT_ROOT,
       stdio: ['ignore', 'ignore', 'inherit'],
+      timeout: CLAUDE_REWRITE_TIMEOUT_MS,
     },
   );
   if (result.error) {
     const reason =
       result.error.code === 'ENOENT'
         ? 'claude CLI not found (install Claude Code or set RELEASE_SKIP_CLAUDE=1)'
-        : result.error.message;
+        : result.error.code === 'ETIMEDOUT'
+          ? `timed out after ${CLAUDE_REWRITE_TIMEOUT_MS / 60000} minutes; keeping default notes`
+          : result.error.message;
     console.warn(`  ! Claude rewrite skipped: ${reason}`);
     return false;
   }


### PR DESCRIPTION
## Problem

`npm run release` could sit on "Rewriting notes with Claude" for minutes with no output.

The notes step runs `claude -p` with a short tool allowlist (`Read Write Bash(git log:*)`) in `acceptEdits` mode. When the model reached for a command outside it, for example `gh release view` to copy the style of past notes, Claude Code raised a permission request. Under a terminal that injects a `PermissionRequest` hook (cmux does), that request waits on a prompt nobody can see until the hook times out, about two minutes per blocked call. The session's transcript showed one call parked from 15:33:29 to 15:35:24 before the next one parked the same way.

## Fix

In `rewriteNotesWithClaude`:

- Run the session with `--permission-mode dontAsk`, so a tool call off the allowlist is refused immediately instead of raising a prompt.
- Allow the read-only commands the model tends to use: `git describe`, `gh release list`, `gh release view`.
- Tell the model which shell commands are available so it doesn't retry refused ones.
- Cap the step at five minutes with a `spawnSync` timeout. A timeout keeps the default notes and says so, same as any other failure.

## Verification

Run in a cmux terminal, where the hang reproduced:

- `dontAsk` with a non-allowlisted `gh release list`: refused in 6.5s (vs about 125s per call before).
- `dontAsk` with an allowlisted `gh release view`: ran normally.
- The edited `rewriteNotesWithClaude`, pulled out of the script and run against the real `claude` for v0.9.0..v0.9.1: returned in 20s with rewritten notes.
- `spawnSync` with a timeout reports `ETIMEDOUT`, which the new message branch keys on.
- `node --check` and ESLint pass on `scripts/release.mjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pgnp7QAJsSAzDcUc43F8LS
